### PR TITLE
(PA-1888) Ruby fixes

### DIFF
--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -99,6 +99,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     pkg.apply_patch "#{base}/aix_ruby_2.1_libpath_with_opt_dir.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_proctitle.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_make_test_failure.patch"
+    pkg.apply_patch "#{base}/Remove-O_CLOEXEC-check-for-AIX-builds.patch"
   end
 
   if platform.is_windows?

--- a/resources/files/ruby_243/rbconfig/rbconfig-aarch64-redhat-linux.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-aarch64-redhat-linux.rb
@@ -21,7 +21,7 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
+  CONFIG["TEENY"] = "3"
   CONFIG["PATCHLEVEL"] = "198"
   CONFIG["INSTALL"] = '/bin/install -c'
   CONFIG["EXEEXT"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-arm-linux-gnueabihf.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-arm-linux-gnueabihf.rb
@@ -11,8 +11,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -196,7 +196,7 @@ module RbConfig
   CONFIG["build_vendor"] = "unknown"
   CONFIG["build_cpu"] = "arm"
   CONFIG["build"] = "arm-unknown-linux-gnueabihf"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = "arm-linux-gnueabihf"
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-i386-pc-solaris2.10.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-i386-pc-solaris2.10.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/opt/csw/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -197,7 +197,7 @@ module RbConfig
   CONFIG["build_vendor"] = "pc"
   CONFIG["build_cpu"] = "i386"
   CONFIG["build"] = "i386-pc-solaris2.10"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-i386-pc-solaris2.11.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-i386-pc-solaris2.11.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/ccs/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -195,7 +195,7 @@ module RbConfig
   CONFIG["build_vendor"] = "pc"
   CONFIG["build_cpu"] = "i386"
   CONFIG["build"] = "i386-pc-solaris2.11"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-i686-w64-mingw32.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-i686-w64-mingw32.rb
@@ -23,8 +23,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/bin/install -c'
   CONFIG["EXEEXT"] = ".exe"
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "C:/ProgramFilesFolder/PuppetLabs/Puppet/sys/ruby")

--- a/resources/files/ruby_243/rbconfig/rbconfig-powerpc-ibm-aix6.1.0.0.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-powerpc-ibm-aix6.1.0.0.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = ''
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -197,7 +197,7 @@ module RbConfig
   CONFIG["build_vendor"] = "ibm"
   CONFIG["build_cpu"] = "powerpc"
   CONFIG["build"] = "powerpc-ibm-aix6.1.0.0"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-powerpc-ibm-aix7.1.0.0.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-powerpc-ibm-aix7.1.0.0.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = ''
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -197,7 +197,7 @@ module RbConfig
   CONFIG["build_vendor"] = "ibm"
   CONFIG["build_cpu"] = "powerpc"
   CONFIG["build"] = "powerpc-ibm-aix7.1.0.0"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-powerpc64le-linux-gnu.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-powerpc64le-linux-gnu.rb
@@ -19,8 +19,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_243/rbconfig/rbconfig-powerpc64le-suse-linux.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-powerpc64le-suse-linux.rb
@@ -21,8 +21,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_243/rbconfig/rbconfig-ppc64le-redhat-linux.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-ppc64le-redhat-linux.rb
@@ -21,8 +21,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_243/rbconfig/rbconfig-s390x-linux-gnu.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-s390x-linux-gnu.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -197,7 +197,7 @@ module RbConfig
   CONFIG["build_vendor"] = "ibm"
   CONFIG["build_cpu"] = "s390x"
   CONFIG["build"] = "s390x-ibm-linux-gnu"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-sparc-sun-solaris2.10.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-sparc-sun-solaris2.10.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/opt/csw/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -197,7 +197,7 @@ module RbConfig
   CONFIG["build_vendor"] = "sun"
   CONFIG["build_cpu"] = "sparc"
   CONFIG["build"] = "sparc-sun-solaris2.10"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-sparc-sun-solaris2.11.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-sparc-sun-solaris2.11.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/usr/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
@@ -195,7 +195,7 @@ module RbConfig
   CONFIG["build_vendor"] = "sun"
   CONFIG["build_cpu"] = "sparc"
   CONFIG["build"] = "sparc-sun-solaris2.11"
-  CONFIG["RUBY_RELEASE_DATE"] = "2017-03-22"
+  CONFIG["RUBY_RELEASE_DATE"] = "2017-12-14"
   CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
   CONFIG["target_alias"] = ""
   CONFIG["host_alias"] = ""

--- a/resources/files/ruby_243/rbconfig/rbconfig-x86_64-w64-mingw32.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-x86_64-w64-mingw32.rb
@@ -23,8 +23,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "2"
-  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
   CONFIG["INSTALL"] = '/bin/install -c'
   CONFIG["EXEEXT"] = ".exe"
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "C:/ProgramFiles64Folder/PuppetLabs/Puppet/sys/ruby")

--- a/resources/patches/ruby_219/Remove-O_CLOEXEC-check-for-AIX-builds.patch
+++ b/resources/patches/ruby_219/Remove-O_CLOEXEC-check-for-AIX-builds.patch
@@ -1,0 +1,28 @@
+From 5ee0b6fa8d66c538d38954a3b07b9c788ab72ca9 Mon Sep 17 00:00:00 2001
+From: "Sean P. McDonald" <sean.mcdonald@puppetlabs.com>
+Date: Tue, 5 Dec 2017 09:16:14 -0800
+Subject: [PATCH] Remove O_CLOEXEC check for AIX builds
+
+---
+ io.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/io.c b/io.c
+index 08775f111c..af4c0cb743 100644
+--- a/io.c
++++ b/io.c
+@@ -228,10 +228,7 @@ int
+ rb_cloexec_open(const char *pathname, int flags, mode_t mode)
+ {
+     int ret;
+-#ifdef O_CLOEXEC
+-    /* O_CLOEXEC is available since Linux 2.6.23.  Linux 2.6.18 silently ignore it. */
+-    flags |= O_CLOEXEC;
+-#elif defined O_NOINHERIT
++#if defined O_NOINHERIT
+     flags |= O_NOINHERIT;
+ #endif
+     ret = open(pathname, flags, mode);
+-- 
+2.14.2.windows.1
+


### PR DESCRIPTION
Two commits to resolve errors I made in porting ruby configs from puppet-agent:

- Add a missing AIX patch (seems to only affect AIX 7.n)
- Updated rbconfigs for ruby 2.4.3

These files were copied directly from puppet-agent. I ran some agent acceptance tests on a build using these commits and [everything seems to be in order](https://jenkins-master-prod-1.delivery.puppetlabs.net/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/104/) (barring a transient which a reload fixed).