### PR TITLE
(PA-1983) Separate shared agent components & settings

### DIFF
--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -1,0 +1,60 @@
+# This "project" is designed to be shared by all puppet-agent projects
+# See configs/projects/agent-runtime-<branchname>.rb
+unless defined?(proj)
+  warn('These are components shared by all puppet-agent projects; They cannot be built as a standalone project.')
+  warn('Please choose one of the other puppet-agent projects instead.')
+  exit 1
+end
+
+########
+# Common components for all versions of puppet-agent
+########
+
+# Common components required by all agent branches
+proj.component 'runtime-agent'
+
+unless proj.settings[:system_openssl]
+  proj.component 'openssl'
+end
+
+proj.component 'curl'
+proj.component 'puppet-ca-bundle'
+proj.component "ruby-#{proj.ruby_version}"
+proj.component 'augeas' unless platform.is_windows?
+proj.component 'libxml2' unless platform.is_windows?
+proj.component 'libxslt' unless platform.is_windows?
+proj.component 'ruby-augeas' unless platform.is_windows?
+proj.component 'ruby-shadow' unless platform.is_aix? || platform.is_windows?
+proj.component 'ruby-stomp'
+# We only build ruby-selinux for EL 5-7
+if platform.name =~ /^el-(5|6|7)-.*/ || platform.is_fedora?
+  proj.component 'ruby-selinux'
+end
+
+# libedit is used instead of readline on these platforms
+if platform.is_aix? || platform.is_solaris?
+  proj.component 'libedit'
+end
+
+proj.component 'rubygem-hocon'
+proj.component 'rubygem-deep-merge'
+proj.component 'rubygem-net-ssh'
+proj.component 'rubygem-semantic_puppet'
+proj.component 'rubygem-text'
+proj.component 'rubygem-locale'
+proj.component 'rubygem-gettext'
+proj.component 'rubygem-fast_gettext'
+
+if platform.is_windows?
+  proj.component 'rubygem-ffi'
+  proj.component 'rubygem-win32-dir'
+  proj.component 'rubygem-win32-process'
+  proj.component 'rubygem-win32-security'
+  proj.component 'rubygem-win32-service'
+  proj.component 'rubygem-win32-eventlog'
+end
+
+if platform.is_windows? || platform.is_solaris?
+  proj.component 'rubygem-minitar'
+end
+

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -1,13 +1,18 @@
-# This project is designed for reuse by branch-specific agent-runtime configs;
+# This "project" is designed to be shared by all puppet-agent projects
 # See configs/projects/agent-runtime-<branchname>.rb
 unless defined?(proj)
-  warn('This is the base project for the puppet-agent runtime.')
+  warn('These are base settings shared by all puppet-agent projects; They cannot be built as a standalone project.')
   warn('Please choose one of the other puppet-agent projects instead.')
   exit 1
 end
 
-# Used in component configurations to conditionally include dependencies
+# Use sparingly in component configurations to conditionally include
+# dependencies that should not be in other projects that use puppet-runtime
 proj.setting(:runtime_project, 'agent')
+
+########
+# Common build settings for all versions of puppet-agent
+########
 
 proj.generate_archives true
 proj.generate_packages false
@@ -21,10 +26,6 @@ proj.version_from_git
 proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
 proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
 
-
-########
-# Common build settings for all versions of puppet-agent
-########
 
 if platform.is_windows?
   proj.setting(:company_id, "PuppetLabs")
@@ -183,13 +184,6 @@ end
 
 proj.timeout 7200 if platform.is_windows?
 
-########
-# Common components for all versions of puppet-agent
-########
-
-# Common components required by all agent branches
-proj.component 'runtime-agent'
-
 # Most branches of puppet-agent use these openssl flags in addition to the defaults in configs/components/openssl.rb -
 # Individual projects can override these if necessary.
 proj.setting(:openssl_extra_configure_flags, [
@@ -205,49 +199,6 @@ proj.setting(:openssl_extra_configure_flags, [
 if platform.name =~ /^redhatfips-7-.*/
   # Link against the system openssl instead of our vendored version:
   proj.setting(:system_openssl, true)
-else
-  proj.component 'openssl'
-end
-
-proj.component 'curl'
-proj.component 'puppet-ca-bundle'
-proj.component "ruby-#{proj.ruby_version}"
-proj.component 'augeas' unless platform.is_windows?
-proj.component 'libxml2' unless platform.is_windows?
-proj.component 'libxslt' unless platform.is_windows?
-proj.component 'ruby-augeas' unless platform.is_windows?
-proj.component 'ruby-shadow' unless platform.is_aix? || platform.is_windows?
-proj.component 'ruby-stomp'
-# We only build ruby-selinux for EL 5-7
-if platform.name =~ /^el-(5|6|7)-.*/ || platform.is_fedora?
-  proj.component 'ruby-selinux'
-end
-
-# libedit is used instead of readline on these platforms
-if platform.is_aix? || platform.is_solaris?
-  proj.component 'libedit'
-end
-
-proj.component 'rubygem-deep-merge'
-proj.component 'rubygem-net-ssh'
-proj.component 'rubygem-hocon'
-proj.component 'rubygem-semantic_puppet'
-proj.component 'rubygem-text'
-proj.component 'rubygem-locale'
-proj.component 'rubygem-gettext'
-proj.component 'rubygem-fast_gettext'
-
-if platform.is_windows?
-  proj.component 'rubygem-ffi'
-  proj.component 'rubygem-win32-dir'
-  proj.component 'rubygem-win32-process'
-  proj.component 'rubygem-win32-security'
-  proj.component 'rubygem-win32-service'
-  proj.component 'rubygem-win32-eventlog'
-end
-
-if platform.is_windows? || platform.is_solaris?
-  proj.component 'rubygem-minitar'
 end
 
 # Commmon platform-specific settings for all agent branches:

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -1,12 +1,24 @@
 project 'agent-runtime-1.10.x' do |proj|
+  # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.1.9'
   proj.setting :augeas_version, '1.4.0'
   proj.setting :rubygem_fast_gettext_version, '1.1.0'
   proj.setting :rubygem_ffi_version, '1.9.14'
   proj.setting :ruby_stomp_version, '1.3.3'
 
-  # The 1.10.x agent's openssl configure flags are slightly different from higher versions:
-  # These flags are applied in addition to the defaults in configs/component/openssl.rb.
+  ########
+  # Load shared agent settings
+  ########
+
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-settings.rb'))
+
+  ########
+  # Settings specific to the 1.10.x branch
+  ########
+
+  # The 1.10.x agent's openssl configure flags are slightly different from
+  # higher versions: These flags are applied in addition to the defaults in
+  # configs/component/openssl.rb.
   proj.setting(:openssl_extra_configure_flags, [
     'enable-cms',
     'enable-seed',
@@ -16,9 +28,15 @@ project 'agent-runtime-1.10.x' do |proj|
     'no-ssl2-method',
   ])
 
-  # Common agent settings:
-  instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
+  ########
+  # Load shared agent components
+  ########
 
-  # Dependencies specific to the 1.10.x branch
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-components.rb'))
+
+  ########
+  # Components specific to the 1.10.x branch
+  ########
+
   proj.component 'rubygem-gettext-setup'
 end

--- a/configs/projects/agent-runtime-5.3.x.rb
+++ b/configs/projects/agent-runtime-5.3.x.rb
@@ -1,10 +1,23 @@
 project 'agent-runtime-5.3.x' do |proj|
+  # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.4.4'
   proj.setting :augeas_version, '1.8.1'
 
-  # Common agent settings:
-  instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
+  ########
+  # Load shared agent settings
+  ########
 
-  # Dependencies specific to the 5.3.x branch
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-settings.rb'))
+
+  ########
+  # Load shared agent components
+  ########
+
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-components.rb'))
+
+  ########
+  # Components specific to the 5.3.x branch
+  ########
+
   proj.component 'rubygem-gettext-setup'
 end

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -1,14 +1,31 @@
 project 'agent-runtime-5.5.x' do |proj|
+  # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.4.4'
   proj.setting :augeas_version, '1.10.1'
 
-  # Common agent settings:
-  instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
+  ########
+  # Load shared agent settings
+  ########
+
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-settings.rb'))
+
+  ########
+  # Settings specific to the 5.5.x branch
+  ########
 
   # Directory for gems shared by puppet and puppetserver
   proj.setting(:puppet_gem_vendor_dir, File.join(proj.libdir, "ruby", "vendor_gems"))
 
-  # Dependencies specific to the 5.5.x branch
+  ########
+  # Load shared agent components
+  ########
+
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-components.rb'))
+
+  ########
+  # Components specific to the 5.5.x branch
+  ########
+
   proj.component 'rubygem-gettext-setup'
   proj.component 'rubygem-multi_json'
   proj.component 'rubygem-highline'

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -1,14 +1,31 @@
 project 'agent-runtime-master' do |proj|
+  # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.4.4'
   proj.setting :augeas_version, '1.10.1'
 
-  # Common agent settings:
-  instance_eval File.read(File.join(File.dirname(__FILE__), 'base-agent-runtime.rb'))
+  ########
+  # Load shared agent settings
+  ########
+
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-settings.rb'))
+
+  ########
+  # Settings specific to the master branch
+  ########
 
   # Directory for gems shared by puppet and puppetserver
   proj.setting(:puppet_gem_vendor_dir, File.join(proj.libdir, "ruby", "vendor_gems"))
 
-  # Dependencies specific to the master branch
+  ########
+  # Load shared agent components
+  ########
+
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-components.rb'))
+
+  ########
+  # Components specific to the master branch
+  ########
+
   proj.component 'rubygem-multi_json'
   proj.component 'rubygem-highline'
   proj.component 'rubygem-trollop'


### PR DESCRIPTION
Managing special cases for agent runtimes while sharing a single common
base project provided too many opportunities for error in the order of
inclusion for settings and components. This commit separates the shared
configuration into two separate files - one each for settings and
components - so that settings can be customized in agent projects before
loading the shared components.

Fixes the gem home for rubygem-hocon, which wasn't correctly set on
5.5.x and master due to this problem.