### PR TITLE
(maint) Add fast-gettext 1.1.0

### DIFF
--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -1,7 +1,18 @@
 component "rubygem-fast_gettext" do |pkg, settings, platform|
   instance_eval File.read('configs/components/base-rubygem.rb')
-  pkg.version "1.1.2"
-  pkg.md5sum "df5a2462d0e1d2e5d49bb233b841f4d6"
+
+  version = settings[:rubygem_fast_gettext_version] || '1.1.2'
+  pkg.version version
+
+  case version
+    when '1.1.0'
+      pkg.md5sum "fc0597bd4d84b749c579cc39c7ceda0f"
+    when '1.1.2'
+      pkg.md5sum "df5a2462d0e1d2e5d49bb233b841f4d6"
+    else
+      raise "rubygem-fast_gettext version #{version} has not been configured; Cannot continue."
+  end
+
   pkg.url "https://rubygems.org/downloads/fast_gettext-#{pkg.get_version}.gem"
   pkg.mirror "#{settings[:buildsources_url]}/fast_gettext-#{pkg.get_version}.gem"
 

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -2,6 +2,7 @@ project 'agent-runtime-1.10.x' do |proj|
   proj.inherit_settings 'puppet-agent', 'git://github.com/puppetlabs/puppet-agent', '1.10.x'
 
   proj.setting :augeas_version, '1.4.0'
+  proj.setting :rubygem_fast_gettext_version, '1.1.0'
 
   # Common agent settings:
   instance_eval File.read('configs/projects/base-agent-runtime.rb')


### PR DESCRIPTION
puppet-agent 1.10.x uses version 1.1.0 of the fast-gettext rubygem - all other projects use version 1.1.2. This PR adds an optional `rubygem_fast_gettext_version` setting that projects can use to select a version explicitly; 1.1.2 is used by default.