### PR TITLE
(PA-1951) Restore curl binaries in agent runtimes

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -46,11 +46,18 @@ component 'curl' do |pkg, settings, platform|
     ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
+  install_steps = [
+    "#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
+  ]
+
+  unless settings[:runtime_project] == 'agent'
+    # Most projects won't need curl binaries, so delete them after installation.
+    # Note that the agent _should_ include curl binaries; Some projects and
+    # scripts depend on them and they can be helpful in debugging.
+    install_steps << "rm -f #{settings[:prefix]}/bin/{curl,curl-config}"
+  end
+
   pkg.install do
-    # Do not need curl binaries, delete after install
-    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
-     "rm -f #{settings[:prefix]}/bin/curl",
-     "rm -f #{settings[:prefix]}/bin/curl-config"
-    ]
+    install_steps
   end
 end


### PR DESCRIPTION
PDK doesn't need the curl binaries, so they were being removed as part of the install step for the curl component. It turns out that although puppet-agent doesn't rely directly on the curl binaries, they're an important part of some workflows!

I've built some agent and pdk tarballs locally using this branch and verified that curl is present in the agent versions and absent in the pdk one (there are no acceptance tests for this).