### PR TITLE
(maint) Remove curl from Bolt

### DIFF
--- a/configs/components/runtime-bolt.rb
+++ b/configs/components/runtime-bolt.rb
@@ -6,11 +6,9 @@ component "runtime-bolt" do |pkg, settings, platform|
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"
     pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll", "#{settings[:bindir]}/libgcc_s_#{lib_type}-1.dll"
 
-    # zlib is a runtime dependency of libcurl
+    # zlib, gdbm, yaml-cpp and iconv are all runtime dependancies of ruby, and their libraries need to exist inside our vendored ruby
     pkg.build_requires "pl-zlib-#{platform.architecture}"
     pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:ruby_bindir]}/zlib1.dll"
-
-    # gdbm, yaml-cpp and iconv are all runtime dependancies of ruby, and their libraries need to exist inside our vendored ruby
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{settings[:ruby_bindir]}/libgdbm-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -103,11 +103,8 @@ project 'bolt-runtime' do |proj|
   # What to build?
   # --------------
 
-  # Common deps
-  proj.component "openssl"
-  proj.component "curl"
-
   # Ruby and deps
+  proj.component "openssl"
   proj.component "runtime-bolt"
   proj.component "puppet-ca-bundle"
   proj.component "ruby-#{proj.ruby_version}"


### PR DESCRIPTION
Ruby and Bolt have no need for libcurl, it was included accidentally.
Remove it.