### PR TITLE
(PA-1888) Add multi_json rubygem

### DIFF
--- a/configs/components/rubygem-multi_json.rb
+++ b/configs/components/rubygem-multi_json.rb
@@ -1,0 +1,15 @@
+component "rubygem-multi_json" do |pkg, settings, platform|
+  instance_eval File.read('configs/components/base-rubygem.rb')
+  pkg.version '1.13.1'
+  pkg.md5sum 'b7702a827fd011461fbda6b80f2219d5'
+  pkg.url "https://rubygems.org/downloads/multi_json-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/multi_json-#{pkg.get_version}.gem"
+
+  # Overwrite the base rubygem's default GEM_HOME with the vendor gem directory
+  # shared by puppet and puppetserver:
+  pkg.environment "GEM_HOME", settings[:puppet_gem_vendor_dir]
+
+  pkg.install do
+    ["#{settings[:gem_install]} multi_json-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -10,4 +10,5 @@ project 'agent-runtime-5.5.x' do |proj|
 
   # Dependencies specific to the 5.5.x branch
   proj.component 'ruby-stomp-1.4.4'
+  proj.component 'rubygem-multi_json'
 end

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -10,4 +10,5 @@ project 'agent-runtime-master' do |proj|
 
   # Dependencies specific to the master branch
   proj.component 'ruby-stomp-1.4.4'
+  proj.component 'rubygem-multi_json'
 end


### PR DESCRIPTION
Ported from puppet-agent; used in 5.5.x and master agent projects only. [The addition to puppet-agent is here](https://github.com/puppetlabs/puppet-agent/commit/783204701cd0ddc7db52cd08a064e6bde16918ec) - the `:ruby_vendordir` setting in that commit is preserved in the runtime via `inherit_settings` for now, but it's something we'll need to double-check when the directions of settings inheritance is reversed in the near future.