### PR TITLE
(PA-1833) Use local puppet-agent settings instead of `inherit_settings`

### DIFF
--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -99,6 +99,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     pkg.apply_patch "#{base}/aix_ruby_2.1_libpath_with_opt_dir.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_proctitle.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_make_test_failure.patch"
+    pkg.apply_patch "#{base}/Remove-O_CLOEXEC-check-for-AIX-builds.patch"
   end
 
   if platform.is_windows?

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -5,7 +5,7 @@ project 'agent-runtime-1.10.x' do |proj|
   proj.setting :rubygem_ffi_version, '1.9.14'
 
   # Common agent settings:
-  instance_eval File.read('configs/projects/base-agent-runtime.rb')
+  instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
 
   # Dependencies specific to the 1.10.x branch
   proj.component 'ruby-stomp-1.3.3'

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -1,14 +1,11 @@
 project 'agent-runtime-1.10.x' do |proj|
-  proj.inherit_settings 'puppet-agent', 'git://github.com/puppetlabs/puppet-agent', '1.10.x'
-
+  proj.setting :ruby_version, '2.1.9'
   proj.setting :augeas_version, '1.4.0'
   proj.setting :rubygem_fast_gettext_version, '1.1.0'
   proj.setting :rubygem_ffi_version, '1.9.14'
 
   # Common agent settings:
   instance_eval File.read('configs/projects/base-agent-runtime.rb')
-
-  proj.version proj.settings[:package_version]
 
   # Dependencies specific to the 1.10.x branch
   proj.component 'ruby-stomp-1.3.3'

--- a/configs/projects/agent-runtime-5.3.x.rb
+++ b/configs/projects/agent-runtime-5.3.x.rb
@@ -1,12 +1,9 @@
 project 'agent-runtime-5.3.x' do |proj|
-  proj.inherit_settings 'puppet-agent', 'git://github.com/puppetlabs/puppet-agent', '5.3.x'
-
+  proj.setting :ruby_version, '2.4.3'
   proj.setting :augeas_version, '1.8.1'
 
   # Common agent settings:
   instance_eval File.read('configs/projects/base-agent-runtime.rb')
-
-  proj.version proj.settings[:package_version]
 
   # Dependencies specific to the 5.3.x branch
   proj.component 'ruby-stomp-1.4.4'

--- a/configs/projects/agent-runtime-5.3.x.rb
+++ b/configs/projects/agent-runtime-5.3.x.rb
@@ -3,7 +3,7 @@ project 'agent-runtime-5.3.x' do |proj|
   proj.setting :augeas_version, '1.8.1'
 
   # Common agent settings:
-  instance_eval File.read('configs/projects/base-agent-runtime.rb')
+  instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
 
   # Dependencies specific to the 5.3.x branch
   proj.component 'ruby-stomp-1.4.4'

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -4,7 +4,7 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.setting :augeas_version, '1.10.1'
 
   # Common agent settings:
-  instance_eval File.read('configs/projects/base-agent-runtime.rb')
+  instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
 
   proj.version proj.settings[:package_version]
 

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -1,12 +1,9 @@
 project 'agent-runtime-master' do |proj|
-  proj.inherit_settings 'puppet-agent', 'git://github.com/puppetlabs/puppet-agent', 'master'
-
+  proj.setting :ruby_version, '2.4.3'
   proj.setting :augeas_version, '1.10.1'
 
   # Common agent settings:
   instance_eval File.read('configs/projects/base-agent-runtime.rb')
-
-  proj.version proj.settings[:package_version]
 
   # Dependencies specific to the master branch
   proj.component 'ruby-stomp-1.4.4'

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -3,7 +3,7 @@ project 'agent-runtime-master' do |proj|
   proj.setting :augeas_version, '1.10.1'
 
   # Common agent settings:
-  instance_eval File.read('configs/projects/base-agent-runtime.rb')
+  instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
 
   # Dependencies specific to the master branch
   proj.component 'ruby-stomp-1.4.4'

--- a/configs/projects/base-agent-runtime.rb
+++ b/configs/projects/base-agent-runtime.rb
@@ -135,11 +135,6 @@ end
 proj.setting(:platform_triple, platform_triple)
 proj.setting(:host, host)
 
-# For some platforms the default doc location for the BOM does not exist or is incorrect - move it to specified directory
-if platform.name =~ /cisco-wrlinux/
-  proj.bill_of_materials File.join(proj.datadir, "doc")
-end
-
 # Define default CFLAGS and LDFLAGS for most platforms, and then
 # tweak or adjust them as needed.
 proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")

--- a/configs/projects/base-agent-runtime.rb
+++ b/configs/projects/base-agent-runtime.rb
@@ -16,15 +16,181 @@ proj.description 'The puppet agent runtime contains third-party components neede
 proj.license 'See components'
 proj.vendor 'Puppet, Inc.  <info@puppet.com>'
 proj.homepage 'https://puppet.com'
+proj.version_from_git
 
-# Some projects and platforms using the runtime set custom ruby installation
-# directories - fall back to the project prefix if ruby_dir hasn't been set
-proj.setting(:ruby_dir, proj.settings[:prefix]) unless proj.settings[:ruby_dir]
-proj.setting(:ruby_bindir, File.join(proj.settings[:ruby_dir], 'bin')) unless proj.settings[:ruby_bindir]
+proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
+proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
+
+
+########
+# Common build settings for all versions of puppet-agent
+########
+
+if platform.is_windows?
+  proj.setting(:company_id, "PuppetLabs")
+  proj.setting(:product_id, "Puppet")
+  if platform.architecture == "x64"
+    proj.setting(:base_dir, "ProgramFiles64Folder")
+  else
+    proj.setting(:base_dir, "ProgramFilesFolder")
+  end
+  # We build for windows not in the final destination, but in the paths that correspond
+  # to the directory ids expected by WIX. This will allow for a portable installation (ideally).
+  proj.setting(:install_root, File.join("C:", proj.base_dir, proj.company_id, proj.product_id))
+  proj.setting(:sysconfdir, File.join("C:", "CommonAppDataFolder", proj.company_id))
+  proj.setting(:tmpfilesdir, "C:/Windows/Temp")
+  proj.setting(:windows_tools, File.join(proj.install_root, "sys/tools/bin"))
+else
+  proj.setting(:install_root, "/opt/puppetlabs")
+  if platform.is_eos?
+    proj.setting(:sysconfdir, "/persist/sys/etc/puppetlabs")
+    proj.setting(:link_sysconfdir, "/etc/puppetlabs")
+  elsif platform.is_macos?
+    proj.setting(:sysconfdir, "/private/etc/puppetlabs")
+  else
+    proj.setting(:sysconfdir, "/etc/puppetlabs")
+  end
+  proj.setting(:logdir, "/var/log/puppetlabs")
+  proj.setting(:piddir, "/var/run/puppetlabs")
+  proj.setting(:tmpfilesdir, "/usr/lib/tmpfiles.d")
+end
+
+proj.setting(:miscdir, File.join(proj.install_root, "misc"))
+proj.setting(:prefix, File.join(proj.install_root, "puppet"))
+proj.setting(:bindir, File.join(proj.prefix, "bin"))
+proj.setting(:link_bindir, File.join(proj.install_root, "bin"))
+proj.setting(:includedir, File.join(proj.prefix, "include"))
+proj.setting(:datadir, File.join(proj.prefix, "share"))
+proj.setting(:mandir, File.join(proj.datadir, "man"))
+
+if platform.is_windows?
+  proj.setting(:ruby_dir, File.join(proj.install_root, "sys/ruby"))
+  proj.setting(:ruby_bindir, File.join(proj.ruby_dir, "bin"))
+  proj.setting(:host_ruby, File.join(proj.ruby_bindir, "ruby.exe"))
+  proj.setting(:host_gem, File.join(proj.ruby_bindir, "gem.bat"))
+  proj.setting(:libdir, File.join(proj.ruby_dir, "lib"))
+else
+  proj.setting(:ruby_dir, proj.settings[:prefix])
+  proj.setting(:ruby_bindir, File.join(proj.settings[:ruby_dir], 'bin'))
+  proj.setting(:host_ruby, File.join(proj.bindir, "ruby"))
+  proj.setting(:host_gem, File.join(proj.bindir, "gem"))
+  proj.setting(:libdir, File.join(proj.prefix, "lib"))
+end
+
+raise "Couldn't find a :ruby_version setting in the project file" unless proj.ruby_version
+ruby_base_version = proj.ruby_version.gsub(/(\d)\.(\d)\.(\d)/, '\1.\2.0')
+proj.setting(:gem_home, File.join(proj.libdir, 'ruby', 'gems', ruby_base_version))
+proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
+
+# Cross-compiled Linux platforms
+platform_triple = "ppc64le-redhat-linux" if platform.architecture == "ppc64le"
+platform_triple = "powerpc64le-suse-linux" if platform.architecture == "ppc64le" && platform.name =~ /^sles-/
+platform_triple = "powerpc64le-linux-gnu" if platform.architecture == "ppc64el"
+platform_triple = "s390x-linux-gnu" if platform.architecture == "s390x"
+platform_triple = "arm-linux-gnueabihf" if platform.name == 'debian-8-armhf'
+platform_triple = "arm-linux-gnueabi" if platform.name == 'debian-8-armel'
+platform_triple = "aarch64-redhat-linux" if platform.name == 'el-7-aarch64'
+
+if platform.is_cross_compiled_linux?
+  host = "--host #{platform_triple}"
+
+  # Use a standalone ruby for cross-compilation
+  proj.setting(:host_ruby, "/opt/pl-build-tools/bin/ruby")
+  proj.setting(:host_gem, "/opt/pl-build-tools/bin/gem")
+end
+
+# For solaris, we build cross-compilers
+if platform.is_solaris?
+  if platform.architecture == 'i386'
+    platform_triple = "#{platform.architecture}-pc-solaris2.#{platform.os_version}"
+  else
+    platform_triple = "#{platform.architecture}-sun-solaris2.#{platform.os_version}"
+    host = "--host #{platform_triple}"
+
+    # For cross-compiling, we have a standalone ruby
+    if platform.os_version == "10"
+      proj.setting(:host_ruby, "/opt/csw/bin/ruby")
+      proj.setting(:host_gem, "/opt/csw/bin/gem2.0")
+    else
+      proj.setting(:host_ruby, "/opt/pl-build-tools/bin/ruby")
+      proj.setting(:host_gem, "/opt/pl-build-tools/bin/gem")
+    end
+  end
+elsif platform.is_windows?
+  # For windows, we need to ensure we are building for mingw not cygwin
+  platform_triple = platform.platform_triple
+  host = "--host #{platform_triple}"
+end
+
+proj.setting(:gem_install, "#{proj.host_gem} install --no-rdoc --no-ri --local ")
+if platform.is_windows?
+  proj.setting(:gem_install, "#{proj.gem_install} --bindir #{proj.ruby_bindir} ")
+end
+
+# For AIX, we use the triple to install a better rbconfig
+if platform.is_aix?
+  platform_triple = "powerpc-ibm-aix#{platform.os_version}.0.0"
+end
+
+proj.setting(:platform_triple, platform_triple)
+proj.setting(:host, host)
+
+# For some platforms the default doc location for the BOM does not exist or is incorrect - move it to specified directory
+if platform.name =~ /cisco-wrlinux/
+  proj.bill_of_materials File.join(proj.datadir, "doc")
+end
+
+# Define default CFLAGS and LDFLAGS for most platforms, and then
+# tweak or adjust them as needed.
+proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+proj.setting(:cflags, "#{proj.cppflags}")
+proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+
+# Platform specific overrides or settings, which may override the defaults
+if platform.is_windows?
+  arch = platform.architecture == "x64" ? "64" : "32"
+  proj.setting(:gcc_root, "C:/tools/mingw#{arch}")
+  proj.setting(:vs_version, '2017')
+  # The msbuild command needs to be surrounded in quotes and shelled
+  # out to cmd.exe because otherwise cygwin will treat the && in bash and
+  # fail. Even though the invocation of msbuild is in quotes, parameters
+  # sent to it don't need extra quotes or escaping.
+  proj.setting(:msbuild, "cmd.exe /C \"C:/tools/vsdevcmd.bat && msbuild\"")
+  proj.setting(:gcc_bindir, "#{proj.gcc_root}/bin")
+  proj.setting(:tools_root, "C:/tools/pl-build-tools")
+  proj.setting(:cppflags, "-I#{proj.tools_root}/include -I#{proj.gcc_root}/include -I#{proj.includedir}")
+  proj.setting(:cflags, "#{proj.cppflags}")
+  proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir} -Wl,--nxcompat -Wl,--dynamicbase")
+  proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
+end
 
 if platform.is_macos?
+  # For OS X, we should optimize for an older architecture than Apple
+  # currently ships for; there's a lot of older xeon chips based on
+  # that architecture still in use throughout the Mac ecosystem.
+  # Additionally, OS X doesn't use RPATH for linking. We shouldn't
+  # define it or try to force it in the linker, because this might
+  # break gcc or clang if they try to use the RPATH values we forced.
+  proj.setting(:cppflags, "-I#{proj.includedir}")
+  proj.setting(:cflags, "-march=core2 -msse4 #{proj.cppflags}")
+  proj.setting(:ldflags, "-L#{proj.libdir} ")
+end
+
+if platform.is_aix?
+  proj.setting(:ldflags, "-Wl,-brtl -L#{proj.libdir} -L/opt/pl-build-tools/lib")
+end
+
+if platform.is_solaris?
+  proj.identifier 'puppetlabs.com'
+elsif platform.is_macos?
   proj.identifier 'com.puppetlabs'
 end
+
+proj.timeout 7200 if platform.is_windows?
+
+########
+# Common components for all versions of puppet-agent
+########
 
 # Common components required by all agent branches
 proj.component 'runtime-agent'
@@ -83,5 +249,3 @@ proj.directory proj.piddir unless platform.is_windows?
 if platform.is_windows? || platform.is_macos?
   proj.directory proj.bindir
 end
-
-proj.timeout 7200 if platform.is_windows?

--- a/resources/files/ruby_243/rbconfig/rbconfig-aarch64-redhat-linux.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-aarch64-redhat-linux.rb
@@ -21,7 +21,7 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
+  CONFIG["TEENY"] = "3"
   CONFIG["PATCHLEVEL"] = "198"
   CONFIG["INSTALL"] = '/bin/install -c'
   CONFIG["EXEEXT"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-arm-linux-gnueabihf.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-arm-linux-gnueabihf.rb
@@ -11,8 +11,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -196,7 +196,7 @@ module RbConfig
   CONFIG["build_vendor"] = "unknown"
   CONFIG["build_cpu"] = "arm"
   CONFIG["build"] = "arm-unknown-linux-gnueabihf"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = "arm-linux-gnueabihf"
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-i386-pc-solaris2.10.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-i386-pc-solaris2.10.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/opt/csw/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -197,7 +197,7 @@ module RbConfig
   CONFIG["build_vendor"] = "pc"
   CONFIG["build_cpu"] = "i386"
   CONFIG["build"] = "i386-pc-solaris2.10"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-i386-pc-solaris2.11.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-i386-pc-solaris2.11.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/ccs/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -195,7 +195,7 @@ module RbConfig
   CONFIG["build_vendor"] = "pc"
   CONFIG["build_cpu"] = "i386"
   CONFIG["build"] = "i386-pc-solaris2.11"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-i686-w64-mingw32.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-i686-w64-mingw32.rb
@@ -23,8 +23,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/bin/install -c'
   CONFIG["EXEEXT"] = ".exe"
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "C:/ProgramFilesFolder/PuppetLabs/Puppet/sys/ruby")

--- a/resources/files/ruby_243/rbconfig/rbconfig-powerpc-ibm-aix6.1.0.0.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-powerpc-ibm-aix6.1.0.0.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = ''
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -197,7 +197,7 @@ module RbConfig
   CONFIG["build_vendor"] = "ibm"
   CONFIG["build_cpu"] = "powerpc"
   CONFIG["build"] = "powerpc-ibm-aix6.1.0.0"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-powerpc-ibm-aix7.1.0.0.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-powerpc-ibm-aix7.1.0.0.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = ''
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -197,7 +197,7 @@ module RbConfig
   CONFIG["build_vendor"] = "ibm"
   CONFIG["build_cpu"] = "powerpc"
   CONFIG["build"] = "powerpc-ibm-aix7.1.0.0"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-powerpc64le-linux-gnu.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-powerpc64le-linux-gnu.rb
@@ -19,8 +19,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_243/rbconfig/rbconfig-powerpc64le-suse-linux.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-powerpc64le-suse-linux.rb
@@ -21,8 +21,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_243/rbconfig/rbconfig-ppc64le-redhat-linux.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-ppc64le-redhat-linux.rb
@@ -21,8 +21,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_243/rbconfig/rbconfig-s390x-linux-gnu.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-s390x-linux-gnu.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -197,7 +197,7 @@ module RbConfig
   CONFIG["build_vendor"] = "ibm"
   CONFIG["build_cpu"] = "s390x"
   CONFIG["build"] = "s390x-ibm-linux-gnu"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-sparc-sun-solaris2.10.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-sparc-sun-solaris2.10.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/opt/csw/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -197,7 +197,7 @@ module RbConfig
   CONFIG["build_vendor"] = "sun"
   CONFIG["build_cpu"] = "sparc"
   CONFIG["build"] = "sparc-sun-solaris2.10"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-sparc-sun-solaris2.11.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-sparc-sun-solaris2.11.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -195,7 +195,7 @@ module RbConfig
   CONFIG["build_vendor"] = "sun"
   CONFIG["build_cpu"] = "sparc"
   CONFIG["build"] = "sparc-sun-solaris2.11"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-x86_64-w64-mingw32.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-x86_64-w64-mingw32.rb
@@ -23,8 +23,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/bin/install -c'
   CONFIG["EXEEXT"] = ".exe"
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "C:/ProgramFiles64Folder/PuppetLabs/Puppet/sys/ruby")

--- a/resources/patches/ruby_219/Remove-O_CLOEXEC-check-for-AIX-builds.patch
+++ b/resources/patches/ruby_219/Remove-O_CLOEXEC-check-for-AIX-builds.patch
@@ -1,0 +1,28 @@
+From 5ee0b6fa8d66c538d38954a3b07b9c788ab72ca9 Mon Sep 17 00:00:00 2001
+From: "Sean P. McDonald" <sean.mcdonald@puppetlabs.com>
+Date: Tue, 5 Dec 2017 09:16:14 -0800
+Subject: [PATCH] Remove O_CLOEXEC check for AIX builds
+
+---
+ io.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/io.c b/io.c
+index 08775f111c..af4c0cb743 100644
+--- a/io.c
++++ b/io.c
+@@ -228,10 +228,7 @@ int
+ rb_cloexec_open(const char *pathname, int flags, mode_t mode)
+ {
+     int ret;
+-#ifdef O_CLOEXEC
+-    /* O_CLOEXEC is available since Linux 2.6.23.  Linux 2.6.18 silently ignore it. */
+-    flags |= O_CLOEXEC;
+-#elif defined O_NOINHERIT
++#ifdef defined O_NOINHERIT
+     flags |= O_NOINHERIT;
+ #endif
+     ret = open(pathname, flags, mode);
+-- 
+2.14.2.windows.1
+


### PR DESCRIPTION
Previously, the puppet-agent runtime projects inherited their settings from puppet-agent using vanagon's `inherit_settings` feature. This PR ports relevant settings from the agent to puppet-runtime so that `inherit_settings` is no longer necessary here.

Also included is a ruby 2.1.9 patch for AIX which I previously forgot to include (and seems necessary for this change).

I've built this branch and used it in a 1.10.x agent which I ran through the ad-hoc agent pipeline  - you can see [passing acceptance tests for the agent build here](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/98/).

Once the changes in this PR are merged, the plan is to apply a corresponding change to puppet-agent, so that settings aren't duplicated across both projects; Instead, puppet-agent will use `inherit_settings` to gather settings from puppet-runtime, applying anything else it needs (wix settings, for example) afterward.