### PR TITLE
(maint) Use alternate mirror for Solaris 10 builds

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -70,10 +70,7 @@ elsif platform.is_solaris?
   pkg.build_requires "runtime-#{settings[:runtime_project]}"
   pkg.build_requires 'libedit'
   if platform.architecture == 'sparc'
-    if platform.os_version == '10'
-      # ruby1.8 is not new enough to successfully cross-compile ruby 2.1.x (it doesn't understand the --disable-gems flag)
-      pkg.build_requires 'ruby20'
-    elsif platform.os_version == '11'
+    if platform.os_version == '11'
       pkg.build_requires 'pl-ruby'
     end
   end

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -87,7 +87,6 @@ component 'augeas' do |pkg, settings, platform|
     pkg.build_requires 'libedit'
     pkg.build_requires "runtime-#{settings[:runtime_project]}"
     if platform.os_version == "10"
-      pkg.build_requires 'pkgconfig'
       pkg.environment "PKG_CONFIG_PATH", "/opt/csw/lib/pkgconfig"
       pkg.environment "PKG_CONFIG", "/opt/csw/bin/pkg-config"
     else

--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -35,14 +35,14 @@ conflict=nocheck
 action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
-  pkgadd -n -a /var/tmp/vanagon-noask -G -d http://get.opencsw.org/now all;
-  /opt/csw/bin/pkgutil -y -i rsync gmake pkgconfig ggrep;
+  echo "mirror=http://www.gtlib.gatech.edu/pub/OpenCSW/testing" > /var/tmp/vanagon-pkgutil.conf;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;
   # RE-5250 - Solaris 10 templates are awful
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
-  /opt/csw/bin/pkgutil -l ruby | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
+  /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
 
   # Install base build dependencies

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -39,14 +39,14 @@ conflict=nocheck
 action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
-  pkgadd -n -a /var/tmp/vanagon-noask -G -d http://get.opencsw.org/now all;
-  /opt/csw/bin/pkgutil -y -i rsync gmake pkgconfig ggrep;
+  echo "mirror=http://www.gtlib.gatech.edu/pub/OpenCSW/testing" > /var/tmp/vanagon-pkgutil.conf;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep ruby20;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
   # RE-5250 - Solaris 10 templates are awful
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
-  /opt/csw/bin/pkgutil -l ruby | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
+  /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
 
   # Install base build dependencies


### PR DESCRIPTION
While opencsw.org's mirror service is unavailable, use alternate
mirror for Solaris 10 dependency packages.