### PR TITLE
(PA-1886) Remove gettext-setup gem

### DIFF
--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -4,6 +4,7 @@ project 'agent-runtime-1.10.x' do |proj|
   proj.setting :rubygem_fast_gettext_version, '1.1.0'
   proj.setting :rubygem_ffi_version, '1.9.14'
   proj.setting :ruby_stomp_version, '1.3.3'
+  proj.component 'rubygem-gettext-setup'
 
   # Common agent settings:
   instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))

--- a/configs/projects/agent-runtime-5.3.x.rb
+++ b/configs/projects/agent-runtime-5.3.x.rb
@@ -1,6 +1,7 @@
 project 'agent-runtime-5.3.x' do |proj|
   proj.setting :ruby_version, '2.4.3'
   proj.setting :augeas_version, '1.8.1'
+  proj.component 'rubygem-gettext-setup'
 
   # Common agent settings:
   instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -1,6 +1,7 @@
 project 'agent-runtime-5.5.x' do |proj|
   proj.setting :ruby_version, '2.4.3'
   proj.setting :augeas_version, '1.10.1'
+  proj.component 'rubygem-gettext-setup'
 
   # Common agent settings:
   instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))

--- a/configs/projects/base-agent-runtime.rb
+++ b/configs/projects/base-agent-runtime.rb
@@ -226,7 +226,6 @@ proj.component 'rubygem-text'
 proj.component 'rubygem-locale'
 proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
-proj.component 'rubygem-gettext-setup'
 
 if platform.is_windows?
   proj.component 'rubygem-ffi'


### PR DESCRIPTION
Since this gem is no longer used at runtime, it should be removed as a
dependency.