### PR TITLE
(PA-1888) Add custom vendor dir for shared rubygems

### DIFF
--- a/configs/components/ruby-2.4.3.rb
+++ b/configs/components/ruby-2.4.3.rb
@@ -101,6 +101,9 @@ component 'ruby-2.4.3' do |pkg, settings, platform|
   base = 'resources/patches/ruby_243'
   pkg.apply_patch "#{base}/ostruct_remove_safe_nav_operator.patch"
   pkg.apply_patch "#{base}/thread_wakeup_ownership_check.patch"
+  # This patch creates our server/client shared Gem path, used for all gems
+  # that are dependencies of the shared Ruby code.
+  pkg.apply_patch "#{base}/rubygems_add_puppet_vendor_dir.patch"
 
   if platform.is_aix?
     # TODO: Remove this patch once PA-1607 is resolved.

--- a/resources/patches/ruby_243/rubygems_add_puppet_vendor_dir.patch
+++ b/resources/patches/ruby_243/rubygems_add_puppet_vendor_dir.patch
@@ -1,0 +1,45 @@
+diff --git a/lib/rubygems/defaults.rb b/lib/rubygems/defaults.rb
+index 43d57fc808..39eaafd6de 100644
+--- a/lib/rubygems/defaults.rb
++++ b/lib/rubygems/defaults.rb
+@@ -52,6 +52,32 @@ def self.default_dir
+     @default_dir ||= File.join(*path)
+   end
+ 
++  ##
++  # Additional default directory which does not include the ruby version
++  # Used for gems shared between puppet-server and puppet-agent
++
++  def self.puppet_vendor_dir
++    path = if defined? RUBY_FRAMEWORK_VERSION then
++             [
++               File.dirname(RbConfig::CONFIG['sitedir']),
++               'VendorGems'
++             ]
++           elsif RbConfig::CONFIG['rubylibprefix'] then
++             [
++              RbConfig::CONFIG['rubylibprefix'],
++              'vendor_gems',
++             ]
++           else
++             [
++               RbConfig::CONFIG['libdir'],
++               'ruby',
++               'vendor_gems',
++             ]
++           end
++
++    @puppet_vendor_dir ||= File.join(*path)
++  end
++
+   ##
+   # Returns binary extensions dir for specified RubyGems base dir or nil
+   # if such directory cannot be determined.
+@@ -93,6 +119,7 @@ def self.default_path
+     path = []
+     path << user_dir if user_home && File.exist?(user_home)
+     path << default_dir
++    path << puppet_vendor_dir
+     path << vendor_dir if vendor_dir and File.directory? vendor_dir
+     path
+   end


### PR DESCRIPTION
Ported from puppet-agent; Affects ruby 2.4.3 only - [here's the original commit](https://github.com/puppetlabs/puppet-agent/commit/7d87bab1352db02705cbfce561038ad34521fe48)