### PR TITLE
(PA-1888) Vendor patch for ruby 2.4.3 sched_yield lookup

### DIFF
--- a/configs/components/ruby-2.4.3.rb
+++ b/configs/components/ruby-2.4.3.rb
@@ -100,6 +100,7 @@ component 'ruby-2.4.3' do |pkg, settings, platform|
 
   base = 'resources/patches/ruby_243'
   pkg.apply_patch "#{base}/ostruct_remove_safe_nav_operator.patch"
+  pkg.apply_patch "#{base}/thread_wakeup_ownership_check.patch"
 
   if platform.is_aix?
     # TODO: Remove this patch once PA-1607 is resolved.

--- a/resources/patches/ruby_243/thread_wakeup_ownership_check.patch
+++ b/resources/patches/ruby_243/thread_wakeup_ownership_check.patch
@@ -1,0 +1,47 @@
+From b860f06413fa7db83c39fe7572982cc1c26ca1e6 Mon Sep 17 00:00:00 2001
+From: normal <normal@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Sat, 30 Sep 2017 21:50:42 +0000
+Subject: [PATCH] thread_pthread.c: do not wakeup inside child processes
+
+* thread_pthread.c (rb_thread_wakeup_timer_thread): check
+  ownership before incrementing
+  (rb_thread_wakeup_timer_thread_low): ditto
+  [Bug #13794] [ruby-core:83064]
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@60079 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+---
+ thread_pthread.c | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/thread_pthread.c b/thread_pthread.c
+index 675a2ddbae77..9576cd3ed767 100644
+--- a/thread_pthread.c
++++ b/thread_pthread.c
+@@ -1318,17 +1318,21 @@ void
+ rb_thread_wakeup_timer_thread(void)
+ {
+     /* must be safe inside sighandler, so no mutex */
+-    ATOMIC_INC(timer_thread_pipe.writing);
+-    rb_thread_wakeup_timer_thread_fd(&timer_thread_pipe.normal[1]);
+-    ATOMIC_DEC(timer_thread_pipe.writing);
++    if (timer_thread_pipe.owner_process == getpid()) {
++	ATOMIC_INC(timer_thread_pipe.writing);
++	rb_thread_wakeup_timer_thread_fd(&timer_thread_pipe.normal[1]);
++	ATOMIC_DEC(timer_thread_pipe.writing);
++    }
+ }
+ 
+ static void
+ rb_thread_wakeup_timer_thread_low(void)
+ {
+-    ATOMIC_INC(timer_thread_pipe.writing);
+-    rb_thread_wakeup_timer_thread_fd(&timer_thread_pipe.low[1]);
+-    ATOMIC_DEC(timer_thread_pipe.writing);
++    if (timer_thread_pipe.owner_process == getpid()) {
++	ATOMIC_INC(timer_thread_pipe.writing);
++	rb_thread_wakeup_timer_thread_fd(&timer_thread_pipe.low[1]);
++	ATOMIC_DEC(timer_thread_pipe.writing);
++    }
+ }
+ 
+ /* VM-dependent API is not available for this function */


### PR DESCRIPTION
Ported from puppet-agent - original commit is [here](https://github.com/puppetlabs/puppet-agent/commit/6229e46e5d6ba6e469d18e2fc1132a9fe5a4ae42).