### PR TITLE
(PA-1822) Set ruby maximum heap size to 2GB

### DIFF
--- a/configs/components/base-ruby.rb
+++ b/configs/components/base-ruby.rb
@@ -30,7 +30,7 @@ end
 
 if platform.is_aix?
   pkg.environment 'CC', '/opt/pl-build-tools/bin/gcc'
-  pkg.environment 'LDFLAGS', settings[:ldflags]
+  pkg.environment 'LDFLAGS', "#{settings[:ldflags]} -Wl,-bmaxdata:0x80000000"
 elsif platform.is_solaris?
   pkg.environment 'PATH', "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
   pkg.environment 'CC', "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"


### PR DESCRIPTION
AIX applications default to a static maximum heap size of 256MB.
This was causing heap exhaustion in the ruby interpreter when
attempting to add an artifactory source for rubygems.

Upping the heap limit allows Ruby to complete the operation
successfully.