### PR TITLE
(maint) Unpin FFI gem in Agent 1.10.x

### DIFF
--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -3,7 +3,6 @@ project 'agent-runtime-1.10.x' do |proj|
   proj.setting :ruby_version, '2.1.9'
   proj.setting :augeas_version, '1.4.0'
   proj.setting :rubygem_fast_gettext_version, '1.1.0'
-  proj.setting :rubygem_ffi_version, '1.9.14'
   proj.setting :ruby_stomp_version, '1.3.3'
 
   ########


### PR DESCRIPTION
The FFI gem was pinned due to some compatibility issues in intervening
versions. Since the latest version appears to work in newer agent
releases, we are unpinning it here in 1.10.x