### PR TITLE
(maint) Update rubygem-gettext-setup to v0.30

### DIFF
--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -1,7 +1,8 @@
 component "rubygem-gettext-setup" do |pkg, settings, platform|
   instance_eval File.read('configs/components/base-rubygem.rb')
-  pkg.version "0.28"
-  pkg.md5sum "65c8e2bb3fe8e07b91f8ea9f0b4c2196"
+  pkg.version "0.30"
+  pkg.md5sum "b7de0e7af0f56ddc55c88435ee95fd47"
+
   pkg.url "https://rubygems.org/downloads/gettext-setup-#{pkg.get_version}.gem"
   pkg.mirror "#{settings[:buildsources_url]}/gettext-setup-#{pkg.get_version}.gem"
 


### PR DESCRIPTION
gettext-setup was recently bumped to version 0.30 in puppet-agent - [here's an example build with this version in the runtime](http://jenkins-release.delivery.puppetlabs.net/job/vanagon_generic_job/1403/).