### PR TITLE
(maint) Separate openssl flags between runtimes

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -135,38 +135,17 @@ component 'openssl' do |pkg, settings, platform|
     sslflags,
     'enable-rfc3779',
     'enable-tlsext',
-    'no-3des',
     'no-camellia',
     'no-ec2m',
-    'no-gost',
     'no-md2',
     'no-mdc2',
-    'no-rc5',
-    'no-srp',
     'no-ssl2',
     'no-ssl3',
   ]
 
-  configure_flags << 'no-psk' unless platform.is_windows?
-
-  if settings[:runtime_project] == 'agent'
-    configure_flags.concat([
-       'no-dtls',
-       'no-dtls1',
-       'no-idea',
-       'no-seed',
-       'no-ssl2-method',
-       'no-weak-ssl-ciphers',
-       '-DOPENSSL_NO_HEARTBEATS',
-    ])
-  elsif settings[:runtime_project] == 'pdk'
-    configure_flags.concat([
-      'enable-cms',
-      'enable-seed',
-    ])
-  end
-
-  configure_flags << cflags << ldflags
+  # Individual projects may provide their own openssl configure flags:
+  project_flags = settings[:openssl_extra_configure_flags] || []
+  configure_flags << project_flags << cflags << ldflags
 
   pkg.configure do
     ["./Configure #{configure_flags.join(' ')}"]

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -5,6 +5,17 @@ project 'agent-runtime-1.10.x' do |proj|
   proj.setting :rubygem_ffi_version, '1.9.14'
   proj.setting :ruby_stomp_version, '1.3.3'
 
+  # The 1.10.x agent's openssl configure flags are slightly different from higher versions:
+  # These flags are applied in addition to the defaults in configs/component/openssl.rb.
+  proj.setting(:openssl_extra_configure_flags, [
+    'enable-cms',
+    'enable-seed',
+    'no-gost',
+    'no-rc5',
+    'no-srp',
+    'no-ssl2-method',
+  ])
+
   # Common agent settings:
   instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
 end

--- a/configs/projects/base-agent-runtime.rb
+++ b/configs/projects/base-agent-runtime.rb
@@ -2,7 +2,7 @@
 # See configs/projects/agent-runtime-<branchname>.rb
 unless defined?(proj)
   warn('This is the base project for the puppet-agent runtime.')
-  warn('Please choose one of `puppet-agent-master`, `puppet-agent-5.3.x`, or `puppet-agent-1.10.x` instead.')
+  warn('Please choose one of the other puppet-agent projects instead.')
   exit 1
 end
 
@@ -191,6 +191,18 @@ proj.timeout 7200 if platform.is_windows?
 
 # Common components required by all agent branches
 proj.component 'runtime-agent'
+
+# Most branches of puppet-agent use these openssl flags in addition to the defaults in configs/components/openssl.rb -
+# Individual projects can override these if necessary.
+proj.setting(:openssl_extra_configure_flags, [
+  'no-dtls',
+  'no-dtls1',
+  'no-idea',
+  'no-seed',
+  'no-ssl2-method',
+  'no-weak-ssl-ciphers',
+  '-DOPENSSL_NO_HEARTBEATS',
+]) unless proj.settings[:openssl_extra_configure_flags]
 
 if platform.name =~ /^redhat-fips-7-.*/
   # Link against the system openssl instead of our vendored version:

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -17,6 +17,15 @@ project 'pdk-runtime' do |proj|
     proj.identifier "com.puppetlabs"
   end
 
+  # These flags are applied in addition to the defaults in configs/component/openssl.rb.
+  proj.setting(:openssl_extra_configure_flags, [
+    'enable-cms',
+    'enable-seed',
+    'no-gost',
+    'no-rc5',
+    'no-srp',
+  ])
+
   # What to build?
   # --------------
 


### PR DESCRIPTION
When adding puppet-agent runtime projects, there was an attempt to use the same openssl configure flags for all projects, which caused integration failures; This commit restores the original configurations
for all projects.

For reference, here are the previous configurations for each project - this PR is intended to restore the configure options used below:
 
- [puppet-agent master](https://github.com/puppetlabs/puppet-agent/blob/master/configs/components/openssl.rb#L100), [puppet-agent 5.5.x](https://github.com/puppetlabs/puppet-agent/blob/5.5.x/configs/components/openssl.rb#L100), and [puppet-agent 5.3.x](https://github.com/puppetlabs/puppet-agent/blob/c43e3f6b34b32d7dca2f2a337e34e6974a83a10b/configs/components/openssl.rb#L100), which are all the same
- [puppet-agent 1.10.x](https://github.com/puppetlabs/puppet-agent/blob/4b6f376d588f0a94d6a762d6720b90b5fb246e51/configs/components/openssl.rb#L111)
- [pdk, which used the runtime before puppet-agent did](https://github.com/puppetlabs/puppet-runtime/blob/77a074f6a68546bc7b6c771ff4eadc0fdd1280dd/configs/components/openssl.rb#L44)