### PR TITLE
(PA-1886) Fix ordering of components in agent projects

### DIFF
--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -4,7 +4,6 @@ project 'agent-runtime-1.10.x' do |proj|
   proj.setting :rubygem_fast_gettext_version, '1.1.0'
   proj.setting :rubygem_ffi_version, '1.9.14'
   proj.setting :ruby_stomp_version, '1.3.3'
-  proj.component 'rubygem-gettext-setup'
 
   # The 1.10.x agent's openssl configure flags are slightly different from higher versions:
   # These flags are applied in addition to the defaults in configs/component/openssl.rb.
@@ -19,4 +18,7 @@ project 'agent-runtime-1.10.x' do |proj|
 
   # Common agent settings:
   instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
+
+  # Dependencies specific to the 1.10.x branch
+  proj.component 'rubygem-gettext-setup'
 end

--- a/configs/projects/agent-runtime-5.3.x.rb
+++ b/configs/projects/agent-runtime-5.3.x.rb
@@ -1,8 +1,10 @@
 project 'agent-runtime-5.3.x' do |proj|
   proj.setting :ruby_version, '2.4.3'
   proj.setting :augeas_version, '1.8.1'
-  proj.component 'rubygem-gettext-setup'
 
   # Common agent settings:
   instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
+
+  # Dependencies specific to the 5.3.x branch
+  proj.component 'rubygem-gettext-setup'
 end

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -1,11 +1,11 @@
 project 'agent-runtime-5.5.x' do |proj|
   proj.setting :ruby_version, '2.4.3'
   proj.setting :augeas_version, '1.10.1'
-  proj.component 'rubygem-gettext-setup'
 
   # Common agent settings:
   instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
 
   # Dependencies specific to the 5.5.x branch
+  proj.component 'rubygem-gettext-setup'
   proj.component 'rubygem-multi_json'
 end


### PR DESCRIPTION
Builds of rubygems rely on a runtime project setting, which (for agent
projects) isn't set until the base agent project is evaluated. This
commit moves the inclusion of gettext-setup to after this point.