### PR TITLE
(PA-2018) Add httpclient gem

### DIFF
--- a/configs/components/rubygem-httpclient.rb
+++ b/configs/components/rubygem-httpclient.rb
@@ -1,0 +1,12 @@
+component "rubygem-httpclient" do |pkg, settings, platform|
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+
+  pkg.version "2.8.3"
+  pkg.md5sum "0d43c4680b56547b942caa0d9fefa8ec"
+  pkg.url "https://rubygems.org/downloads/httpclient-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/httpclient-#{pkg.get_version}.gem"
+
+  pkg.install do
+    ["#{settings[:gem_install]} httpclient-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -30,4 +30,5 @@ project 'agent-runtime-master' do |proj|
   proj.component 'rubygem-highline'
   proj.component 'rubygem-trollop'
   proj.component 'rubygem-hiera-eyaml'
+  proj.component 'rubygem-httpclient'
 end


### PR DESCRIPTION
This commit adds the HTTPClient gem, version 2.8.3, for use with the new
Puppet REST client.