### PR TITLE
(PA-1925) Add hiera-eyaml rubygem

### DIFF
--- a/configs/components/rubygem-hiera-eyaml.rb
+++ b/configs/components/rubygem-hiera-eyaml.rb
@@ -1,0 +1,19 @@
+component "rubygem-hiera-eyaml" do |pkg, settings, platform|
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+
+  pkg.version '2.1.0'
+  pkg.md5sum 'cd7d348b6edbf8344e3091e015ce5767'
+  pkg.url "https://rubygems.org/downloads/hiera-eyaml-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/hiera-eyaml-#{pkg.get_version}.gem"
+
+  pkg.build_requires "rubygem-highline"
+  pkg.build_requires "rubygem-trollop"
+
+  # Overwrite the base rubygem's default GEM_HOME with the vendor gem directory
+  # shared by puppet and puppetserver:
+  pkg.environment "GEM_HOME", settings[:puppet_gem_vendor_dir]
+
+  pkg.install do
+    ["#{settings[:gem_install]} hiera-eyaml-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/components/rubygem-highline.rb
+++ b/configs/components/rubygem-highline.rb
@@ -1,0 +1,16 @@
+component "rubygem-highline" do |pkg, settings, platform|
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+
+  pkg.version '1.6.21'
+  pkg.md5sum 'fc79952fb9d12957d828da76b94e4ecb'
+  pkg.url "https://rubygems.org/downloads/highline-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/highline-#{pkg.get_version}.gem"
+
+  # Overwrite the base rubygem's default GEM_HOME with the vendor gem directory
+  # shared by puppet and puppetserver:
+  pkg.environment "GEM_HOME", settings[:puppet_gem_vendor_dir]
+
+  pkg.install do
+    ["#{settings[:gem_install]} highline-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/components/rubygem-trollop.rb
+++ b/configs/components/rubygem-trollop.rb
@@ -1,0 +1,16 @@
+component "rubygem-trollop" do |pkg, settings, platform|
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+
+  pkg.version '2.1.2'
+  pkg.md5sum '6ff25bc7f93497c107b67f9ae5bf73b4'
+  pkg.url "https://rubygems.org/downloads/trollop-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/trollop-#{pkg.get_version}.gem"
+
+  # Overwrite the base rubygem's default GEM_HOME with the vendor gem directory
+  # shared by puppet and puppetserver:
+  pkg.environment "GEM_HOME", settings[:puppet_gem_vendor_dir]
+
+  pkg.install do
+    ["#{settings[:gem_install]} trollop-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -8,4 +8,7 @@ project 'agent-runtime-5.5.x' do |proj|
   # Dependencies specific to the 5.5.x branch
   proj.component 'rubygem-gettext-setup'
   proj.component 'rubygem-multi_json'
+  proj.component 'rubygem-highline'
+  proj.component 'rubygem-trollop'
+  proj.component 'rubygem-hiera-eyaml'
 end

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -7,4 +7,7 @@ project 'agent-runtime-master' do |proj|
 
   # Dependencies specific to the master branch
   proj.component 'rubygem-multi_json'
+  proj.component 'rubygem-highline'
+  proj.component 'rubygem-trollop'
+  proj.component 'rubygem-hiera-eyaml'
 end


### PR DESCRIPTION
This commit also adds highline and trollop, both of which are
dependencies of hiera-eyaml.