### PR TITLE
(PA-1918) Remove ruby-stomp as a component from agent-runtime-master

### DIFF
--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -25,7 +25,6 @@ proj.component 'libxml2' unless platform.is_windows?
 proj.component 'libxslt' unless platform.is_windows?
 proj.component 'ruby-augeas' unless platform.is_windows?
 proj.component 'ruby-shadow' unless platform.is_aix? || platform.is_windows?
-proj.component 'ruby-stomp'
 # We only build ruby-selinux for EL 5-7
 if platform.name =~ /^el-(5|6|7)-.*/ || platform.is_fedora?
   proj.component 'ruby-selinux'

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -39,4 +39,5 @@ project 'agent-runtime-1.10.x' do |proj|
   ########
 
   proj.component 'rubygem-gettext-setup'
+  proj.component 'ruby-stomp'
 end

--- a/configs/projects/agent-runtime-5.3.x.rb
+++ b/configs/projects/agent-runtime-5.3.x.rb
@@ -20,4 +20,5 @@ project 'agent-runtime-5.3.x' do |proj|
   ########
 
   proj.component 'rubygem-gettext-setup'
+  proj.component 'ruby-stomp'
 end

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -31,4 +31,5 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'rubygem-highline'
   proj.component 'rubygem-trollop'
   proj.component 'rubygem-hiera-eyaml'
+  proj.component 'ruby-stomp'
 end


### PR DESCRIPTION
We are deprecating mcollective from the puppet-agent for Platform
6. This includes deprecating ruby-stomp, because mcollective is the
only agent component that depends on it. Thus, work in this commit
removes ruby-stomp as a shared agent component, only declaring it as
a component in the 1.10.x, 5.3.x, and 5.5.x agent branches.