### PR TITLE
 (maint) Migrate Hocon gem to shared vendor dir

### DIFF
--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -8,6 +8,10 @@ component "rubygem-hocon" do |pkg, settings, platform|
 
   install_steps = ["#{settings[:gem_install]} hocon-#{pkg.get_version}.gem"]
 
+  # Overwrite the base rubygem's default GEM_HOME with the vendor gem directory
+  # shared by puppet and puppetserver. Fall-back to gem_home for other projects.
+  pkg.environment "GEM_HOME", (settings[:puppet_gem_vendor_dir] || settings[:gem_home])
+
   if platform.is_macos?
     # The unicode characters in one of the hocon gem's spec files will make tar
     # blow up when extracting the runtime tarball on MacOS if not using unicode.

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -5,6 +5,9 @@ project 'agent-runtime-5.5.x' do |proj|
   # Common agent settings:
   instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
 
+  # Directory for gems shared by puppet and puppetserver
+  proj.setting(:puppet_gem_vendor_dir, File.join(proj.libdir, "ruby", "vendor_gems"))
+
   # Dependencies specific to the 5.5.x branch
   proj.component 'rubygem-gettext-setup'
   proj.component 'rubygem-multi_json'

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -5,6 +5,9 @@ project 'agent-runtime-master' do |proj|
   # Common agent settings:
   instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
 
+  # Directory for gems shared by puppet and puppetserver
+  proj.setting(:puppet_gem_vendor_dir, File.join(proj.libdir, "ruby", "vendor_gems"))
+
   # Dependencies specific to the master branch
   proj.component 'rubygem-multi_json'
   proj.component 'rubygem-highline'

--- a/configs/projects/base-agent-runtime.rb
+++ b/configs/projects/base-agent-runtime.rb
@@ -81,8 +81,6 @@ raise "Couldn't find a :ruby_version setting in the project file" unless proj.ru
 ruby_base_version = proj.ruby_version.gsub(/(\d)\.(\d)\.(\d)/, '\1.\2.0')
 proj.setting(:gem_home, File.join(proj.libdir, 'ruby', 'gems', ruby_base_version))
 proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
-# Directory for gems shared by puppet and puppetserver
-proj.setting(:puppet_gem_vendor_dir, File.join(proj.libdir, "ruby", "vendor_gems"))
 
 # Cross-compiled Linux platforms
 platform_triple = "ppc64le-redhat-linux" if platform.architecture == "ppc64le"


### PR DESCRIPTION
This moves the hocon gem to the shared vendor dir, where it can be picked up by the resource_api gem.

It also makes sure that older versions of the agent do not try to set the shared gem vendor directory path, so that gem components don't have to check the agent version to know where they should be installed.