### PR TITLE
(PA-1959) Various CVE patches backported to Ruby 2.1.9 (agent 1.10.x)

### DIFF
--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -118,6 +118,16 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   pkg.apply_patch "#{base}/cve-2017-14064.patch"
   pkg.apply_patch "#{base}/cve-2017-17405.patch"
 
+  # Patches from Ruby 2.2.10 security fixes from March 2018. See
+  # RE-10480 for more details.
+  pkg.apply_patch "#{base}/cve-2018-8780.patch"
+  pkg.apply_patch "#{base}/cve-2018-6914.patch"
+  pkg.apply_patch "#{base}/cve-2018-8779.patch"
+  pkg.apply_patch "#{base}/cve-2018-8778.patch"
+  pkg.apply_patch "#{base}/cve-2018-8777-1.patch"
+  pkg.apply_patch "#{base}/cve-2018-8777-2.patch"
+  pkg.apply_patch "#{base}/cve-2017-17742.patch"
+
   if platform.is_aix?
     pkg.apply_patch "#{base}/aix_ruby_2.1_libpath_with_opt_dir.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_proctitle.patch"

--- a/resources/patches/ruby_219/cve-2017-17742.patch
+++ b/resources/patches/ruby_219/cve-2017-17742.patch
@@ -1,0 +1,121 @@
+From bbda1a027475bf7ce5e1a9583a7b55d0be71c8fe Mon Sep 17 00:00:00 2001
+From: usa <usa@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Wed, 28 Mar 2018 14:50:27 +0000
+Subject: [PATCH] merge revision(s) 62968:
+
+	webrick: prevent response splitting and header injection
+
+	Original patch by tenderlove (with minor style adjustments).
+
+	* lib/webrick/httpresponse.rb (send_header): call check_header
+	  (check_header): raise on embedded CRLF in header value
+	* test/webrick/test_httpresponse.rb
+	  (test_prevent_response_splitting_headers): new test
+	* (test_prevent_response_splitting_cookie_headers): ditto
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/branches/ruby_2_2@63022 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+---
+ ChangeLog                         | 12 ++++++++++++
+ lib/webrick/httpresponse.rb       | 27 +++++++++++++++++++++++++--
+ test/webrick/test_httpresponse.rb | 22 ++++++++++++++++++++++
+ version.h                         |  2 +-
+ 4 files changed, 60 insertions(+), 3 deletions(-)
+
+diff --git a/lib/webrick/httpresponse.rb b/lib/webrick/httpresponse.rb
+index 048929b0ec..4c30045713 100644
+--- a/lib/webrick/httpresponse.rb
++++ b/lib/webrick/httpresponse.rb
+@@ -20,6 +20,8 @@ module WEBrick
+   # WEBrick HTTP Servlet.
+ 
+   class HTTPResponse
++    class InvalidHeader < StandardError
++    end
+ 
+     ##
+     # HTTP Response version
+@@ -286,14 +288,19 @@ module WEBrick
+         data = status_line()
+         @header.each{|key, value|
+           tmp = key.gsub(/\bwww|^te$|\b\w/){ $&.upcase }
+-          data << "#{tmp}: #{value}" << CRLF
++          data << "#{tmp}: #{check_header(value)}" << CRLF
+         }
+         @cookies.each{|cookie|
+-          data << "Set-Cookie: " << cookie.to_s << CRLF
++          data << "Set-Cookie: " << check_header(cookie.to_s) << CRLF
+         }
+         data << CRLF
+         _write_data(socket, data)
+       end
++    rescue InvalidHeader => e
++      @header.clear
++      @cookies.clear
++      set_error e
++      retry
+     end
+ 
+     ##
+@@ -353,6 +360,22 @@ module WEBrick
+         host, port = @config[:ServerName], @config[:Port]
+       end
+ 
++      error_body(backtrace, ex, host, port)
++    end
++
++    private
++
++    def check_header(header_value)
++      if header_value =~ /\r\n/
++        raise InvalidHeader
++      else
++        header_value
++      end
++    end
++
++    # :stopdoc:
++
++    def error_body(backtrace, ex, host, port)
+       @body = ''
+       @body << <<-_end_of_html_
+ <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+diff --git a/test/webrick/test_httpresponse.rb b/test/webrick/test_httpresponse.rb
+index d264637786..b8a3eb99cc 100644
+--- a/test/webrick/test_httpresponse.rb
++++ b/test/webrick/test_httpresponse.rb
+@@ -1,6 +1,7 @@
+ require "webrick"
+ require "minitest/autorun"
+ require "stringio"
++require "net/http"
+ 
+ module WEBrick
+   class TestHTTPResponse < MiniTest::Unit::TestCase
+@@ -27,6 +28,27 @@ module WEBrick
+       @res.keep_alive  = true
+     end
+ 
++    def test_prevent_response_splitting_headers
++      res['X-header'] = "malicious\r\nCookie: hack"
++      io = StringIO.new
++      res.send_response io
++      io.rewind
++      res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
++      assert_equal '500', res.code
++      refute_match 'hack', io.string
++    end
++
++    def test_prevent_response_splitting_cookie_headers
++      user_input = "malicious\r\nCookie: hack"
++      res.cookies << WEBrick::Cookie.new('author', user_input)
++      io = StringIO.new
++      res.send_response io
++      io.rewind
++      res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
++      assert_equal '500', res.code
++      refute_match 'hack', io.string
++    end
++
+     def test_304_does_not_log_warning
+       res.status      = 304
+       res.setup_header

--- a/resources/patches/ruby_219/cve-2018-6914.patch
+++ b/resources/patches/ruby_219/cve-2018-6914.patch
@@ -1,0 +1,116 @@
+# Patch backported to Ruby 2.1.9 by Scott Garman <scott.garman@puppet.com>
+From e9ddf2ba41a0bffe1047e33576affd48808c5d0b Mon Sep 17 00:00:00 2001
+From: usa <usa@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Wed, 28 Mar 2018 14:34:14 +0000
+Subject: [PATCH] merge revision(s) 62990:
+
+	Ignore file separator from tmpfile/tmpdir name.
+
+	From: SHIBATA Hiroshi <hsbt@ruby-lang.org>
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/branches/ruby_2_2@63017 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+---
+ ChangeLog             |  4 ++++
+ lib/tmpdir.rb         |  2 ++
+ test/test_tempfile.rb | 28 +++++++++++++++++++++++++++-
+ test/test_tmpdir.rb   | 34 ++++++++++++++++++++++++++++++++++
+ version.h             |  2 +-
+ 5 files changed, 68 insertions(+), 2 deletions(-)
+
+diff --git a/lib/tmpdir.rb b/lib/tmpdir.rb
+index 494725cb33..95f20e984c 100644
+--- a/lib/tmpdir.rb
++++ b/lib/tmpdir.rb
+@@ -116,6 +116,12 @@
+       else
+         raise ArgumentError, "unexpected prefix_suffix: #{prefix_suffix.inspect}"
+       end
++      prefix = (String.try_convert(prefix) or
++                raise ArgumentError, "unexpected prefix: #{prefix.inspect}")
++      prefix = prefix.delete("#{File::SEPARATOR}#{File::ALT_SEPARATOR}")
++      suffix &&= (String.try_convert(suffix) or
++                  raise ArgumentError, "unexpected suffix: #{suffix.inspect}")
++      suffix &&= suffix.delete("#{File::SEPARATOR}#{File::ALT_SEPARATOR}")
+       t = Time.now.strftime("%Y%m%d")
+       path = "#{prefix}#{t}-#{$$}-#{rand(0x100000000).to_s(36)}"
+       path << "-#{n}" if n
+diff --git a/test/test_tempfile.rb b/test/test_tempfile.rb
+index 2fe62d37c5..8a44dd33f1 100644
+--- a/test/test_tempfile.rb
++++ b/test/test_tempfile.rb
+@@ -339,5 +339,31 @@ puts Tempfile.new('foo').path
+     f.close if f && !f.closed?
+     File.unlink path if path
+   end
+-end
+ 
++  TRAVERSAL_PATH = Array.new(Dir.pwd.split('/').count, '..').join('/') + Dir.pwd + '/'
++
++  def test_open_traversal_dir
++    expect = Dir.glob(TRAVERSAL_PATH + '*').count
++    t = Tempfile.open([TRAVERSAL_PATH, 'foo'])
++    actual = Dir.glob(TRAVERSAL_PATH + '*').count
++    assert_equal expect, actual
++  ensure
++    t.close!
++  end
++
++  def test_new_traversal_dir
++    expect = Dir.glob(TRAVERSAL_PATH + '*').count
++    t = Tempfile.new(TRAVERSAL_PATH + 'foo')
++    actual = Dir.glob(TRAVERSAL_PATH + '*').count
++    assert_equal expect, actual
++  ensure
++    t.close!
++  end
++
++  def test_create_traversal_dir
++    expect = Dir.glob(TRAVERSAL_PATH + '*').count
++    Tempfile.create(TRAVERSAL_PATH + 'foo')
++    actual = Dir.glob(TRAVERSAL_PATH + '*').count
++    assert_equal expect, actual
++  end
++end
+diff --git a/test/test_tmpdir.rb b/test/test_tmpdir.rb
+index 62b4abfa1a..2585453183 100644
+--- a/test/test_tmpdir.rb
++++ b/test/test_tmpdir.rb
+@@ -30,4 +30,38 @@
+     ENV["HOME"] = home
+     Dir.rmdir(dir) if dir
+   end
++
++  TRAVERSAL_PATH = Array.new(Dir.pwd.split('/').count, '..').join('/') + Dir.pwd + '/'
++  TRAVERSAL_PATH.delete!(':') if /mswin|mingw/ =~ RUBY_PLATFORM
++
++  def test_mktmpdir_traversal
++    expect = Dir.glob(TRAVERSAL_PATH + '*').count
++    Dir.mktmpdir(TRAVERSAL_PATH + 'foo')
++    actual = Dir.glob(TRAVERSAL_PATH + '*').count
++    assert_equal expect, actual
++  end
++
++  def test_mktmpdir_traversal_array
++    expect = Dir.glob(TRAVERSAL_PATH + '*').count
++    Dir.mktmpdir([TRAVERSAL_PATH, 'foo'])
++    actual = Dir.glob(TRAVERSAL_PATH + '*').count
++    assert_equal expect, actual
++  end
++
++  TRAVERSAL_PATH = Array.new(Dir.pwd.split('/').count, '..').join('/') + Dir.pwd + '/'
++  TRAVERSAL_PATH.delete!(':') if /mswin|mingw/ =~ RUBY_PLATFORM
++
++  def test_mktmpdir_traversal
++    expect = Dir.glob(TRAVERSAL_PATH + '*').count
++    Dir.mktmpdir(TRAVERSAL_PATH + 'foo')
++    actual = Dir.glob(TRAVERSAL_PATH + '*').count
++    assert_equal expect, actual
++  end
++
++  def test_mktmpdir_traversal_array
++    expect = Dir.glob(TRAVERSAL_PATH + '*').count
++    Dir.mktmpdir([TRAVERSAL_PATH, 'foo'])
++    actual = Dir.glob(TRAVERSAL_PATH + '*').count
++    assert_equal expect, actual
++  end
+ end

--- a/resources/patches/ruby_219/cve-2018-8777-1.patch
+++ b/resources/patches/ruby_219/cve-2018-8777-1.patch
@@ -1,0 +1,399 @@
+# Patch backported to Ruby 2.1.9 by Scott Garman <scott.garman@puppet.com>
+From 19cb3fa9e0621004a9dc08e90884c512c75dac57 Mon Sep 17 00:00:00 2001
+From: usa <usa@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Wed, 28 Mar 2018 14:44:20 +0000
+Subject: [PATCH] merge revision(s) 60584,62954-62959,63008:
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+	webrick: support Proc objects as body responses
+
+	* lib/webrick/httpresponse.rb (send_body): call send_body_proc
+	  (send_body_proc): new method
+	  (class ChunkedWrapper): new class
+
+	* test/webrick/test_httpresponse.rb (test_send_body_proc): new test
+	  (test_send_body_proc_chunked): ditto
+	  [Feature #855]
+
+	webrick: favor .write over << method
+
+	This will make the next change to use IO.copy_stream
+	easier-to-read.  When we can drop Ruby 2.4 support in a few
+	years, this will allow us to use writev(2) with multiple
+	arguments for headers and chunked responses.
+
+	* lib/webrick/cgi.rb (write): new wrapper method
+	  lib/webrick/httpresponse.rb: (send_header): use socket.write
+	  (send_body_io): ditto
+	  (send_body_string): ditto
+	  (send_body_proc): ditto
+	  (_write_data): ditto
+	  (ChunkedWrapper#write): ditto
+	  (_send_file): ditto
+	------------------------------------------------------------------------
+	r62954 | normal | 2018-03-28 17:05:52 +0900 (水, 28 3 2018) | 14 lines
+
+	webrick/httpresponse: IO.copy_stream for regular files
+
+	Remove the redundant _send_file method since its functionality
+	is unnecessary with IO.copy_stream.  IO.copy_stream also allows
+	the use of sendfile under some OSes to speed up copies to
+	non-TLS sockets.
+
+	Testing with "curl >/dev/null" and "ruby -run -e httpd" to
+	read a 1G file over Linux loopback reveals a reduction from
+	around ~0.770 to ~0.490 seconds on the client side.
+
+	* lib/webrick/httpresponse.rb (send_body_io): use IO.copy_stream
+	  (_send_file): remove
+	  [Feature #14237]
+	------------------------------------------------------------------------
+	r62955 | normal | 2018-03-28 17:05:57 +0900 (水, 28 3 2018) | 10 lines
+
+	webrick: use IO.copy_stream for single range response
+
+	This is also compatible with range responses generated
+	by Rack::File (tested with rack 2.0.3).
+
+	* lib/webrick/httpresponse.rb (send_body_io): use Content-Range
+	* lib/webrick/httpservlet/filehandler.rb (make_partial_content):
+	  use File object for the single range case
+	* test/webrick/test_filehandler.rb (get_res_body): use send_body
+	  to test result
+	------------------------------------------------------------------------
+	r62956 | normal | 2018-03-28 17:06:02 +0900 (水, 28 3 2018) | 7 lines
+
+	test/webrick/test_filehandler.rb: stricter multipart range test
+
+	We need to ensure we generate compatibile output in
+	the face of future changes
+
+	* test/webrick/test_filehandler.rb (test_make_partial_content):
+	  check response body
+	------------------------------------------------------------------------
+	r62957 | normal | 2018-03-28 17:06:08 +0900 (水, 28 3 2018) | 8 lines
+
+	webrick: quiet warning for multi-part ranges
+
+	Content-Length is ignored by WEBrick::HTTPResponse even if we
+	calculate it, so instead we chunk responses to HTTP/1.1 clients
+	and terminate HTTP/1.0 connections.
+
+	* lib/webrick/httpservlet/filehandler.rb (make_partial_content):
+	  quiet warning
+	------------------------------------------------------------------------
+	r62958 | normal | 2018-03-28 17:06:13 +0900 (水, 28 3 2018) | 7 lines
+
+	webrick/httpresponse: make ChunkedWrapper copy_stream-compatible
+
+	The .write method needs to return the number of bytes written
+	to avoid confusing IO.copy_stream.
+
+	* lib/webrick/httpresponse.rb (ChunkedWrapper#write): return bytes written
+	  (ChunkedWrapper#<<): return self
+	------------------------------------------------------------------------
+	r62959 | normal | 2018-03-28 17:06:18 +0900 (水, 28 3 2018) | 9 lines
+
+	webrick: use IO.copy_stream for multipart response
+
+	Use the new Proc response body feature to generate a multipart
+	range response dynamically.  We use a flat array to minimize
+	object overhead as much as possible; as many ranges may fit
+	into an HTTP request header.
+
+	* lib/webrick/httpservlet/filehandler.rb (multipart_body): new method
+	  (make_partial_content): use multipart_body
+
+	get rid of test error/failure on Windows introduced at r62955
+
+	* lib/webrick/httpresponse.rb (send_body_io): use seek if NotImplementedError
+	  is raised in IO.copy_stream with offset.
+
+	* lib/webrick/httpservlet/filehandler.rb (multipart_body): ditto.
+
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/branches/ruby_2_2@63020 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+---
+ ChangeLog                              | 98 ++++++++++++++++++++++++++++++++++
+ lib/webrick/httpresponse.rb            | 68 ++++++++++++++++-------
+ lib/webrick/httpservlet/filehandler.rb | 65 ++++++++++++++--------
+ test/webrick/test_filehandler.rb       | 31 +++++++----
+ test/webrick/test_httpresponse.rb      | 33 ++++++++++++
+ version.h                              |  2 +-
+ 6 files changed, 244 insertions(+), 53 deletions(-)
+
+diff --git a/lib/webrick/httpresponse.rb b/lib/webrick/httpresponse.rb
+index e897e8c01b..048929b0ec 100644
+--- a/lib/webrick/httpresponse.rb
++++ b/lib/webrick/httpresponse.rb
+@@ -302,6 +302,8 @@ module WEBrick
+     def send_body(socket) # :nodoc:
+       if @body.respond_to? :readpartial then
+         send_body_io(socket)
++      elsif @body.respond_to?(:call) then
++        send_body_proc(socket)
+       else
+         send_body_string(socket)
+       end
+@@ -404,9 +406,20 @@ module WEBrick
+           end
+           _write_data(socket, "0#{CRLF}#{CRLF}")
+         else
+-          size = @header['content-length'].to_i
+-          _send_file(socket, @body, 0, size)
+-          @sent_size = size
++          if %r{\Abytes (\d+)-(\d+)/\d+\z} =~ @header['content-range']
++            offset = $1.to_i
++            size = $2.to_i - offset + 1
++          else
++            offset = nil
++            size = @header['content-length']
++            size = size.to_i if size
++          end
++          begin
++            @sent_size = IO.copy_stream(@body, socket, size, offset)
++          rescue NotImplementedError
++            @body.seek(offset, IO::SEEK_SET)
++            @sent_size = IO.copy_stream(@body, socket, size)
++          end
+         end
+       ensure
+         @body.close
+@@ -435,24 +448,41 @@ module WEBrick
+       end
+     end
+ 
+-    def _send_file(output, input, offset, size)
+-      while offset > 0
+-        sz = @buffer_size < size ? @buffer_size : size
+-        buf = input.read(sz)
+-        offset -= buf.bytesize
++    def send_body_proc(socket)
++      if @request_method == "HEAD"
++        # do nothing
++      elsif chunked?
++        @body.call(ChunkedWrapper.new(socket, self))
++        _write_data(socket, "0#{CRLF}#{CRLF}")
++      else
++        size = @header['content-length'].to_i
++        @body.call(socket)
++        @sent_size = size
++      end
++    end
++
++    class ChunkedWrapper
++      def initialize(socket, resp)
++        @socket = socket
++        @resp = resp
+       end
+ 
+-      if size == 0
+-        while buf = input.read(@buffer_size)
+-          _write_data(output, buf)
+-        end
+-      else
+-        while size > 0
+-          sz = @buffer_size < size ? @buffer_size : size
+-          buf = input.read(sz)
+-          _write_data(output, buf)
+-          size -= buf.bytesize
+-        end
++      def write(buf)
++        return 0 if buf.empty?
++        socket = @socket
++        @resp.instance_eval {
++          size = buf.bytesize
++          data = "#{size.to_s(16)}#{CRLF}#{buf}#{CRLF}"
++          _write_data(socket, data)
++          data.clear
++          @sent_size += size
++          size
++        }
++      end
++
++      def <<(*buf)
++        write(buf)
++        self
+       end
+     end
+ 
+diff --git a/lib/webrick/httpservlet/filehandler.rb b/lib/webrick/httpservlet/filehandler.rb
+index cc9db4a870..c10d9b30c2 100644
+--- a/lib/webrick/httpservlet/filehandler.rb
++++ b/lib/webrick/httpservlet/filehandler.rb
+@@ -86,6 +86,35 @@ module WEBrick
+         return false
+       end
+ 
++      # returns a lambda for webrick/httpresponse.rb send_body_proc
++      def multipart_body(body, parts, boundary, mtype, filesize)
++        lambda do |socket|
++          begin
++            begin
++              first = parts.shift
++              last = parts.shift
++              socket.write(
++                "--#{boundary}#{CRLF}" \
++                "Content-Type: #{mtype}#{CRLF}" \
++                "Content-Range: bytes #{first}-#{last}/#{filesize}#{CRLF}" \
++                "#{CRLF}"
++              )
++
++              begin
++                IO.copy_stream(body, socket, last - first + 1, first)
++              rescue NotImplementedError
++                body.seek(first, IO::SEEK_SET)
++                IO.copy_stream(body, socket, last - first + 1)
++              end
++              socket.write(CRLF)
++            end while parts[0]
++            socket.write("--#{boundary}--#{CRLF}")
++          ensure
++            body.close
++          end
++        end
++      end
++
+       def make_partial_content(req, res, filename, filesize)
+         mtype = HTTPUtils::mime_type(filename, @config[:MimeTypes])
+         unless ranges = HTTPUtils::parse_range_header(req['range'])
+@@ -96,37 +125,27 @@ module WEBrick
+           if ranges.size > 1
+             time = Time.now
+             boundary = "#{time.sec}_#{time.usec}_#{Process::pid}"
+-            body = ''
+-            ranges.each{|range|
+-              first, last = prepare_range(range, filesize)
+-              next if first < 0
+-              io.pos = first
+-              content = io.read(last-first+1)
+-              body << "--" << boundary << CRLF
+-              body << "Content-Type: #{mtype}" << CRLF
+-              body << "Content-Range: bytes #{first}-#{last}/#{filesize}" << CRLF
+-              body << CRLF
+-              body << content
+-              body << CRLF
++            parts = []
++            ranges.each {|range|
++              prange = prepare_range(range, filesize)
++              next if prange[0] < 0
++              parts.concat(prange)
+             }
+-            raise HTTPStatus::RequestRangeNotSatisfiable if body.empty?
+-            body << "--" << boundary << "--" << CRLF
++            raise HTTPStatus::RequestRangeNotSatisfiable if parts.empty?
+             res["content-type"] = "multipart/byteranges; boundary=#{boundary}"
+-            res.body = body
++            if req.http_version < '1.1'
++              res['connection'] = 'close'
++            else
++              res.chunked = true
++            end
++            res.body = multipart_body(io.dup, parts, boundary, mtype, filesize)
+           elsif range = ranges[0]
+             first, last = prepare_range(range, filesize)
+             raise HTTPStatus::RequestRangeNotSatisfiable if first < 0
+-            if last == filesize - 1
+-              content = io.dup
+-              content.pos = first
+-            else
+-              io.pos = first
+-              content = io.read(last-first+1)
+-            end
+             res['content-type'] = mtype
+             res['content-range'] = "bytes #{first}-#{last}/#{filesize}"
+             res['content-length'] = last - first + 1
+-            res.body = content
++            res.body = io.dup
+           else
+             raise HTTPStatus::BadRequest
+           end
+diff --git a/test/webrick/test_filehandler.rb b/test/webrick/test_filehandler.rb
+index f984efb3ac..ff1f428b73 100644
+--- a/test/webrick/test_filehandler.rb
++++ b/test/webrick/test_filehandler.rb
+@@ -14,11 +14,10 @@
+   end
+ 
+   def get_res_body(res)
+-    if defined? res.body.read
+-      res.body.read
+-    else
+-      res.body
+-    end
++    sio = StringIO.new
++    sio.binmode
++    res.send_body(sio)
++    sio.string
+   end
+ 
+   def make_range_request(range_spec)
+@@ -75,6 +69,23 @@ class WEBrick::TestFileHandler < Test::Unit::TestCase
+ 
+     res = make_range_response(filename, "bytes=0-0, -2")
+     assert_match(%r{^multipart/byteranges}, res["content-type"])
++    body = get_res_body(res)
++    boundary = /; boundary=(.+)/.match(res['content-type'])[1]
++    off = filesize - 2
++    last = filesize - 1
++
++    exp = "--#{boundary}\r\n" \
++          "Content-Type: text/plain\r\n" \
++          "Content-Range: bytes 0-0/#{filesize}\r\n" \
++          "\r\n" \
++          "#{IO.read(__FILE__, 1)}\r\n" \
++          "--#{boundary}\r\n" \
++          "Content-Type: text/plain\r\n" \
++          "Content-Range: bytes #{off}-#{last}/#{filesize}\r\n" \
++          "\r\n" \
++          "#{IO.read(__FILE__, 2, off)}\r\n" \
++          "--#{boundary}--\r\n"
++    assert_equal exp, body
+   end
+ 
+   def test_filehandler
+diff --git a/test/webrick/test_httpresponse.rb b/test/webrick/test_httpresponse.rb
+index c916ed57c2..d264637786 100644
+--- a/test/webrick/test_httpresponse.rb
++++ b/test/webrick/test_httpresponse.rb
+@@ -137,5 +137,38 @@
+       r.binmode
+       assert_equal "5\r\nhello\r\n0\r\n\r\n", r.read
+     end
++
++    def test_send_body_proc
++      @res.body = Proc.new { |out| out.write('hello') }
++      IO.pipe do |r, w|
++        @res.send_body(w)
++        w.close
++        r.binmode
++        assert_equal 'hello', r.read
++      end
++      assert_equal 0, logger.messages.length
++    end
++
++    def test_send_body_proc_chunked
++      @res.body = Proc.new { |out| out.write('hello') }
++      @res.chunked = true
++      IO.pipe do |r, w|
++        @res.send_body(w)
++        w.close
++        r.binmode
++        assert_equal "5\r\nhello\r\n0\r\n\r\n", r.read
++      end
++      assert_equal 0, logger.messages.length
++    end
++
++    def test_set_error
++      status = 400
++      message = 'missing attribute'
++      @res.status = status
++      error = WEBrick::HTTPStatus[status].new(message)
++      body = @res.set_error(error)
++      assert_match(/#{@res.reason_phrase}/, body)
++      assert_match(/#{message}/, body)
++    end
+   end
+ end

--- a/resources/patches/ruby_219/cve-2018-8777-2.patch
+++ b/resources/patches/ruby_219/cve-2018-8777-2.patch
@@ -1,0 +1,386 @@
+# Patch backported to Ruby 2.1.9 by Scott Garman <scott.garman@puppet.com>
+From a45622669bb1ff18d3ee9b411128acd839c4263e Mon Sep 17 00:00:00 2001
+From: usa <usa@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Wed, 28 Mar 2018 14:47:30 +0000
+Subject: [PATCH] merge revision(s) 62960-62965:
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+	webrick: use IO.copy_stream for multipart response
+
+	Use the new Proc response body feature to generate a multipart
+	range response dynamically.  We use a flat array to minimize
+	object overhead as much as possible; as many ranges may fit
+	into an HTTP request header.
+
+	* lib/webrick/httpservlet/filehandler.rb (multipart_body): new method
+	  (make_partial_content): use multipart_body
+	------------------------------------------------------------------------
+	r62960 | normal | 2018-03-28 17:06:23 +0900 (水, 28 3 2018) | 13 lines
+
+	webrick/httprequest: limit request headers size
+
+	We use the same 112 KB limit started (AFAIK) by Mongrel, Thin,
+	and Puma to prevent malicious users from using up all the memory
+	with a single request.  This also limits the damage done by
+	excessive ranges in multipart Range: requests.
+
+	Due to the way we rely on IO#gets and the desire to keep
+	the code simple, the actual maximum header may be 4093 bytes
+	larger than 112 KB, but we're splitting hairs at that point.
+
+	* lib/webrick/httprequest.rb: define MAX_HEADER_LENGTH
+	  (read_header): raise when headers exceed max length
+	------------------------------------------------------------------------
+	r62961 | normal | 2018-03-28 17:06:28 +0900 (水, 28 3 2018) | 9 lines
+
+	webrick/httpservlet/cgihandler: reduce memory use
+
+	WEBrick::HTTPRequest#body can be passed a block to process the
+	body in chunks.  Use this feature to avoid building a giant
+	string in memory.
+
+	* lib/webrick/httpservlet/cgihandler.rb (do_GET):
+	  avoid reading entire request body into memory
+	  (do_POST is aliased to do_GET, so it handles bodies)
+	------------------------------------------------------------------------
+	r62962 | normal | 2018-03-28 17:06:34 +0900 (水, 28 3 2018) | 7 lines
+
+	webrick/httprequest: raise correct exception
+
+	"BadRequest" alone does not resolve correctly, it is in the
+	HTTPStatus namespace.
+
+	* lib/webrick/httprequest.rb (read_chunked): use correct exception
+	* test/webrick/test_httpserver.rb (test_eof_in_chunk): new test
+	------------------------------------------------------------------------
+	r62963 | normal | 2018-03-28 17:06:39 +0900 (水, 28 3 2018) | 9 lines
+
+	webrick/httprequest: use InputBufferSize for chunked requests
+
+	While WEBrick::HTTPRequest#body provides a Proc interface
+	for streaming large request bodies, clients must not force
+	the server to use an excessively large chunk size.
+
+	* lib/webrick/httprequest.rb (read_chunk_size): limit each
+	  read and block.call to :InputBufferSize in config.
+	* test/webrick/test_httpserver.rb (test_big_chunks): new test
+	------------------------------------------------------------------------
+	r62964 | normal | 2018-03-28 17:06:44 +0900 (水, 28 3 2018) | 9 lines
+
+	webrick: add test for Digest auth-int
+
+	No changes to the actual code, this is a new test for
+	a feature for which no tests existed.  I don't understand
+	the Digest authentication code well at all, but this is
+	necessary for the subsequent change.
+
+	* test/webrick/test_httpauth.rb (test_digest_auth_int): new test
+	  (credentials_for_request): support bodies with POST
+	------------------------------------------------------------------------
+	r62965 | normal | 2018-03-28 17:06:49 +0900 (水, 28 3 2018) | 18 lines
+
+	webrick/httpauth/digestauth: stream req.body
+
+	WARNING! WARNING! WARNING!  LIKELY BROKEN CHANGE
+
+	Pass a proc to WEBrick::HTTPRequest#body to avoid reading a
+	potentially large request body into memory during
+	authentication.
+
+	WARNING! this will break apps completely which want to do
+	something with the body besides calculating the MD5 digest
+	of it.
+
+	Also, keep in mind that probably nobody uses "auth-int".
+	Servers such as Apache, lighttpd, nginx don't seem to
+	support it; nor does curl when using POST/PUT bodies;
+	and we didn't have tests for it until now...
+
+	* lib/webrick/httpauth/digestauth.rb (_authenticate): stream req.body
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/branches/ruby_2_2@63021 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+---
+ ChangeLog                             | 83 ++++++++++++++++++++++++++++++++
+ lib/webrick/httpauth/digestauth.rb    |  8 ++--
+ lib/webrick/httprequest.rb            | 23 ++++++---
+ lib/webrick/httpservlet/cgihandler.rb |  4 +-
+ test/webrick/test_httpauth.rb         | 90 ++++++++++++++++++++++++++++++++++-
+ test/webrick/test_httpserver.rb       | 67 ++++++++++++++++++++++++++
+ version.h                             |  2 +-
+ 7 files changed, 262 insertions(+), 15 deletions(-)
+
+diff --git a/lib/webrick/httpauth/digestauth.rb b/lib/webrick/httpauth/digestauth.rb
+index 0eea94774f..eb7581afb0 100644
+--- a/lib/webrick/httpauth/digestauth.rb
++++ b/lib/webrick/httpauth/digestauth.rb
+@@ -235,9 +235,11 @@ module WEBrick
+           ha2 = hexdigest(req.request_method, auth_req['uri'])
+           ha2_res = hexdigest("", auth_req['uri'])
+         elsif auth_req['qop'] == "auth-int"
+-          ha2 = hexdigest(req.request_method, auth_req['uri'],
+-                          hexdigest(req.body))
+-          ha2_res = hexdigest("", auth_req['uri'], hexdigest(res.body))
++          body_digest = @h.new
++          req.body { |chunk| body_digest.update(chunk) }
++          body_digest = body_digest.hexdigest
++          ha2 = hexdigest(req.request_method, auth_req['uri'], body_digest)
++          ha2_res = hexdigest("", auth_req['uri'], body_digest)
+         end
+ 
+         if auth_req['qop'] == "auth" || auth_req['qop'] == "auth-int"
+diff --git a/lib/webrick/httprequest.rb b/lib/webrick/httprequest.rb
+index 6aa2d1c1f2..d00ced35c4 100644
+--- a/lib/webrick/httprequest.rb
++++ b/lib/webrick/httprequest.rb
+@@ -413,9 +413,13 @@ module WEBrick
+ 
+     MAX_URI_LENGTH = 2083 # :nodoc:
+ 
++    # same as Mongrel, Thin and Puma
++    MAX_HEADER_LENGTH = (112 * 1024) # :nodoc:
++
+     def read_request_line(socket)
+       @request_line = read_line(socket, MAX_URI_LENGTH) if socket
+-      if @request_line.bytesize >= MAX_URI_LENGTH and @request_line[-1, 1] != LF
++      @request_bytes = @request_line.bytesize
++      if @request_bytes >= MAX_URI_LENGTH and @request_line[-1, 1] != LF
+         raise HTTPStatus::RequestURITooLarge
+       end
+       @request_time = Time.now
+@@ -434,6 +438,9 @@ module WEBrick
+       if socket
+         while line = read_line(socket)
+           break if /\A(#{CRLF}|#{LF})\z/om =~ line
++          if (@request_bytes += line.bytesize) > MAX_HEADER_LENGTH
++            raise HTTPStatus::RequestEntityTooLarge, 'headers too large'
++          end
+           @raw_header << line
+         end
+       end
+@@ -501,12 +508,16 @@ module WEBrick
+     def read_chunked(socket, block)
+       chunk_size, = read_chunk_size(socket)
+       while chunk_size > 0
+-        data = read_data(socket, chunk_size) # read chunk-data
+-        if data.nil? || data.bytesize != chunk_size
+-          raise BadRequest, "bad chunk data size."
+-        end
++        begin
++          sz = [ chunk_size, @buffer_size ].min
++          data = read_data(socket, sz) # read chunk-data
++          if data.nil? || data.bytesize != sz
++            raise HTTPStatus::BadRequest, "bad chunk data size."
++          end
++          block.call(data)
++        end while (chunk_size -= sz) > 0
++
+         read_line(socket)                    # skip CRLF
+-        block.call(data)
+         chunk_size, = read_chunk_size(socket)
+       end
+       read_header(socket)                    # trailer + CRLF
+diff --git a/lib/webrick/httpservlet/cgihandler.rb b/lib/webrick/httpservlet/cgihandler.rb
+index 40b0e0b97d..8f2b820a3b 100644
+--- a/lib/webrick/httpservlet/cgihandler.rb
++++ b/lib/webrick/httpservlet/cgihandler.rb
+@@ -64,9 +64,7 @@ module WEBrick
+           cgi_in.write("%8d" % dump.bytesize)
+           cgi_in.write(dump)
+ 
+-          if req.body and req.body.bytesize > 0
+-            cgi_in.write(req.body)
+-          end
++          req.body { |chunk| cgi_in.write(chunk) }
+         ensure
+           cgi_in.close
+           status = $?.exitstatus
+diff --git a/test/webrick/test_httpauth.rb b/test/webrick/test_httpauth.rb
+index 0aebb7a231..3b80f754a0 100644
+--- a/test/webrick/test_httpauth.rb
++++ b/test/webrick/test_httpauth.rb
+@@ -3,6 +3,7 @@ require "net/http"
+ require "tempfile"
+ require "webrick"
+ require "webrick/httpauth/basicauth"
++require "stringio"
+ require_relative "utils"
+ 
+ class TestWEBrickHTTPAuth < Test::Unit::TestCase
+@@ -210,12 +211,97 @@ class TestWEBrickHTTPAuth < Test::Unit::TestCase
+     }
+   end
+ 
++  def test_digest_auth_int
++    log_tester = lambda {|log, access_log|
++      log.reject! {|line| /\A\s*\z/ =~ line }
++      pats = [
++        /ERROR Digest wb auth-int realm: no credentials in the request\./,
++        /ERROR WEBrick::HTTPStatus::Unauthorized/,
++        /ERROR Digest wb auth-int realm: foo: digest unmatch\./
++      ]
++      pats.each {|pat|
++        assert(!log.grep(pat).empty?, "webrick log doesn't have expected error: #{pat.inspect}")
++        log.reject! {|line| pat =~ line }
++      }
++      assert_equal([], log)
++   }
++    TestWEBrick.start_httpserver({}, log_tester) {|server, addr, port, log|
++      realm = "wb auth-int realm"
++      path = "/digest_auth_int"
++
++      Tempfile.create("test_webrick_auth_int") {|tmpfile|
++        tmpfile.close
++        tmp_pass = WEBrick::HTTPAuth::Htdigest.new(tmpfile.path)
++        tmp_pass.set_passwd(realm, "foo", "Hunter2")
++        tmp_pass.flush
++
++        htdigest = WEBrick::HTTPAuth::Htdigest.new(tmpfile.path)
++        users = []
++        htdigest.each{|user, pass| users << user }
++        assert_equal %w(foo), users
++
++        auth = WEBrick::HTTPAuth::DigestAuth.new(
++          :Realm => realm, :UserDB => htdigest,
++          :Algorithm => 'MD5',
++          :Logger => server.logger,
++          :Qop => %w(auth-int),
++        )
++        server.mount_proc(path){|req, res|
++          auth.authenticate(req, res)
++          res.body = "bbb"
++        }
++        Net::HTTP.start(addr, port) do |http|
++          post = Net::HTTP::Post.new(path)
++          params = {}
++          data = 'hello=world'
++          body = StringIO.new(data)
++          post.content_length = data.bytesize
++          post['Content-Type'] = 'application/x-www-form-urlencoded'
++          post.body_stream = body
++
++          http.request(post) do |res|
++            assert_equal('401', res.code, log.call)
++            res["www-authenticate"].scan(DIGESTRES_) do |key, quoted, token|
++              params[key.downcase] = token || quoted.delete('\\')
++            end
++             params['uri'] = "http://#{addr}:#{port}#{path}"
++          end
++
++          body.rewind
++          cred = credentials_for_request('foo', 'Hunter3', params, body)
++          post['Authorization'] = cred
++          post.body_stream = body
++          http.request(post){|res|
++            assert_equal('401', res.code, log.call)
++            assert_not_equal("bbb", res.body, log.call)
++          }
++
++          body.rewind
++          cred = credentials_for_request('foo', 'Hunter2', params, body)
++          post['Authorization'] = cred
++          post.body_stream = body
++          http.request(post){|res| assert_equal("bbb", res.body, log.call)}
++        end
++      }
++    }
++  end
++
+   private
+-  def credentials_for_request(user, password, params)
++  def credentials_for_request(user, password, params, body = nil)
+     cnonce = "hoge"
+     nonce_count = 1
+     ha1 = "#{user}:#{params['realm']}:#{password}"
+-    ha2 = "GET:#{params['uri']}"
++    if body
++      dig = Digest::MD5.new
++      while buf = body.read(16384)
++        dig.update(buf)
++      end
++      body.rewind
++      ha2 = "POST:#{params['uri']}:#{dig.hexdigest}"
++    else
++      ha2 = "GET:#{params['uri']}"
++    end
++
+     request_digest =
+       "#{Digest::MD5.hexdigest(ha1)}:" \
+       "#{params['nonce']}:#{'%08x' % nonce_count}:#{cnonce}:#{params['qop']}:" \
+diff --git a/test/webrick/test_httpserver.rb b/test/webrick/test_httpserver.rb
+index a3dc35ecf0..01316fdc3b 100644
+--- a/test/webrick/test_httpserver.rb
++++ b/test/webrick/test_httpserver.rb
+@@ -366,4 +366,71 @@
+     }
+     assert_equal(requested, 1)
+   end
++
++  def test_gigantic_request_header
++    log_tester = lambda {|log, access_log|
++      assert_equal 1, log.size
++      assert log[0].include?('ERROR headers too large')
++    }
++    TestWEBrick.start_httpserver({}, log_tester){|server, addr, port, log|
++      server.mount('/', WEBrick::HTTPServlet::FileHandler, __FILE__)
++      TCPSocket.open(addr, port) do |c|
++        c.write("GET / HTTP/1.0\r\n")
++        junk = "X-Junk: #{' ' * 1024}\r\n"
++        assert_raise(Errno::ECONNRESET, Errno::EPIPE) do
++          loop { c.write(junk) }
++        end
++      end
++    }
++  end
++
++  def test_eof_in_chunk
++    log_tester = lambda do |log, access_log|
++      assert_equal 1, log.size
++      assert log[0].include?('ERROR bad chunk data size')
++    end
++    TestWEBrick.start_httpserver({}, log_tester){|server, addr, port, log|
++      server.mount_proc('/', ->(req, res) { res.body = req.body })
++      TCPSocket.open(addr, port) do |c|
++        c.write("POST / HTTP/1.1\r\nHost: example.com\r\n" \
++                "Transfer-Encoding: chunked\r\n\r\n5\r\na")
++        c.shutdown(Socket::SHUT_WR) # trigger EOF in server
++        res = c.read
++        assert_match %r{\AHTTP/1\.1 400 }, res
++      end
++    }
++  end
++
++  def test_big_chunks
++    nr_out = 3
++    buf = 'big' # 3 bytes is bigger than 2!
++    config = { :InputBufferSize => 2 }.freeze
++    total = 0
++    all = ''
++    TestWEBrick.start_httpserver(config){|server, addr, port, log|
++      server.mount_proc('/', ->(req, res) {
++        err = []
++        ret = req.body do |chunk|
++          n = chunk.bytesize
++          n > config[:InputBufferSize] and err << "#{n} > :InputBufferSize"
++          total += n
++          all << chunk
++        end
++        ret.nil? or err << 'req.body should return nil'
++        (buf * nr_out) == all or err << 'input body does not match expected'
++        res.header['connection'] = 'close'
++        res.body = err.join("\n")
++      })
++      TCPSocket.open(addr, port) do |c|
++        c.write("POST / HTTP/1.1\r\nHost: example.com\r\n" \
++                "Transfer-Encoding: chunked\r\n\r\n")
++        chunk = "#{buf.bytesize.to_s(16)}\r\n#{buf}\r\n"
++        nr_out.times { c.write(chunk) }
++        c.write("0\r\n\r\n")
++        head, body = c.read.split("\r\n\r\n")
++        assert_match %r{\AHTTP/1\.1 200 OK}, head
++        assert_nil body
++      end
++    }
++  end
+ end

--- a/resources/patches/ruby_219/cve-2018-8778.patch
+++ b/resources/patches/ruby_219/cve-2018-8778.patch
@@ -1,0 +1,45 @@
+From 4cd92d7b13002161a3452a0fe278b877901a8859 Mon Sep 17 00:00:00 2001
+From: usa <usa@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Wed, 28 Mar 2018 14:38:39 +0000
+Subject: [PATCH] merge revision(s) 62992:
+
+	pack.c: fix underflow
+
+	* pack.c (pack_unpack_internal): get rid of underflow.
+	  https://hackerone.com/reports/298246
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/branches/ruby_2_2@63019 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+---
+ ChangeLog              | 7 +++++++
+ pack.c                 | 2 +-
+ test/ruby/test_pack.rb | 3 +++
+ version.h              | 2 +-
+ 4 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/pack.c b/pack.c
+index a5982c9c0f..2b51d83923 100644
+--- a/pack.c
++++ b/pack.c
+@@ -1203,7 +1203,7 @@ pack_unpack(VALUE str, VALUE fmt)
+ 	else if (ISDIGIT(*p)) {
+ 	    errno = 0;
+ 	    len = STRTOUL(p, (char**)&p, 10);
+-	    if (errno) {
++	    if (len < 0 || errno) {
+ 		rb_raise(rb_eRangeError, "pack length too big");
+ 	    }
+ 	}
+diff --git a/test/ruby/test_pack.rb b/test/ruby/test_pack.rb
+index 18f71e4a2f..449911198c 100644
+--- a/test/ruby/test_pack.rb
++++ b/test/ruby/test_pack.rb
+@@ -480,6 +480,9 @@ class TestPack < Test::Unit::TestCase
+     assert_equal([1, 2], "\x01\x00\x00\x02".unpack("C@3C"))
+     assert_equal([nil], "\x00".unpack("@1C")) # is it OK?
+     assert_raise(ArgumentError) { "\x00".unpack("@2C") }
++
++    pos = (1 << [nil].pack("p").bytesize * 8) - 100 # -100
++    assert_raise(RangeError) {"0123456789".unpack("@#{pos}C10")}
+   end
+ 
+   def test_pack_unpack_percent

--- a/resources/patches/ruby_219/cve-2018-8779.patch
+++ b/resources/patches/ruby_219/cve-2018-8779.patch
@@ -1,0 +1,87 @@
+# Patch backported to ruby 2.1.9 by Scott Garman <scott.garman@puppet.com>
+From 47165eed264d357e78e27371cfef20d5c2bde5d9 Mon Sep 17 00:00:00 2001
+From: usa <usa@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Wed, 28 Mar 2018 14:36:23 +0000
+Subject: [PATCH] merge revision(s) 62991,63000:
+
+	unixsocket.c: check NUL bytes
+
+	* ext/socket/unixsocket.c (rsock_init_unixsock): check NUL bytes.
+	  https://hackerone.com/reports/302997
+
+	unixsocket.c: abstract namespace
+
+	* ext/socket/unixsocket.c (unixsock_path_value): fix r62991 for
+	  Linux abstract namespace.
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/branches/ruby_2_2@63018 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+---
+ ChangeLog                | 12 ++++++++++++
+ ext/socket/unixsocket.c  | 24 +++++++++++++++++++++++-
+ test/socket/test_unix.rb | 10 ++++++++++
+ version.h                |  2 +-
+ 4 files changed, 46 insertions(+), 2 deletions(-)
+
+diff --git a/ext/socket/unixsocket.c b/ext/socket/unixsocket.c
+index 9a4c2cfc01..d80526c322 100644
+--- a/ext/socket/unixsocket.c
++++ b/ext/socket/unixsocket.c
+@@ -25,6 +25,28 @@ unixsock_connect_internal(VALUE a)
+ 			        arg->sockaddrlen, 0);
+ }
+ 
++static VALUE
++unixsock_path_value(VALUE path)
++{
++#ifdef __linux__
++#define TO_STR_FOR_LINUX_ABSTRACT_NAMESPACE 0
++
++    VALUE name = path;
++#if TO_STR_FOR_LINUX_ABSTRACT_NAMESPACE
++    const int isstr = !NIL_P(name = rb_check_string_type(name));
++#else
++    const int isstr = RB_TYPE_P(name, T_STRING);
++#endif
++    if (isstr) {
++        if (RSTRING_LEN(name) == 0 || RSTRING_PTR(name)[0] == '\0') {
++            rb_check_safe_obj(name);
++            return name;             /* ignore encoding */
++        }
++    }
++#endif
++    return rb_get_path(path);
++}
++
+ VALUE
+ rsock_init_unixsock(VALUE sock, VALUE path, int server)
+ {
+@@ -55,7 +55,7 @@
+     int fd, status;
+     rb_io_t *fptr;
+ 
+-    SafeStringValue(path);
++    path = unixsock_path_value(path);
+     fd = rsock_socket(AF_UNIX, SOCK_STREAM, 0);
+     if (fd < 0) {
+ 	rsock_sys_fail_path("socket(2)", path);
+diff --git a/test/socket/test_unix.rb b/test/socket/test_unix.rb
+index 866c83906e..004c5693ae 100644
+--- a/test/socket/test_unix.rb
++++ b/test/socket/test_unix.rb
+@@ -253,6 +253,16 @@
+     File.unlink path if path && File.socket?(path)
+   end
+ 
++  def test_open_nul_byte
++    tmpfile = Tempfile.new("s")
++    path = tmpfile.path
++    tmpfile.close(true)
++    assert_raise(ArgumentError) {UNIXServer.open(path+"\0")}
++    assert_raise(ArgumentError) {UNIXSocket.open(path+"\0")}
++  ensure
++    File.unlink path if path && File.socket?(path)
++  end
++
+   def test_addr
+     bound_unix_socket(UNIXServer) {|serv, path|
+       c = UNIXSocket.new(path)

--- a/resources/patches/ruby_219/cve-2018-8780.patch
+++ b/resources/patches/ruby_219/cve-2018-8780.patch
@@ -1,0 +1,97 @@
+From 143eb22f1877815dd802f7928959c5f93d4c7bb3 Mon Sep 17 00:00:00 2001
+From: usa <usa@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Wed, 28 Mar 2018 14:27:51 +0000
+Subject: [PATCH] merge revision(s) 62989:
+
+	dir.c: check NUL bytes
+
+	* dir.c (GlobPathValue): should be used in rb_push_glob only.
+	  other methods should use FilePathValue.
+	  https://hackerone.com/reports/302338
+
+	* dir.c (rb_push_glob): expand GlobPathValue
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/branches/ruby_2_2@63015 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+---
+ ChangeLog             | 10 ++++++++++
+ dir.c                 | 22 ++++++++++------------
+ test/ruby/test_dir.rb |  4 ++++
+ version.h             | 10 +++++-----
+ 4 files changed, 29 insertions(+), 17 deletions(-)
+
+diff --git a/dir.c b/dir.c
+index 84413c6b57..ac5e9934fb 100644
+--- a/dir.c
++++ b/dir.c
+@@ -423,15 +423,6 @@ static const rb_data_type_t dir_data_type = {
+ 
+ static VALUE dir_close(VALUE);
+ 
+-#define GlobPathValue(str, safe) \
+-    /* can contain null bytes as separators */	\
+-    (!RB_TYPE_P((str), T_STRING) ?		\
+-     (void)FilePathValue(str) :			\
+-     (void)(check_safe_glob((str), (safe)),		\
+-      check_glob_encoding(str), (str)))
+-#define check_safe_glob(str, safe) ((safe) ? rb_check_safe_obj(str) : (void)0)
+-#define check_glob_encoding(str) rb_enc_check((str), rb_enc_from_encoding(rb_usascii_encoding()))
+-
+ static VALUE
+ dir_s_alloc(VALUE klass)
+ {
+@@ -480,7 +471,7 @@ dir_initialize(int argc, VALUE *argv, VALUE dir)
+ 	}
+     }
+ 
+-    GlobPathValue(dirname, FALSE);
++    FilePathValue(dirname);
+     orig = rb_str_dup_frozen(dirname);
+     dirname = rb_str_encode_ospath(dirname);
+     dirname = rb_str_dup_frozen(dirname);
+@@ -2050,7 +2041,14 @@ rb_push_glob(VALUE str, int flags) /* '\0' is delimiter */
+     long offset = 0;
+     VALUE ary;
+ 
+-    GlobPathValue(str, TRUE);
++    /* can contain null bytes as separators */
++    if (!RB_TYPE_P((str), T_STRING)) {
++	FilePathValue(str);
++    }
++    else {
++	rb_check_safe_obj(str);
++	rb_enc_check(str, rb_enc_from_encoding(rb_usascii_encoding()));
++    }
+     ary = rb_ary_new();
+ 
+     while (offset < RSTRING_LEN(str)) {
+@@ -2080,7 +2078,7 @@ dir_globs(long argc, const VALUE *argv, int flags)
+     for (i = 0; i < argc; ++i) {
+ 	int status;
+ 	VALUE str = argv[i];
+-	GlobPathValue(str, TRUE);
++	FilePathValue(str);
+ 	status = push_glob(ary, str, flags);
+ 	if (status) GLOB_JUMP_TAG(status);
+     }
+diff --git a/test/ruby/test_dir.rb b/test/ruby/test_dir.rb
+index 85fdd16dfd..cac9330640 100644
+--- a/test/ruby/test_dir.rb
++++ b/test/ruby/test_dir.rb
+@@ -149,6 +149,9 @@ class TestDir < Test::Unit::TestCase
+ 
+     assert_equal([File.join(@root, "a")], Dir.glob(File.join(@root, 'a\\')))
+     assert_equal((?a..?f).map {|f| File.join(@root, f) }.sort, Dir.glob(File.join(@root, '[abc/def]')).sort)
++    assert_raise(ArgumentError) {
++      Dir.glob([[@root, File.join(@root, "*")].join("\0")])
++    }
+   end
+ 
+   def test_glob_recursive
+@@ -179,6 +182,7 @@ class TestDir < Test::Unit::TestCase
+ 
+   def test_foreach
+     assert_equal(Dir.foreach(@root).to_a.sort, %w(. ..) + (?a..?z).to_a)
++    assert_raise(ArgumentError) {Dir.foreach(@root+"\0").to_a}
+   end
+ 
+   def test_dir_enc


### PR DESCRIPTION
These patches resolve a number of Ruby CVEs announced in March 2018.