### PR TITLE
Revert "(maint) Remove Fedora 25 platforms"

### DIFF
--- a/configs/platforms/fedora-f25-i386.rb
+++ b/configs/platforms/fedora-f25-i386.rb
@@ -1,0 +1,10 @@
+platform "fedora-f25-i386" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-25.noarch.rpm"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+  plat.vmpooler_template "fedora-25-i386"
+end

--- a/configs/platforms/fedora-f25-x86_64.rb
+++ b/configs/platforms/fedora-f25-x86_64.rb
@@ -1,0 +1,10 @@
+platform "fedora-f25-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-25.noarch.rpm"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+  plat.vmpooler_template "fedora-25-x86_64"
+end


### PR DESCRIPTION
This reverts commit 598e4ace834ce369d7a370a1549295783aca2f50.

Fedora 25 hasn't been removed from the agent yet, so this removal was premature - we can reapply it later once the removal process is finished there.