### PR TITLE
(maint) Update curl to version 7.58.0

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -1,6 +1,6 @@
 component 'curl' do |pkg, settings, platform|
-  pkg.version '7.57.0'
-  pkg.md5sum 'c7aab73aaf5e883ca1d7518f93649dc2'
+  pkg.version '7.58.0'
+  pkg.md5sum '7e9e9d5405c61148d53035426f162b0a'
   pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/curl-#{pkg.get_version}.tar.gz"
 


### PR DESCRIPTION
Updates curl to 7.58.0 - this was a super simple update in the agent, but [here are some example runtime builds with this new version](http://jenkins-release.delivery.puppetlabs.net/job/vanagon_generic_job/1402/) if anyone's curious.