### PR TITLE
(PA-1874) Add Ubuntu 18.04 platform definition

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -79,16 +79,15 @@ component 'openssl' do |pkg, settings, platform|
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_macos?
     pkg.build_requires 'makedepend'
-  elsif platform.is_linux?
-    unless platform.is_fedora? && platform.os_version.delete('f').to_i >= 26
-      # TODO: pdk had this for all linux platforms, but agent didn't - necessary?
-      pkg.build_requires 'pl-binutils'
-    end
-    pkg.build_requires 'pl-gcc'
+  elsif platform.is_cross_compiled_linux?
+    pkg.build_requires "pl-binutils-#{platform.architecture}"
+    pkg.build_requires "pl-gcc-#{platform.architecture}"
 
     if platform.name =~ /debian-8-arm/
       pkg.build_requires 'xutils-dev'
     end
+  elsif platform.is_linux?
+    pkg.build_requires 'pl-gcc'
   end
 
   #########

--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -1,0 +1,12 @@
+platform "ubuntu-18.04-amd64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "bionic"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-1804-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
+end


### PR DESCRIPTION
Adds a platform configuration for Ubuntu 18.04, bionic beaver. I also pared down the cases where pl-binutils is required for linux platforms in openssl, since it's not really necessary for newer platforms like this one (we're trying not to have to ship a pl-binutils for 18.04). Will unblock pending green builds on affected platforms.