### PR TITLE
(packaging) Update vanagon to version 0.15.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def vanagon_location_for(place)
 end
 
 gem 'artifactory'
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.14.3')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.15.5')
 gem 'packaging', :github => 'puppetlabs/packaging', branch: '1.0.x'
 gem 'rake', '~> 12.0'
 


### PR DESCRIPTION
Vanagon 0.14.3 was too old to understand the redhat 7 FIPS platform - this doesn't matter in CI, since `VANAGON_LOCATION` is set to a newer version there, but locally we must update the Gemfile