### PR TITLE
(BOLT-427) Fix for 32-bit systems

### DIFF
--- a/configs/components/runtime-bolt.rb
+++ b/configs/components/runtime-bolt.rb
@@ -18,7 +18,8 @@ component "runtime-bolt" do |pkg, settings, platform|
     # Do nothing
 
   else # Linux and Solaris systems
-    libdir = "/opt/pl-build-tools/lib64"
+    libbase = platform.architecture =~ /64/ ? 'lib64' : 'lib'
+    libdir = "/opt/pl-build-tools/#{libbase}"
     pkg.add_source "file://resources/files/runtime/runtime.sh"
     pkg.install do
       "bash runtime.sh #{libdir}"


### PR DESCRIPTION
Copying runtime files failed on 32-bit systems because the directory
doesn't exist. Use the right directory.