### PR TITLE
(PA-1995) Publish yaml settings on build for all projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def vanagon_location_for(place)
 end
 
 gem 'artifactory'
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.15.5')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.15.10')
 gem 'packaging', :github => 'puppetlabs/packaging', branch: '1.0.x'
 gem 'rake', '~> 12.0'
 

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -6,6 +6,9 @@ unless defined?(proj)
   exit 1
 end
 
+# Export the settings for the current project and platform as yaml during builds
+proj.publish_yaml_settings
+
 # Use sparingly in component configurations to conditionally include
 # dependencies that should not be in other projects that use puppet-runtime
 proj.setting(:runtime_project, 'agent')

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -131,5 +131,8 @@ project 'bolt-runtime' do |proj|
   # What to include in package?
   proj.directory proj.prefix
 
+  # Export the settings for the current project and platform as yaml during builds
+  proj.publish_yaml_settings
+
   proj.timeout 7200 if platform.is_windows?
 end

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -185,6 +185,9 @@ project 'pdk-runtime' do |proj|
   proj.directory proj.prefix
   proj.directory proj.link_bindir unless platform.is_windows?
 
+  # Export the settings for the current project and platform as yaml during builds
+  proj.publish_yaml_settings
+
   proj.timeout 7200 if platform.is_windows?
 
   # Here we rewrite public http urls to use our internal source host instead.


### PR DESCRIPTION
Writes a yaml file containing the settings used during a build (plus a sha1sum for that file) to the output directory alongside other artifacts.

This is intended to make building downstream projects locally with development builds of puppet-runtime easier. It depends on https://github.com/puppetlabs/vanagon/pull/566, so I'm marking this `do not merge` for now.