### PR TITLE
(maint) Add semantic_puppet to bolt-runtime

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -109,12 +109,13 @@ project 'bolt-runtime' do |proj|
   proj.component "puppet-ca-bundle"
   proj.component "ruby-#{proj.ruby_version}"
 
-  # Possibly optional Puppet dependencies
+  # Puppet dependencies
   proj.component 'rubygem-deep-merge'
   proj.component 'rubygem-text'
   proj.component 'rubygem-locale'
   proj.component 'rubygem-gettext'
   proj.component 'rubygem-fast_gettext'
+  proj.component 'rubygem-semantic_puppet'
 
   # Core dependencies
   proj.component 'rubygem-ffi'


### PR DESCRIPTION
This is now a dependency of the vendored puppet in bolt, so we need to
explicitly pull it in.