### PR TITLE
(maint) Allow using system openssl for puppet-agent

### DIFF
--- a/configs/components/base-ruby.rb
+++ b/configs/components/base-ruby.rb
@@ -52,7 +52,11 @@ end
 # BUILD REQUIREMENTS
 ####################
 
-pkg.build_requires 'openssl'
+if settings[:system_openssl]
+  pkg.build_requires 'openssl-devel'
+else
+  pkg.build_requires 'openssl'
+end
 
 if platform.is_aix?
   pkg.build_requires "runtime-#{settings[:runtime_project]}"

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -9,7 +9,12 @@ component 'curl' do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/curl/curl-7.55.1-aix-poll.patch'
   end
 
-  pkg.build_requires "openssl"
+  if settings[:system_openssl]
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
   pkg.build_requires "puppet-ca-bundle"
 
   if platform.is_cross_compiled_linux?

--- a/configs/components/puppet-ca-bundle.rb
+++ b/configs/components/puppet-ca-bundle.rb
@@ -1,13 +1,17 @@
 component "puppet-ca-bundle" do |pkg, settings, platform|
   pkg.load_from_json("configs/components/puppet-ca-bundle.json")
 
-  pkg.build_requires "openssl"
+  if settings[:system_openssl]
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
 
-  openssl_cmd = "#{settings[:bindir]}/openssl"
-
-  if platform.is_cross_compiled_linux?
-    # Use the build host's openssl command, not our cross-compiled one
-    openssl_cmd = "/usr/bin/openssl"
+  if platform.is_cross_compiled_linux? || settings[:system_openssl]
+    # Use the build host's openssl command, not our cross-compiled or vendored one
+    openssl_cmd = '/usr/bin/openssl'
+  else
+    openssl_cmd = "#{settings[:bindir]}/openssl"
   end
 
   install_commands = [

--- a/configs/projects/base-agent-runtime.rb
+++ b/configs/projects/base-agent-runtime.rb
@@ -28,7 +28,14 @@ end
 
 # Common components required by all agent branches
 proj.component 'runtime-agent'
-proj.component 'openssl'
+
+if platform.name =~ /^redhat-fips-7-.*/
+  # Link against the system openssl instead of our vendored version:
+  proj.setting(:system_openssl, true)
+else
+  proj.component 'openssl'
+end
+
 proj.component 'curl'
 proj.component 'puppet-ca-bundle'
 proj.component "ruby-#{proj.ruby_version}"


### PR DESCRIPTION
FIPS-enabled platforms must use the system openssl instead of puppet's vendored version; This PR  uses the system openssl when building agent runtimes for redhat-fips-7.