### PR TITLE
(maint) switch solaris to primary opencsw mirrors

### DIFF
--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -35,7 +35,7 @@ conflict=nocheck
 action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
-  echo "mirror=http://www.gtlib.gatech.edu/pub/OpenCSW/testing" > /var/tmp/vanagon-pkgutil.conf;
+  echo "mirror=http://mirror.opencsw.org/opencsw/testing" > /var/tmp/vanagon-pkgutil.conf;
   /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -39,7 +39,7 @@ conflict=nocheck
 action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
-  echo "mirror=http://www.gtlib.gatech.edu/pub/OpenCSW/testing" > /var/tmp/vanagon-pkgutil.conf;
+  echo "mirror=http://mirror.opencsw.org/opencsw/testing" > /var/tmp/vanagon-pkgutil.conf;
   /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep ruby20;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;


### PR DESCRIPTION
It looks like the GA Tech secondary mirrors have gone offline.
Switching back to the primaries.