### PR TITLE
Add three new platforms, fix ruby location for pdk

### DIFF
--- a/configs/components/base-ruby.rb
+++ b/configs/components/base-ruby.rb
@@ -4,11 +4,11 @@
 
 # Condensed version, e.g. '2.4.3' -> '243'
 ruby_version_condensed = settings[:ruby_version].tr('.', '')
-# Base version, e.g. '2.4.3' -> '2.4'
-ruby_version_short = settings[:ruby_version].gsub(/(\d)\.(\d)\.(\d)/, '\1.\2')
+# Y version, e.g. '2.4.3' -> '2.4'
+ruby_version_y = settings[:ruby_version].gsub(/(\d)\.(\d)\.(\d)/, '\1.\2')
 
 pkg.mirror "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
-pkg.url "https://cache.ruby-lang.org/pub/ruby/#{ruby_version_short}/ruby-#{pkg.get_version}.tar.gz"
+pkg.url "https://cache.ruby-lang.org/pub/ruby/#{ruby_version_y}/ruby-#{pkg.get_version}.tar.gz"
 
 
 #########

--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -116,7 +116,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   # ENVIRONMENT, FLAGS
   ####################
 
-  special_flags = " --prefix=#{settings[:prefix]} --with-opt-dir=#{settings[:prefix]} "
+  special_flags = " --prefix=#{settings[:ruby_dir]} --with-opt-dir=#{settings[:prefix]} "
 
   if platform.is_aix?
     # This normalizes the build string to something like AIX 7.1.0.0 rather
@@ -166,7 +166,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     # installing a compiled gem would not work without us shipping that gcc.
     # This tells the ruby setup that it can use the default system gcc rather
     # than our own.
-    target_dir = File.join(settings[:libdir], "ruby", "2.1.0", rbconfig_info[settings[:platform_triple]][:target_double])
+    target_dir = File.join(settings[:ruby_dir], 'lib', 'ruby', '2.1.0', rbconfig_info[settings[:platform_triple]][:target_double])
     sed = "sed"
     sed = "gsed" if platform.is_solaris?
     sed = "/opt/freeware/bin/sed" if platform.is_aix?

--- a/configs/components/ruby-2.4.3.rb
+++ b/configs/components/ruby-2.4.3.rb
@@ -130,7 +130,7 @@ component 'ruby-2.4.3' do |pkg, settings, platform|
     pkg.environment 'optflags', '-O2'
   end
 
-  special_flags = " --prefix=#{settings[:prefix]} --with-opt-dir=#{settings[:prefix]} "
+  special_flags = " --prefix=#{settings[:ruby_dir]} --with-opt-dir=#{settings[:prefix]} "
 
   if platform.is_aix?
     # This normalizes the build string to something like AIX 7.1.0.0 rather
@@ -183,7 +183,7 @@ component 'ruby-2.4.3' do |pkg, settings, platform|
     # installing a compiled gem would not work without us shipping that gcc.
     # This tells the ruby setup that it can use the default system gcc rather
     # than our own.
-    target_dir = File.join(settings[:libdir], "ruby", "2.4.0", rbconfig_info[settings[:platform_triple]][:target_double])
+    target_dir = File.join(settings[:ruby_dir], 'lib', 'ruby', '2.4.0', rbconfig_info[settings[:platform_triple]][:target_double])
     sed = "sed"
     sed = "gsed" if platform.is_solaris?
     sed = "/opt/freeware/bin/sed" if platform.is_aix?

--- a/configs/components/rubygem-win32-eventlog.rb
+++ b/configs/components/rubygem-win32-eventlog.rb
@@ -1,0 +1,12 @@
+component 'rubygem-win32-eventlog' do |pkg, settings, platform|
+  instance_eval File.read('configs/components/base-rubygem.rb')
+  pkg.version '0.6.2'
+  pkg.md5sum '89b2e7dd8cc599168fa444e73c014c3d'
+  pkg.url "https://rubygems.org/downloads/win32-eventlog-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/win32-eventlog-#{pkg.get_version}.gem"
+
+
+  pkg.install do
+    ["#{settings[:gem_install]} win32-eventlog-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/platforms/cumulus-2.2-amd64.rb
+++ b/configs/platforms/cumulus-2.2-amd64.rb
@@ -1,0 +1,27 @@
+platform "cumulus-22-amd64" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "sysv"
+  plat.codename "cumulus"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-wheezy.deb"
+
+  plat.provision_with %(
+echo 'deb http://enterprise.delivery.puppetlabs.net/build-tools/debian/CumulusLinux CumulusLinux-2.2 build-tools
+deb http://osmirror.delivery.puppetlabs.net/cumulus/ CumulusLinux-2.2 main addons security-updates testing updates' > /etc/apt/sources.list
+echo 'Package: *
+Pin: release n="CumulusLinux-2.2*"
+Pin-Priority: 1001' > /etc/apt/preferences.d/cumulus
+apt-get update -qq
+export DEBIAN_FRONTEND=noninteractive APT_LISTCHANGES_FRONTEND=none
+apt-get dist-upgrade -qy --force-yes -o Dpkg::Options::="--force-confold" --allow-unauthenticated
+echo 'deb http://osmirror.delivery.puppetlabs.net/debian/ wheezy main
+deb http://osmirror.delivery.puppetlabs.net/debian/ wheezy-updates main' >> /etc/apt/sources.list
+apt-get update -qq
+apt-get install -qy --no-install-recommends build-essential make quilt pkg-config debhelper devscripts rsync
+)
+
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "debian-7-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
+end

--- a/configs/platforms/eos-4-i386.rb
+++ b/configs/platforms/eos-4-i386.rb
@@ -1,0 +1,12 @@
+platform "eos-4-i386" do |plat|
+  plat.servicedir "/etc/rc.d/init.d"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "sysv"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/14/i386/pl-build-tools-fedora-14.repo"
+  plat.add_build_repository "http://osmirror.delivery.puppetlabs.net/eos-4-i386/eos-4-i386.repo"
+  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils zip"
+
+  plat.install_build_dependencies_with "yum install -y --nogpgcheck"
+  plat.vmpooler_template "fedora-14-i386"
+end

--- a/configs/platforms/redhat-fips-7-x86_64.rb
+++ b/configs/platforms/redhat-fips-7-x86_64.rb
@@ -1,0 +1,10 @@
+platform "redhat-fips-7-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-el-7.noarch.rpm"
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.vmpooler_template "redhat-fips-7-x86_64"
+end

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -3,7 +3,7 @@ project 'agent-runtime-1.10.x' do |proj|
   # Common agent settings:
   instance_eval File.read('configs/projects/base-agent-runtime.rb')
 
-  proj.version "#{proj.settings[:package_version]}"
+  proj.version proj.settings[:package_version]
 
   # Dependencies specific to the 1.10.x branch
   proj.component 'ruby-stomp-1.3.3'

--- a/configs/projects/agent-runtime-5.3.x.rb
+++ b/configs/projects/agent-runtime-5.3.x.rb
@@ -3,7 +3,7 @@ project 'agent-runtime-5.3.x' do |proj|
   # Common agent settings:
   instance_eval File.read('configs/projects/base-agent-runtime.rb')
 
-  proj.version "#{proj.settings[:package_version]}"
+  proj.version proj.settings[:package_version]
 
   # Dependencies specific to the 5.3.x branch
   proj.component 'ruby-stomp-1.4.4'

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -3,7 +3,7 @@ project 'agent-runtime-master' do |proj|
   # Common agent settings:
   instance_eval File.read('configs/projects/base-agent-runtime.rb')
 
-  proj.version "#{proj.settings[:package_version]}"
+  proj.version proj.settings[:package_version]
 
   # Dependencies specific to the master branch
   proj.component 'ruby-stomp-1.4.4'

--- a/configs/projects/base-agent-runtime.rb
+++ b/configs/projects/base-agent-runtime.rb
@@ -63,6 +63,7 @@ if platform.is_windows?
   proj.component 'rubygem-win32-process'
   proj.component 'rubygem-win32-security'
   proj.component 'rubygem-win32-service'
+  proj.component 'rubygem-win32-eventlog'
 end
 
 if platform.is_windows? || platform.is_solaris?

--- a/configs/projects/base-agent-runtime.rb
+++ b/configs/projects/base-agent-runtime.rb
@@ -17,10 +17,10 @@ proj.license 'See components'
 proj.vendor 'Puppet, Inc.  <info@puppet.com>'
 proj.homepage 'https://puppet.com'
 
-# For puppet-agent, the ruby_bindir is only set for windows, but the augeas
-# component requires it to be set everywhere:
-proj.setting(:ruby_bindir, "#{proj.settings[:bindir]}") unless platform.is_windows?
-proj.setting(:ruby_dir, "#{proj.settings[:prefix]}") unless platform.is_windows?
+# Some projects and platforms using the runtime set custom ruby installation
+# directories - fall back to the project prefix if ruby_dir hasn't been set
+proj.setting(:ruby_dir, proj.settings[:prefix]) unless proj.settings[:ruby_dir]
+proj.setting(:ruby_bindir, File.join(proj.settings[:ruby_dir], 'bin')) unless proj.settings[:ruby_bindir]
 
 if platform.is_macos?
   proj.identifier 'com.puppetlabs'


### PR DESCRIPTION
There are two commits here:

- Add cumulus, arista, and redhat-fips platforms in support of the agent runtime ([here's an example build](http://jenkins-release.delivery.puppetlabs.net/job/vanagon_generic_job/1378/)), and
- Fix the ruby path for pdk ([example build](http://jenkins-release.delivery.puppetlabs.net/job/vanagon_generic_job/1377/console))- puppet-agent uses the prefix as the ruby installation directory, but pdk uses the `:ruby_dir` setting - this updates the agent runtime to use the prefix directory unless `:ruby_dir` is explicitly set, and uses `:ruby_dir` as the ruby installation directory generally.