### PR TITLE
(PA-1958) Rename redhat-fips platform to redhatfips

### DIFF
--- a/configs/platforms/redhatfips-7-x86_64.rb
+++ b/configs/platforms/redhatfips-7-x86_64.rb
@@ -1,4 +1,4 @@
-platform "redhat-fips-7-x86_64" do |plat|
+platform "redhatfips-7-x86_64" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"

--- a/configs/projects/base-agent-runtime.rb
+++ b/configs/projects/base-agent-runtime.rb
@@ -204,7 +204,7 @@ proj.setting(:openssl_extra_configure_flags, [
   '-DOPENSSL_NO_HEARTBEATS',
 ]) unless proj.settings[:openssl_extra_configure_flags]
 
-if platform.name =~ /^redhat-fips-7-.*/
+if platform.name =~ /^redhatfips-7-.*/
   # Link against the system openssl instead of our vendored version:
   proj.setting(:system_openssl, true)
 else


### PR DESCRIPTION
Dashes in platform names cause trouble down the line when it comes time
to add the platform to pe_repo, so make this platform name 'redhatfips'.