### PR TITLE
(maint) notice when pkgutil can't find a source mirror

### DIFF
--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -36,7 +36,7 @@ action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=http://mirror.opencsw.org/opencsw/testing" > /var/tmp/vanagon-pkgutil.conf;
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep || exit 1;
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -40,7 +40,7 @@ action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=http://mirror.opencsw.org/opencsw/testing" > /var/tmp/vanagon-pkgutil.conf;
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep ruby20;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep ruby20 || exit 1;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;


### PR DESCRIPTION
Solaris10 uses the Vanagon provision_with capability to run a moderately
complex shell fragment to provision things. The issue is that if given a
series of shell commands to execute, only the exit status of the last command
run is noticed when determining success.

We have had issues with the mirror server for Solaris10 dropping off the
net, causing build fails. This change provides the ability to fail when
pkgutil fails to find the mirror, which means the build will fail much faster.