### PR TITLE
(maint) Add rubygem-ffi version 1.9.18

### DIFF
--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -1,18 +1,35 @@
 component "rubygem-ffi" do |pkg, settings, platform|
   instance_eval File.read('configs/components/base-rubygem.rb')
-  pkg.version "1.9.18"
+
+  version = settings[:rubygem_ffi_version] || '1.9.18'
+  pkg.version version
+
+  if platform.architecture == "x64"
+    pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x64-mingw32.gem"
+    pkg.mirror "#{settings[:buildsources_url]}/ffi-#{pkg.get_version}-x64-mingw32.gem"
+  else
+    pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x86-mingw32.gem"
+    pkg.mirror "#{settings[:buildsources_url]}/ffi-#{pkg.get_version}-x86-mingw32.gem"
+  end
+
+  case version
+    when '1.9.14'
+      if platform.architecture == "x64"
+        pkg.md5sum "6d78ae5b2378513d3fc68600981366e9"
+      else
+        pkg.md5sum "54a20f0f73d03c06adf63789faa53746"
+      end
+    when '1.9.18'
+      if platform.architecture == "x64"
+        pkg.md5sum "664afc6a316dd648f497fbda3be87137"
+      else
+        pkg.md5sum "0b6fd994826952231d285f078cefce32"
+      end
+    else
+      raise "rubygem-ffi version #{version} has not been configured; Cannot continue."
+  end
 
   if platform.is_windows?
-    if platform.architecture == "x64"
-      pkg.md5sum "664afc6a316dd648f497fbda3be87137"
-      pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x64-mingw32.gem"
-      pkg.mirror "#{settings[:buildsources_url]}/ffi-#{pkg.get_version}-x64-mingw32.gem"
-    else
-      pkg.md5sum "0b6fd994826952231d285f078cefce32"
-      pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x86-mingw32.gem"
-      pkg.mirror "#{settings[:buildsources_url]}/ffi-#{pkg.get_version}-x86-mingw32.gem"
-    end
-
     pkg.install do
       ["#{settings[:gem_install]} ffi-#{pkg.get_version}-#{platform.architecture}-mingw32.gem"]
     end

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -3,6 +3,7 @@ project 'agent-runtime-1.10.x' do |proj|
 
   proj.setting :augeas_version, '1.4.0'
   proj.setting :rubygem_fast_gettext_version, '1.1.0'
+  proj.setting :rubygem_ffi_version, '1.9.14'
 
   # Common agent settings:
   instance_eval File.read('configs/projects/base-agent-runtime.rb')


### PR DESCRIPTION
puppet-agent's 1.10.x branch uses version 1.9.14 of rubygem-ffi; All other branches (and PDK) use the existing 1.9.18 version. This PR adds version 1.9.14, and a `rubygem_ffi_version` setting that projects can use to select a version explicitly. If `rubygem_ffi_version` is empty, version 1.9.18 will be used by default.