### PR TITLE
(PE-24779) Add pe-client-tools-runtime

### DIFF
--- a/configs/components/libicu.rb
+++ b/configs/components/libicu.rb
@@ -1,0 +1,79 @@
+component 'libicu' do |pkg, settings, platform|
+  ## SOURCE METADATA
+  pkg.version '62.1'
+  underscore_version = pkg.get_version.gsub('.', '_')
+  pkg.md5sum '490ad9d920158e0314e10ba74ae9a150'
+  pkg.url "http://download.icu-project.org/files/icu4c/#{pkg.get_version}/icu4c-#{underscore_version}-src.tgz"
+  pkg.mirror "#{settings[:buildsources_url]}/icu4c-#{underscore_version}-src.tgz"
+  pkg.dirname "icu/source"
+
+  # Instead of using the pre-built data library included in the icu source, we
+  # build our own custom library with certain unnecessary bits of data removed
+  # to reduce filesize.
+  pkg.add_source("#{settings[:buildsources_url]}/icu4c-#{underscore_version}-data.zip", sum: "07e03444244883ef9789a56fc25010c0")
+
+  # These rules restrict the set of locales we build, which significantly
+  # reduces the size of the resulting package.
+  %w[curr lang locales region unit zone].each do |dir|
+    pkg.add_source("file://resources/files/libicu/#{dir}_reslocal.mk")
+  end
+
+  if platform.is_linux?
+    pkg.build_requires 'pl-gcc'
+    pkg.build_requires 'unzip'
+  elsif platform.is_windows?
+    pkg.build_requires '7zip.commandline'
+  end
+
+  ## BUILD CONFIGURATION
+  if platform.is_windows?
+    pkg.environment 'PATH', "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:chocolatey_bin]}):$(PATH)"
+    pkg.environment 'CYGWIN', settings[:cygwin]
+    pkg.environment 'CC', settings[:cc]
+    pkg.environment 'CXX', settings[:cxx]
+    pkg.environment 'MAKE', platform[:make]
+  elsif platform.is_macos?
+    pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
+  else
+    pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
+  end
+
+  ## BUILD COMMANDS
+  pkg.configure do
+    if platform.is_windows?
+      icu_platform = 'MinGW'
+      icu_flags = "--host #{platform.platform_triple}"
+      # Workaround for http://bugs.icu-project.org/trac/ticket/12896
+      cxx_flags = '-DU_USE_STRTOD_L=0'
+    elsif platform.is_macos?
+      icu_platform = 'MacOSX'
+      icu_flags = '--enable-rpath'
+    else
+      icu_platform = 'Linux/gcc'
+    end
+
+    [# Remove the pre-built data library from the source tarball and copy in
+     # the data sources
+     "rm -rf data && mv ../../icu4c-#{underscore_version}-data/data data",
+     # Removing these makefiles prevents building conversion tables for
+     # encodings we don't need, reducing the resulting filesize
+     "rm data/mappings/ucmfiles.mk data/mappings/ucmebcdic.mk",
+     "for file in ../../*_reslocal.mk; do mv $$file data/$$(basename $$file _reslocal.mk)/reslocal.mk; done",
+     "LDFLAGS='#{settings[:ldflags]}' CXXFLAGS='#{cxx_flags}' ./runConfigureICU #{icu_platform} #{icu_flags} --prefix=#{settings[:prefix]}"]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    install_cmds = ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+    # ICU incorrectly installs its .dlls to lib instead of bin on windows, so
+    # we have to move them...
+    if platform.is_windows?
+      install_cmds << "mv #{settings[:libdir]}/icu*.dll #{settings[:bindir]}"
+    end
+    install_cmds
+  end
+end
+

--- a/configs/components/runtime-client-tools.rb
+++ b/configs/components/runtime-client-tools.rb
@@ -1,0 +1,26 @@
+# This component exists to link in the gcc and stdc++ runtime libraries.
+component "runtime-client-tools" do |pkg, settings, platform|
+  pkg.environment "PROJECT_SHORTNAME", "client-tools"
+
+  if platform.is_windows?
+    lib_type = platform.architecture == "x64" ? "seh" : "sjlj"
+    ["libgcc_s_#{lib_type}-1.dll", 'libstdc++-6.dll', 'libwinpthread-1.dll'].each do |dll|
+      pkg.install_file File.join(settings[:gcc_bindir], dll), File.join(settings[:bindir], dll)
+    end
+
+    # zlib is a runtime dependency of libcurl
+    pkg.build_requires "pl-zlib-#{platform.architecture}"
+    pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:bindir]}/zlib1.dll"
+  elsif platform.is_macos?
+
+    # Do nothing
+
+  else # Linux and Solaris systems
+    libbase = platform.architecture =~ /64/ ? 'lib64' : 'lib'
+    libdir = "/opt/pl-build-tools/#{libbase}"
+    pkg.add_source "file://resources/files/runtime/runtime.sh"
+    pkg.install do
+      "bash runtime.sh #{libdir}"
+    end
+  end
+end

--- a/configs/projects/_shared-client-tools-runtime.rb
+++ b/configs/projects/_shared-client-tools-runtime.rb
@@ -1,0 +1,93 @@
+# This project is designed for reuse by branch-specific client-tools-runtime configs;
+# See configs/projects/client-tools-runtime-<branchname>.rb
+unless defined?(proj)
+  warn('This is the base project for the client-tools runtime.')
+  warn('Please choose one of the other client-tools projects instead.')
+  exit 1
+end
+
+proj.setting(:runtime_project, 'client-tools')
+proj.setting(:openssl_version, '1.0.2')
+
+proj.generate_archives true
+proj.generate_packages false
+
+proj.description "The client-tools runtime contains third-party components needed for client-tools"
+proj.license "See components"
+proj.vendor "Puppet, Inc.  <info@puppet.com>"
+proj.homepage "https://puppet.com"
+proj.identifier "com.puppetlabs"
+proj.version_from_git
+
+platform = proj.get_platform
+
+proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
+proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
+
+if platform.is_windows?
+  # Windows Installer settings.
+  proj.setting(:company_id, "PuppetLabs")
+  proj.setting(:product_id, "Client")
+  if platform.architecture == "x64"
+    proj.setting(:base_dir, "ProgramFiles64Folder")
+  else
+    proj.setting(:base_dir, "ProgramFilesFolder")
+  end
+
+  proj.setting(:prefix, File.join("C:", proj.base_dir, proj.company_id, proj.product_id, 'tools'))
+else
+  proj.setting(:prefix, "/opt/puppetlabs/client-tools")
+end
+
+proj.setting(:bindir, File.join(proj.prefix, "bin"))
+proj.setting(:libdir, File.join(proj.prefix, "lib"))
+proj.setting(:includedir, File.join(proj.prefix, "include"))
+proj.setting(:datadir, File.join(proj.prefix, "share"))
+proj.setting(:mandir, File.join(proj.datadir, "man"))
+
+proj.setting(:host, "--host #{platform.platform_triple}") if platform.is_windows?
+proj.setting(:platform_triple, platform.platform_triple)
+
+if platform.is_macos?
+  # For OS X, we should optimize for an older architecture than Apple
+  # currently ships for; there's a lot of older xeon chips based on
+  # that architecture still in use throughout the Mac ecosystem.
+  # Additionally, OS X doesn't use RPATH for linking. We shouldn't
+  # define it or try to force it in the linker, because this might
+  # break gcc or clang if they try to use the RPATH values we forced.
+  proj.setting(:cppflags, "-I#{proj.includedir}")
+  proj.setting(:cflags, "-march=core2 -msse4 #{proj.cppflags}")
+  proj.setting(:ldflags, "-L#{proj.libdir} ")
+elsif platform.is_windows?
+  arch = platform.architecture == "x64" ? "64" : "32"
+  proj.setting(:gcc_root, "C:/tools/mingw#{arch}")
+  proj.setting(:gcc_bindir, "#{proj.gcc_root}/bin")
+  proj.setting(:tools_root, "C:/tools/pl-build-tools")
+  proj.setting(:chocolatey_bin, 'C:/ProgramData/chocolatey/bin')
+  proj.setting(:cppflags, "-I#{proj.tools_root}/include -I#{proj.gcc_root}/include -I#{proj.includedir}")
+  proj.setting(:cflags, "#{proj.cppflags}")
+  proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir} -Wl,--nxcompat -Wl,--dynamicbase")
+  proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
+else
+  proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+  proj.setting(:cflags, "#{proj.cppflags}")
+  proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+end
+
+# What to build?
+# --------------
+
+# Common deps
+proj.component "runtime-client-tools"
+proj.component "openssl-#{proj.openssl_version}"
+proj.component "curl"
+proj.component "puppet-ca-bundle"
+proj.component "libicu"
+
+# What to include in package?
+proj.directory proj.prefix
+
+# Export the settings for the current project and platform as yaml during builds
+proj.publish_yaml_settings
+
+proj.timeout 7200 if platform.is_windows?

--- a/configs/projects/client-tools-runtime-irving.rb
+++ b/configs/projects/client-tools-runtime-irving.rb
@@ -1,0 +1,4 @@
+project 'client-tools-runtime-irving' do |proj|
+  # Common settings
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-client-tools-runtime.rb'))
+end

--- a/resources/files/libicu/curr_reslocal.mk
+++ b/resources/files/libicu/curr_reslocal.mk
@@ -1,0 +1,34 @@
+CURR_CLDR_VERSION = 31.0.1
+# A list of txt's to build
+# This file was created by copying data/curr/resfiles.mk from the icu data
+# source, and removing unused locales.
+
+# Aliases without a corresponding xx.xml file (see icu-config.xml & build.xml)
+CURR_SYNTHETIC_ALIAS = en_NH.txt en_RH.txt ja_JP.txt ja_JP_TRADITIONAL.txt
+
+
+# All aliases (to not be included under 'installed'), but not including root.
+CURR_ALIAS_SOURCE = $(CURR_SYNTHETIC_ALIAS)
+
+
+# Ordinary resources
+CURR_SOURCE = en.txt en_001.txt en_150.txt en_AG.txt en_AI.txt\
+ en_AT.txt en_AU.txt en_BB.txt en_BE.txt en_BI.txt\
+ en_BM.txt en_BS.txt en_BW.txt en_BZ.txt en_CA.txt\
+ en_CC.txt en_CH.txt en_CK.txt en_CM.txt en_CX.txt\
+ en_CY.txt en_DE.txt en_DG.txt en_DK.txt en_DM.txt\
+ en_ER.txt en_FI.txt en_FJ.txt en_FK.txt en_FM.txt\
+ en_GB.txt en_GD.txt en_GG.txt en_GH.txt en_GI.txt\
+ en_GM.txt en_GY.txt en_HK.txt en_IE.txt en_IL.txt\
+ en_IM.txt en_IN.txt en_IO.txt en_JE.txt en_JM.txt\
+ en_KE.txt en_KI.txt en_KN.txt en_KY.txt en_LC.txt\
+ en_LR.txt en_LS.txt en_MG.txt en_MO.txt en_MS.txt\
+ en_MT.txt en_MU.txt en_MW.txt en_MY.txt en_NA.txt\
+ en_NF.txt en_NG.txt en_NL.txt en_NR.txt en_NU.txt\
+ en_NZ.txt en_PG.txt en_PH.txt en_PK.txt en_PN.txt\
+ en_PW.txt en_RW.txt en_SB.txt en_SC.txt en_SD.txt\
+ en_SE.txt en_SG.txt en_SH.txt en_SI.txt en_SL.txt\
+ en_SS.txt en_SX.txt en_SZ.txt en_TC.txt en_TK.txt\
+ en_TO.txt en_TT.txt en_TV.txt en_TZ.txt en_UG.txt\
+ en_VC.txt en_VG.txt en_VU.txt en_WS.txt en_ZA.txt\
+ en_ZM.txt en_ZW.txt eo.txt ja.txt

--- a/resources/files/libicu/lang_reslocal.mk
+++ b/resources/files/libicu/lang_reslocal.mk
@@ -1,0 +1,36 @@
+# © 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html#License
+LANG_CLDR_VERSION = 31.0.1
+# A list of txt's to build
+# This file was created by copying data/lang/resfiles.mk from the icu data
+# source, and removing unused locales.
+
+# Aliases without a corresponding xx.xml file (see icu-config.xml & build.xml)
+LANG_SYNTHETIC_ALIAS = en_NH.txt en_RH.txt ja_JP.txt ja_JP_TRADITIONAL.txt
+
+
+# All aliases (to not be included under 'installed'), but not including root.
+LANG_ALIAS_SOURCE = $(LANG_SYNTHETIC_ALIAS)
+
+
+# Ordinary resources
+LANG_SOURCE = en.txt en_001.txt en_150.txt en_AG.txt en_AI.txt\
+ en_AT.txt en_AU.txt en_BB.txt en_BE.txt en_BM.txt\
+ en_BS.txt en_BW.txt en_BZ.txt en_CA.txt en_CC.txt\
+ en_CH.txt en_CK.txt en_CM.txt en_CX.txt en_CY.txt\
+ en_DE.txt en_DG.txt en_DK.txt en_DM.txt en_ER.txt\
+ en_FI.txt en_FJ.txt en_FK.txt en_FM.txt en_GB.txt\
+ en_GD.txt en_GG.txt en_GH.txt en_GI.txt en_GM.txt\
+ en_GY.txt en_HK.txt en_IE.txt en_IL.txt en_IM.txt\
+ en_IN.txt en_IO.txt en_JE.txt en_JM.txt en_KE.txt\
+ en_KI.txt en_KN.txt en_KY.txt en_LC.txt en_LR.txt\
+ en_LS.txt en_MG.txt en_MO.txt en_MS.txt en_MT.txt\
+ en_MU.txt en_MW.txt en_MY.txt en_NA.txt en_NF.txt\
+ en_NG.txt en_NL.txt en_NR.txt en_NU.txt en_NZ.txt\
+ en_PG.txt en_PH.txt en_PK.txt en_PN.txt en_PW.txt\
+ en_RW.txt en_SB.txt en_SC.txt en_SD.txt en_SE.txt\
+ en_SG.txt en_SH.txt en_SI.txt en_SL.txt en_SS.txt\
+ en_SX.txt en_SZ.txt en_TC.txt en_TK.txt en_TO.txt\
+ en_TT.txt en_TV.txt en_TZ.txt en_UG.txt en_VC.txt\
+ en_VG.txt en_VU.txt en_WS.txt en_ZA.txt en_ZM.txt\
+ en_ZW.txt eo.txt ja.txt

--- a/resources/files/libicu/locales_reslocal.mk
+++ b/resources/files/libicu/locales_reslocal.mk
@@ -1,0 +1,38 @@
+# © 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html#License
+GENRB_CLDR_VERSION = 31.0.1
+# A list of txt's to build
+# This file was created by copying data/locales/resfiles.mk from the icu data
+# source, and removing unused locales.
+
+# Aliases without a corresponding xx.xml file (see icu-config.xml & build.xml)
+GENRB_SYNTHETIC_ALIAS = en_NH.txt en_RH.txt ja_JP_TRADITIONAL.txt
+
+
+# All aliases (to not be included under 'installed'), but not including root.
+GENRB_ALIAS_SOURCE = $(GENRB_SYNTHETIC_ALIAS)
+
+
+# Ordinary resources
+GENRB_SOURCE = en.txt en_001.txt en_150.txt en_AG.txt\
+ en_AI.txt en_AS.txt en_AT.txt en_AU.txt en_BB.txt\
+ en_BE.txt en_BI.txt en_BM.txt en_BS.txt en_BW.txt\
+ en_BZ.txt en_CA.txt en_CC.txt en_CH.txt en_CK.txt\
+ en_CM.txt en_CX.txt en_CY.txt en_DE.txt en_DG.txt\
+ en_DK.txt en_DM.txt en_ER.txt en_FI.txt en_FJ.txt\
+ en_FK.txt en_FM.txt en_GB.txt en_GD.txt en_GG.txt\
+ en_GH.txt en_GI.txt en_GM.txt en_GU.txt en_GY.txt\
+ en_HK.txt en_IE.txt en_IL.txt en_IM.txt en_IN.txt\
+ en_IO.txt en_JE.txt en_JM.txt en_KE.txt en_KI.txt\
+ en_KN.txt en_KY.txt en_LC.txt en_LR.txt en_LS.txt\
+ en_MG.txt en_MH.txt en_MO.txt en_MP.txt en_MS.txt\
+ en_MT.txt en_MU.txt en_MW.txt en_MY.txt en_NA.txt\
+ en_NF.txt en_NG.txt en_NL.txt en_NR.txt en_NU.txt\
+ en_NZ.txt en_PG.txt en_PH.txt en_PK.txt en_PN.txt\
+ en_PR.txt en_PW.txt en_RW.txt en_SB.txt en_SC.txt\
+ en_SD.txt en_SE.txt en_SG.txt en_SH.txt en_SI.txt\
+ en_SL.txt en_SS.txt en_SX.txt en_SZ.txt en_TC.txt\
+ en_TK.txt en_TO.txt en_TT.txt en_TV.txt en_TZ.txt\
+ en_UG.txt en_UM.txt en_US.txt en_US_POSIX.txt en_VC.txt\
+ en_VG.txt en_VI.txt en_VU.txt en_WS.txt en_ZA.txt\
+ en_ZM.txt en_ZW.txt eo.txt ja.txt ja_JP.txt

--- a/resources/files/libicu/region_reslocal.mk
+++ b/resources/files/libicu/region_reslocal.mk
@@ -1,0 +1,35 @@
+# © 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html#License
+REGION_CLDR_VERSION = 31.0.1
+# A list of txt's to build
+# This file was created by copying data/region/resfiles.mk from the icu data
+# source, and removing unused locales.
+
+# Aliases without a corresponding xx.xml file (see icu-config.xml & build.xml)
+REGION_SYNTHETIC_ALIAS = en_NH.txt en_RH.txt ja_JP.txt ja_JP_TRADITIONAL.txt
+
+
+# All aliases (to not be included under 'installed'), but not including root.
+REGION_ALIAS_SOURCE = $(REGION_SYNTHETIC_ALIAS)
+
+
+# Ordinary resources
+REGION_SOURCE = en_AU.txt en_BB.txt en_BE.txt en_BM.txt en_BS.txt\
+ en_BW.txt en_BZ.txt en_CA.txt en_CC.txt en_CH.txt\
+ en_CK.txt en_CM.txt en_CX.txt en_CY.txt en_DE.txt\
+ en_DG.txt en_DK.txt en_DM.txt en_ER.txt en_FI.txt\
+ en_FJ.txt en_FK.txt en_FM.txt en_GB.txt en_GD.txt\
+ en_GG.txt en_GH.txt en_GI.txt en_GM.txt en_GY.txt\
+ en_HK.txt en_IE.txt en_IL.txt en_IM.txt en_IN.txt\
+ en_IO.txt en_JE.txt en_JM.txt en_KE.txt en_KI.txt\
+ en_KN.txt en_KY.txt en_LC.txt en_LR.txt en_LS.txt\
+ en_MG.txt en_MO.txt en_MS.txt en_MT.txt en_MU.txt\
+ en_MW.txt en_MY.txt en_NA.txt en_NF.txt en_NG.txt\
+ en_NL.txt en_NR.txt en_NU.txt en_NZ.txt en_PG.txt\
+ en_PH.txt en_PK.txt en_PN.txt en_PW.txt en_RW.txt\
+ en_SB.txt en_SC.txt en_SD.txt en_SE.txt en_SG.txt\
+ en_SH.txt en_SI.txt en_SL.txt en_SS.txt en_SX.txt\
+ en_SZ.txt en_TC.txt en_TK.txt en_TO.txt en_TT.txt\
+ en_TV.txt en_TZ.txt en_UG.txt en_VC.txt en_VG.txt\
+ en_VU.txt en_WS.txt en_ZA.txt en_ZM.txt en_ZW.txt\
+ eo.txt ja.txt

--- a/resources/files/libicu/unit_reslocal.mk
+++ b/resources/files/libicu/unit_reslocal.mk
@@ -1,0 +1,38 @@
+# © 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html#License
+UNIT_CLDR_VERSION = 31.0.1
+# A list of txt's to build
+# This file was created by copying data/unit/resfiles.mk from the icu data
+# source, and removing unused locales.
+
+# Aliases without a corresponding xx.xml file (see icu-config.xml & build.xml)
+UNIT_SYNTHETIC_ALIAS = en_NH.txt en_RH.txt ja_JP.txt ja_JP_TRADITIONAL.txt
+
+
+# All aliases (to not be included under 'installed'), but not including root.
+UNIT_ALIAS_SOURCE = $(UNIT_SYNTHETIC_ALIAS)
+
+
+# Ordinary resources
+UNIT_SOURCE = en.txt\
+ en_001.txt en_150.txt en_AG.txt en_AI.txt en_AT.txt\
+ en_AU.txt en_BB.txt en_BE.txt en_BM.txt en_BS.txt\
+ en_BW.txt en_BZ.txt en_CA.txt en_CC.txt en_CH.txt\
+ en_CK.txt en_CM.txt en_CX.txt en_CY.txt en_DE.txt\
+ en_DG.txt en_DK.txt en_DM.txt en_ER.txt en_FI.txt\
+ en_FJ.txt en_FK.txt en_FM.txt en_GB.txt en_GD.txt\
+ en_GG.txt en_GH.txt en_GI.txt en_GM.txt en_GY.txt\
+ en_HK.txt en_IE.txt en_IL.txt en_IM.txt en_IN.txt\
+ en_IO.txt en_JE.txt en_JM.txt en_KE.txt en_KI.txt\
+ en_KN.txt en_KY.txt en_LC.txt en_LR.txt en_LS.txt\
+ en_MG.txt en_MO.txt en_MS.txt en_MT.txt en_MU.txt\
+ en_MW.txt en_MY.txt en_NA.txt en_NF.txt en_NG.txt\
+ en_NL.txt en_NR.txt en_NU.txt en_NZ.txt en_PG.txt\
+ en_PH.txt en_PK.txt en_PN.txt en_PW.txt en_RW.txt\
+ en_SB.txt en_SC.txt en_SD.txt en_SE.txt en_SG.txt\
+ en_SH.txt en_SI.txt en_SL.txt en_SS.txt en_SX.txt\
+ en_SZ.txt en_TC.txt en_TK.txt en_TO.txt en_TT.txt\
+ en_TV.txt en_TZ.txt en_UG.txt en_VC.txt en_VG.txt\
+ en_VU.txt en_WS.txt en_ZA.txt en_ZM.txt en_ZW.txt\
+ eo.txt ja.txt
+

--- a/resources/files/libicu/zone_reslocal.mk
+++ b/resources/files/libicu/zone_reslocal.mk
@@ -1,0 +1,38 @@
+# © 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html#License
+ZONE_CLDR_VERSION = 31.0.1
+# A list of txt's to build
+# This file was created by copying data/zone/resfiles.mk from the icu data
+# source, and removing unused locales.
+
+# Aliases without a corresponding xx.xml file (see icu-config.xml & build.xml)
+ZONE_SYNTHETIC_ALIAS = en_NH.txt en_RH.txt ja_JP.txt ja_JP_TRADITIONAL.txt
+
+
+# All aliases (to not be included under 'installed'), but not including root.
+ZONE_ALIAS_SOURCE = $(ZONE_SYNTHETIC_ALIAS)
+
+
+# Ordinary resources
+ZONE_SOURCE = en.txt en_001.txt\
+ en_150.txt en_AG.txt en_AI.txt en_AT.txt en_AU.txt\
+ en_BB.txt en_BE.txt en_BM.txt en_BS.txt en_BW.txt\
+ en_BZ.txt en_CA.txt en_CC.txt en_CH.txt en_CK.txt\
+ en_CM.txt en_CX.txt en_CY.txt en_DE.txt en_DG.txt\
+ en_DK.txt en_DM.txt en_ER.txt en_FI.txt en_FJ.txt\
+ en_FK.txt en_FM.txt en_GB.txt en_GD.txt en_GG.txt\
+ en_GH.txt en_GI.txt en_GM.txt en_GU.txt en_GY.txt\
+ en_HK.txt en_IE.txt en_IL.txt en_IM.txt en_IN.txt\
+ en_IO.txt en_JE.txt en_JM.txt en_KE.txt en_KI.txt\
+ en_KN.txt en_KY.txt en_LC.txt en_LR.txt en_LS.txt\
+ en_MG.txt en_MH.txt en_MO.txt en_MP.txt en_MS.txt\
+ en_MT.txt en_MU.txt en_MW.txt en_MY.txt en_NA.txt\
+ en_NF.txt en_NG.txt en_NL.txt en_NR.txt en_NU.txt\
+ en_NZ.txt en_PG.txt en_PH.txt en_PK.txt en_PN.txt\
+ en_PW.txt en_RW.txt en_SB.txt en_SC.txt en_SD.txt\
+ en_SE.txt en_SG.txt en_SH.txt en_SI.txt en_SL.txt\
+ en_SS.txt en_SX.txt en_SZ.txt en_TC.txt en_TK.txt\
+ en_TO.txt en_TT.txt en_TV.txt en_TZ.txt en_UG.txt\
+ en_VC.txt en_VG.txt en_VU.txt en_WS.txt en_ZA.txt\
+ en_ZM.txt en_ZW.txt eo.txt\
+ ja.txt jgo.txt jmc.txt ka.txt kab.txt


### PR DESCRIPTION
Adds the pe-client-tools-runtime, for use in future PE releases.