### PR TITLE
(PA-2055) Add vendored yaml-cpp and boost

### DIFF
--- a/configs/components/_base-ruby-augeas.rb
+++ b/configs/components/_base-ruby-augeas.rb
@@ -19,7 +19,7 @@ pkg.build_requires "augeas"
 
 pkg.environment "PATH", "$(PATH):/opt/pl-build-tools/bin:/usr/local/bin:/opt/csw/bin:/usr/ccs/bin:/usr/sfw/bin"
 if platform.is_aix?
-  pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm"
+  # We still use pl-gcc for AIX 7.1
   pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
   pkg.environment "RUBY", host_ruby
   pkg.environment "LDFLAGS", " -brtl #{settings[:ldflags]}"

--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -34,7 +34,8 @@ end
 #############
 
 if platform.is_aix?
-  pkg.environment 'CC', '/opt/pl-build-tools/bin/gcc'
+  # We still use pl-gcc for AIX 7.1
+  pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
   pkg.environment 'LDFLAGS', "#{settings[:ldflags]} -Wl,-bmaxdata:0x80000000"
 elsif platform.is_solaris?
   pkg.environment 'PATH', "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
@@ -85,8 +86,7 @@ elsif platform.is_windows?
 end
 
 if platform.is_aix?
-  pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/zlib-1.2.3-4.aix5.2.ppc.rpm"
-  pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/zlib-devel-1.2.3-4.aix5.2.ppc.rpm"
+  # Do nothing here, all package requirements in the platform file
 elsif platform.is_deb?
   pkg.build_requires 'zlib1g-dev'
 elsif platform.is_rpm?

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -41,12 +41,12 @@ component 'augeas' do |pkg, settings, platform|
   pkg.environment "PKG_CONFIG_PATH", "#{settings[:libdir]}/pkgconfig"
 
   if platform.is_aix?
-    pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm"
+        # We still use pl-gcc for AIX 7.1
     pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
+    pkg.build_requires "runtime-#{settings[:runtime_project]}"
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", "-I#{settings[:includedir]}"
     pkg.build_requires 'libedit'
-    pkg.build_requires "runtime-#{settings[:runtime_project]}"
   end
 
   if platform.is_rpm? && !platform.is_aix?

--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -1,0 +1,165 @@
+component "boost" do |pkg, settings, platform|
+  # Source-Related Metadata
+  pkg.version "1.67.0"
+  pkg.md5sum "4850fceb3f2222ee011d4f3ea304d2cb"
+  # Apparently boost doesn't use dots to version they use underscores....arg
+  pkg.url "http://downloads.sourceforge.net/project/boost/boost/#{pkg.get_version}/boost_#{pkg.get_version.gsub('.','_')}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/boost_#{pkg.get_version.gsub('.','_')}.tar.gz"
+
+  if platform.is_solaris?
+    pkg.apply_patch 'resources/patches/boost/0001-fix-build-for-solaris.patch'
+    pkg.apply_patch 'resources/patches/boost/Fix-bootstrap-build-for-solaris-10.patch'
+  end
+
+  if platform.is_solaris? || platform.is_aix?
+    pkg.apply_patch 'resources/patches/boost/solaris-aix-boost-filesystem-unique-path.patch'
+  end
+
+  if platform.is_cisco_wrlinux?
+    pkg.apply_patch 'resources/patches/boost/no-fionbio.patch'
+  end
+
+  if platform.architecture == "aarch64"
+    #pkg.apply_patch 'resources/patches/boost/boost-aarch64-flags.patch'
+  end
+
+  # Package Dependency Metadata
+
+  # Build Requirements
+  if platform.is_cross_compiled_linux?
+    pkg.build_requires "pl-binutils-#{platform.architecture}"
+    pkg.build_requires "pl-gcc-#{platform.architecture}"
+  elsif platform.is_aix?
+    #
+  elsif platform.is_solaris?
+    #
+  elsif platform.is_windows?
+    #
+  elsif platform.is_macos?
+    #
+  else
+    pkg.build_requires "pl-gcc"
+    # Various Linux platforms
+    case platform.name
+    when /el|fedora/
+      pkg.build_requires 'bzip2-devel'
+      pkg.build_requires 'zlib-devel'
+    when /sles-(11|12)/
+      pkg.build_requires 'libbz2-devel'
+      pkg.build_requires 'zlib-devel'
+    when /debian|ubuntu|Cumulus/i
+      pkg.build_requires 'libbz2-dev'
+      pkg.build_requires 'zlib1g-dev'
+    end
+  end
+
+  # Build-time Configuration
+  boost_libs = [ 'atomic', 'chrono', 'container', 'date_time', 'exception', 'filesystem', 'graph', 'graph_parallel', 'iostreams', 'locale', 'log', 'math', 'program_options', 'random', 'regex', 'serialization', 'signals', 'system', 'test', 'thread', 'timer', 'wave' ]
+
+  cflags = "-fPIC -std=c99"
+  cxxflags = "-std=c++11 -fPIC"
+
+  # These are all places where windows differs from *nix. These are the default *nix settings.
+  toolset = 'gcc'
+  with_toolset = "--with-toolset=#{toolset}"
+  boost_dir = ""
+  bootstrap_suffix = ".sh"
+  execute = "./"
+  addtl_flags = ""
+  gpp = "#{settings[:tools_root]}/bin/g++"
+  b2flags = ""
+
+  if platform.is_cross_compiled_linux?
+    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
+    linkflags = "-Wl,-rpath=#{settings[:libdir]}"
+    gpp = "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-g++"
+  elsif platform.is_macos?
+    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
+    linkflags = ""
+    gpp = "clang++"
+    toolset = 'gcc'
+    with_toolset = "--with-toolset=clang"
+  elsif platform.is_solaris?
+    pkg.environment 'PATH', '/opt/pl-build-tools/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:/usr/csw/bin'
+    linkflags = "-Wl,-rpath=#{settings[:libdir]},-L/opt/pl-build-tools/#{settings[:platform_triple]}/lib,-L/usr/lib"
+    b2flags = "define=_XOPEN_SOURCE=600"
+    if platform.architecture == "sparc"
+      b2flags = "#{b2flags} instruction-set=v9"
+    end
+    gpp = "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-g++"
+  elsif platform.is_windows?
+    arch = platform.architecture == "x64" ? "64" : "32"
+    pkg.environment "PATH" => "C:/tools/mingw#{arch}/bin:$$PATH"
+    pkg.environment "CYGWIN" => "nodosfilewarning"
+
+    # bootstrap.bat does not take the `--with-toolset` flag
+    toolset = "gcc"
+    with_toolset = ""
+    # boost is installed with this extra subdirectory on windows
+    boost_dir = "boost-1_67"
+    # we do not need to reference the .bat suffix when calling the bootstrap script
+    bootstrap_suffix = ""
+    # we need to make sure we link against non-cygwin libraries
+    execute = "cmd.exe /c "
+
+    gpp = "C:/tools/mingw#{arch}/bin/g++"
+
+    # We don't have iconv available on windows yet
+    addtl_flags = "boost.locale.iconv=off"
+  elsif platform.is_aix?
+    pkg.environment "PATH" => "/opt/freeware/bin:/opt/pl-build-tools/bin:$(PATH)"
+    linkflags = "-Wl,-L#{settings[:libdir]},-L/opt/pl-build-tools/lib"
+  else
+    pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
+    linkflags = "-Wl,-rpath=#{settings[:libdir]},-rpath=#{settings[:libdir]}64"
+  end
+
+  # Set user-config.jam
+  if platform.is_windows?
+    userconfigjam = %Q{using gcc : : #{gpp} ;}
+  else
+    if platform.architecture =~ /arm|s390x/ || platform.is_aix?
+      userconfigjam = %Q{using gcc : 5.2.0 : #{gpp} : <linkflags>"#{linkflags}" <cflags>"#{cflags}" <cxxflags>"#{cxxflags}" ;}
+    else
+      userconfigjam = %Q{using gcc : 4.8.2 : #{gpp} : <linkflags>"#{linkflags}" <cflags>"#{cflags}" <cxxflags>"#{cxxflags}" ;}
+    end
+  end
+
+  # Build Commands
+
+  # On some platforms, we have multiple means of specifying paths. Sometimes, we need to use either one
+  # form or another. `special_prefix` allows us to do this. i.e., on windows, we need to have the
+  # windows specific path (C:/), whereas for everything else, we can default to the drive root currently
+  # in use (/cygdrive/c). This has to do with how the program is built, where it is expecting to find
+  # libraries and binaries, and how it tries to find them.
+  pkg.build do
+    [
+      %Q{echo '#{userconfigjam}' > ~/user-config.jam},
+      "cd tools/build",
+      "#{execute}bootstrap#{bootstrap_suffix} #{with_toolset}",
+      "./b2 install -d+2 \
+      --prefix=#{settings[:prefix]} \
+      toolset=#{toolset} \
+      #{b2flags} \
+      --debug-configuration"
+    ]
+  end
+
+  pkg.install do
+    [ "#{settings[:prefix]}/bin/b2 \
+    -d+2 \
+    toolset=#{toolset} \
+    #{b2flags} \
+    --debug-configuration \
+    --build-dir=. \
+    --prefix=#{settings[:prefix]} \
+    #{boost_libs.map {|lib| "--with-#{lib}"}.join(" ")} \
+    #{addtl_flags} \
+    install",
+    "chmod 0644 #{settings[:includedir]}/#{boost_dir}/boost/graph/vf2_sub_graph_iso.hpp",
+    "chmod 0644 #{settings[:includedir]}/#{boost_dir}/boost/thread/v2/shared_mutex.hpp",
+    # Remove the user-config.jam from the build user's home directory:
+    "rm -f ~/user-config.jam"
+    ]
+  end
+end

--- a/configs/components/libedit.rb
+++ b/configs/components/libedit.rb
@@ -9,7 +9,6 @@ component 'libedit' do |pkg, settings, platform|
   if platform.is_solaris?
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
   elsif platform.is_aix?
-    pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gawk-3.1.3-1.aix5.1.ppc.rpm"
     pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
     pkg.environment "LDFLAGS", settings[:ldflags]
   end

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -36,8 +36,7 @@ component 'openssl' do |pkg, settings, platform|
                'linux64-s390x'
              end
   elsif platform.is_aix?
-    pkg.environment 'CC', '/opt/pl-build-tools/bin/gcc'
-
+    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
     cflags = '$${CFLAGS} -static-libgcc'
     target = 'aix-gcc'
   elsif platform.is_solaris?
@@ -76,7 +75,7 @@ component 'openssl' do |pkg, settings, platform|
     pkg.build_requires 'xorg-x11-util-devel' if platform.name =~ /^sles/
     pkg.build_requires 'xutils-dev' if platform.is_deb?
   elsif platform.is_aix?
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
+    # Do nothing, aix requirements are included in platform file
   elsif platform.is_macos?
     pkg.build_requires 'makedepend'
   elsif platform.is_cross_compiled_linux?

--- a/configs/components/ruby-2.4.4.rb
+++ b/configs/components/ruby-2.4.4.rb
@@ -88,8 +88,6 @@ component 'ruby-2.4.4' do |pkg, settings, platform|
   ####################
 
   if platform.is_aix?
-    pkg.build_requires 'http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/zlib-1.2.3-4.aix5.2.ppc.rpm'
-
     # TODO: Remove this once PA-1607 is resolved.
     pkg.build_requires 'http://pl-build-tools.delivery.puppetlabs.net/aix/5.3/ppc/pl-autoconf-2.69-1.aix5.3.ppc.rpm'
   end
@@ -156,6 +154,7 @@ component 'ruby-2.4.4' do |pkg, settings, platform|
   ###########
 
   # TODO: Remove this once PA-1607 is resolved.
+  # TODO: Can we use native autoconf? The dependencies seemed a little too extensive
   pkg.configure { ["/opt/pl-build-tools/bin/autoconf"] } if platform.is_aix?
 
   # Here we set --enable-bundled-libyaml to ensure that the libyaml included in

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -15,7 +15,6 @@ component "runtime-agent" do |pkg, settings, platform|
     pkg.build_requires "pl-binutils-#{platform.architecture}"
     pkg.build_requires "pl-gcc-#{platform.architecture}"
   elsif platform.is_aix?
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
     libdir = "/opt/pl-build-tools/lib/gcc/powerpc-ibm-aix#{platform.os_version}.0.0/5.2.0/"
   elsif platform.is_windows?
     # We only need zlib because curl is dynamically linking against zlib

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -1,0 +1,96 @@
+component "yaml-cpp" do |pkg, settings, platform|
+  pkg.url "git://github.com/jbeder/yaml-cpp.git"
+  pkg.ref "refs/tags/yaml-cpp-0.6.2"
+
+  # Build Requirements
+  if platform.is_cross_compiled_linux?
+    pkg.build_requires "pl-binutils-#{platform.architecture}"
+    pkg.build_requires "pl-gcc-#{platform.architecture}"
+    pkg.build_requires "pl-cmake"
+  elsif platform.is_solaris?
+    if platform.os_version == "10"
+      pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-cmake-3.2.3-15.i386.pkg.gz"
+    elsif platform.os_version == "11"
+      pkg.build_requires "pl-binutils-#{platform.architecture}"
+      pkg.build_requires "pl-gcc-#{platform.architecture}"
+      pkg.build_requires "pl-cmake"
+    end
+  elsif platform.is_windows?
+    pkg.build_requires "pl-toolchain-#{platform.architecture}"
+    pkg.build_requires "cmake"
+  elsif platform.is_macos?
+    pkg.build_requires "cmake"
+  elsif platform.is_aix?
+    # Moved to platform def, do nothing
+  else
+    pkg.build_requires "pl-gcc"
+    pkg.build_requires "make"
+    pkg.build_requires "pl-cmake"
+  end
+
+  # Build-time Configuration
+  cmake = "#{settings[:tools_root]}/bin/cmake"
+  cmake_toolchain_file = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+  make = 'make'
+  mkdir = 'mkdir'
+
+  if platform.is_cross_compiled_linux?
+    # We're using the x86_64 version of cmake
+    cmake = "/opt/pl-build-tools/bin/cmake"
+    cmake_toolchain_file = "-DPL_TOOLS_ROOT=/opt/freeware -DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
+  elsif platform.is_solaris?
+    if platform.os_version == "11"
+      make = '/usr/bin/gmake'
+    end
+    # We always use the i386 build of cmake, even on sparc
+    cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
+    cmake_toolchain_file = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
+    pkg.environment "PATH" => "$$PATH:/opt/csw/bin"
+  elsif platform.is_macos?
+    cmake_toolchain_file = ""
+    cmake = "/usr/local/bin/cmake"
+  elsif platform.is_windows?
+    make = "#{settings[:gcc_bindir]}/mingw32-make"
+    mkdir = '/usr/bin/mkdir'
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "CYGWIN", settings[:cygwin]
+    cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
+    cmake_toolchain_file = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+  end
+
+  # Build Commands
+  pkg.build do
+    [ "#{mkdir} build-shared",
+      "cd build-shared",
+      "#{cmake} \
+      #{cmake_toolchain_file} \
+      -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
+      -DCMAKE_VERBOSE_MAKEFILE=ON \
+      -DYAML_CPP_BUILD_TOOLS=0 \
+      -DYAML_CPP_BUILD_TESTS=0 \
+      -DBUILD_SHARED_LIBS=ON \
+      .. ",
+      "#{make} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1)",
+      "cd ../",
+      "#{mkdir} build-static",
+      "cd build-static",
+      "#{cmake} \
+      #{cmake_toolchain_file} \
+      -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
+      -DCMAKE_VERBOSE_MAKEFILE=ON \
+      -DYAML_CPP_BUILD_TOOLS=0 \
+      -DYAML_CPP_BUILD_TESTS=0 \
+      -DBUILD_SHARED_LIBS=OFF \
+      ..",
+      "#{make} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"
+    ]
+  end
+
+  pkg.install do
+    [ "cd build-shared",
+      "#{make} install",
+      "cd ../build-static",
+      "#{make} install"
+    ]
+  end
+end

--- a/configs/platforms/aix-6.1-ppc.rb
+++ b/configs/platforms/aix-6.1-ppc.rb
@@ -6,8 +6,29 @@ platform "aix-6.1-ppc" do |plat|
   plat.rpmbuild "/usr/bin/rpm"
   plat.patch "/opt/freeware/bin/patch"
 
-  # Basic vanagon operations require mktemp, rsync, coreutils, make, tar and sed so leave this in there
-  plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
+  os_version = 6.1
+  # We can't rely on yum, and rpm can't download over https on AIX, so curl packages before installing them
+  # Order matters here - there is no automatic dependency resolution
+  packages = [
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_oss4aix.org/RPMS/mktemp/mktemp-1.7-1.aix5.1.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/rsync/rsync-3.0.6-1.aix5.3.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/coreutils/coreutils-5.2.1-2.aix5.1.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/sed/sed-4.1.1-1.aix5.1.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/make/make-3.80-1.aix5.1.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/tar/tar-1.22-1.aix6.1.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/pkg-config/pkg-config-0.19-6.aix5.2.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/zlib/zlib-1.2.3-4.aix5.2.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/zlib/zlib-devel-1.2.3-4.aix5.2.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/gawk/gawk-3.1.3-1.aix5.1.ppc.rpm",
+    "http://pl-build-tools.delivery.puppetlabs.net/aix/#{os_version}/ppc/pl-gcc-5.2.0-11.aix#{os_version}.ppc.rpm",
+    "http://pl-build-tools.delivery.puppetlabs.net/aix/#{os_version}/ppc/pl-cmake-3.2.3-2.aix#{os_version}.ppc.rpm",
+  ]
+
+  packages.each do |uri|
+    name = uri.split("/").last
+    plat.provision_with("curl -O #{uri} > /dev/null")
+    plat.provision_with("rpm -Uvh --replacepkgs --nodeps #{name}")
+  end
 
   # We use --force with rpm because the pl-gettext and pl-autoconf
   # packages conflict with a charset.alias file.

--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -6,8 +6,29 @@ platform "aix-7.1-ppc" do |plat|
   plat.rpmbuild "/usr/bin/rpm"
   plat.patch "/opt/freeware/bin/patch"
 
-  # Basic vanagon operations require mktemp, rsync, coreutils, tar and sed so leave this in there
-  plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
+  os_version = 7.1
+  # We can't rely on yum, and rpm can't download over https on AIX, so curl packages before installing them
+  # Order matters here - there is no automatic dependency resolution
+  packages = [
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_oss4aix.org/RPMS/mktemp/mktemp-1.7-1.aix5.1.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/rsync/rsync-3.0.6-1.aix5.3.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/coreutils/coreutils-5.2.1-2.aix5.1.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/sed/sed-4.1.1-1.aix5.1.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/make/make-3.80-1.aix5.1.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/tar/tar-1.22-1.aix6.1.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/pkg-config/pkg-config-0.19-6.aix5.2.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/zlib/zlib-1.2.3-4.aix5.2.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/zlib/zlib-devel-1.2.3-4.aix5.2.ppc.rpm",
+    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/gawk/gawk-3.1.3-1.aix5.1.ppc.rpm",
+    "http://pl-build-tools.delivery.puppetlabs.net/aix/#{os_version}/ppc/pl-gcc-5.2.0-11.aix#{os_version}.ppc.rpm",
+    "http://pl-build-tools.delivery.puppetlabs.net/aix/#{os_version}/ppc/pl-cmake-3.2.3-2.aix#{os_version}.ppc.rpm",
+  ]
+
+  packages.each do |uri|
+    name = uri.split("/").last
+    plat.provision_with("curl -O #{uri} > /dev/null")
+    plat.provision_with("rpm -Uvh --replacepkgs --nodeps #{name}")
+  end
 
   # We use --force with rpm because the pl-gettext and pl-autoconf
   # packages conflict with a charset.alias file.

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -23,6 +23,7 @@ proj.component "ruby-#{proj.ruby_version}"
 proj.component 'augeas' unless platform.is_windows?
 proj.component 'libxml2' unless platform.is_windows?
 proj.component 'libxslt' unless platform.is_windows?
+
 proj.component 'ruby-augeas' unless platform.is_windows?
 proj.component 'ruby-shadow' unless platform.is_aix? || platform.is_windows?
 # We only build ruby-selinux for EL 5-7
@@ -31,7 +32,7 @@ if platform.name =~ /^el-(5|6|7)-.*/ || platform.is_fedora?
 end
 
 # libedit is used instead of readline on these platforms
-if platform.is_aix? || platform.is_solaris?
+if platform.is_solaris? || platform.is_aix?
   proj.component 'libedit'
 end
 
@@ -56,4 +57,3 @@ end
 if platform.is_windows? || platform.is_solaris?
   proj.component 'rubygem-minitar'
 end
-

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -158,6 +158,8 @@ if platform.is_windows?
   proj.setting(:cflags, "#{proj.cppflags}")
   proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir} -Wl,--nxcompat -Wl,--dynamicbase")
   proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
+else
+  proj.setting(:tools_root, "/opt/pl-build-tools")
 end
 
 if platform.is_macos?

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -31,4 +31,6 @@ project 'agent-runtime-master' do |proj|
   proj.component 'rubygem-trollop'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'rubygem-httpclient'
+  proj.component 'boost'
+  proj.component 'yaml-cpp'
 end

--- a/resources/patches/boost/0001-fix-build-for-solaris.patch
+++ b/resources/patches/boost/0001-fix-build-for-solaris.patch
@@ -1,0 +1,25 @@
+From f00dd485bf3793e17614637a085c3950c7ad8dcc Mon Sep 17 00:00:00 2001
+From: "Sean P. McDonald" <sean.mcdonald@puppetlabs.com>
+Date: Tue, 15 May 2018 14:02:23 -0700
+Subject: [PATCH] fix-build-for-solaris '
+
+---
+ tools/build/src/engine/build.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/build/src/engine/build.sh b/tools/build/src/engine/build.sh
+index 50a28e83..0a3ec858 100644
+--- a/tools/build/src/engine/build.sh
++++ b/tools/build/src/engine/build.sh
+@@ -132,7 +132,7 @@ case $BOOST_JAM_TOOLSET in
+ 
+     gcc)
+         # Check whether it's MinGW GCC, which has Windows headers and none of POSIX ones.
+-        machine=$(gcc -dumpmachine 2>/dev/null)
++        machine=`gcc -dumpmachine 2>/dev/null`
+         if [ $? -ne 0 ]; then
+             echo "BOOST_JAM_TOOLSET is gcc, but the 'gcc' command cannot be executed."
+             echo "Make sure 'gcc' is in PATH, or use a different toolset."
+-- 
+2.17.0.windows.1
+

--- a/resources/patches/boost/Fix-bootstrap-build-for-solaris-10.patch
+++ b/resources/patches/boost/Fix-bootstrap-build-for-solaris-10.patch
@@ -1,0 +1,47 @@
+From abcf55123b8d1fe9a72113b6bd0f20376a54cba6 Mon Sep 17 00:00:00 2001
+From: "Sean P. McDonald" <sean.mcdonald@puppetlabs.com>
+Date: Wed, 23 May 2018 13:55:53 -0700
+Subject: [PATCH] Fix bootstrap build for solaris 10
+
+The bootstrap build for boost includes building the 'b2' tool to
+eventually build boost. For Solaris, anything requiring the clock_gettime
+header needs to supply the -lrt flag to link against the rt lib. This patch
+supplies the -lrt flag to both the build.sh and the build.jam configurations
+that invoke gcc to build the b2 tool.
+---
+ tools/build/src/engine/build.jam | 8 ++++----
+ tools/build/src/engine/build.sh  | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/tools/build/src/engine/build.jam b/tools/build/src/engine/build.jam
+index a92b70f7..d5784707 100644
+--- a/tools/build/src/engine/build.jam
++++ b/tools/build/src/engine/build.jam
+@@ -215,7 +215,7 @@ toolset darwin cc :  "-o " : -D
+     : -L$(--python-lib[1]) -l$(--python-lib[2]) ;
+ ## GCC 2.x, 3.x, 4.x
+ toolset gcc gcc : "-o " : -D
+-    : -pedantic -fno-strict-aliasing
++    : -pedantic -fno-strict-aliasing -lrt
+     [ opt --release : [ opt --symbols : -g : -s ] -O3 ]
+     [ opt --debug : -g -O0 -fno-inline ]
+     [ opt --profile : -O3 -g -pg ]
+ ## Microsoft Visual C++ .NET 7.x
+ toolset vc7 cl : /Fe /Fe /Fd /Fo : -D
+     : /nologo
+diff --git a/tools/build/src/engine/build.sh b/tools/build/src/engine/build.sh
+index 0a3ec858..12b22eed 100644
+--- a/tools/build/src/engine/build.sh
++++ b/tools/build/src/engine/build.sh
+@@ -330,7 +330,7 @@ if test "${BJAM_UPDATE}" != "update" ; then
+             echo_run ./bootstrap/mkjambase0 jambase.c Jambase
+         fi
+     fi
+-    echo_run ${BOOST_JAM_CC} ${BOOST_JAM_OPT_JAM} ${BJAM_SOURCES}
++    echo_run ${BOOST_JAM_CC} ${BOOST_JAM_OPT_JAM} -lrt ${BJAM_SOURCES}
+ fi
+ if test -x "./bootstrap/jam0" ; then
+     if test "${BJAM_UPDATE}" != "update" ; then
+--
+2.17.0.windows.1
+

--- a/resources/patches/boost/boost-aarch64-flags.patch
+++ b/resources/patches/boost/boost-aarch64-flags.patch
@@ -1,0 +1,17 @@
+# Boost doesn't build with the -m64 option on aarch64, and the compiler
+# builds 64-bit binaries by default, so remove the option.
+Index: boost_1_58_0/tools/build/src/tools/gcc.jam
+===================================================================
+--- boost_1_58_0.orig/tools/build/src/tools/gcc.jam
++++ boost_1_58_0/tools/build/src/tools/gcc.jam
+@@ -457,10 +457,6 @@ rule setup-address-model ( targets * : s
+                 {
+                     option = -m32 ;
+                 }
+-                else if $(model) = 64
+-                {
+-                    option = -m64 ;
+-                }
+             }
+             # For darwin, the model can be 32_64. darwin.jam will handle that
+             # on its own.

--- a/resources/patches/boost/no-fionbio.patch
+++ b/resources/patches/boost/no-fionbio.patch
@@ -1,0 +1,127 @@
+From 2c0439ce3a11433a87321bc943ba0c05234c1c11 Mon Sep 17 00:00:00 2001
+From: Michael Smith <michael.smith@puppet.com>
+Date: Tue, 31 Jan 2017 23:23:53 +0000
+Subject: [PATCH] Patch for Cisco IOS XR
+
+---
+ boost/asio/detail/impl/descriptor_ops.ipp | 15 ---------------
+ boost/asio/detail/impl/socket_ops.ipp     | 15 ++-------------
+ 2 files changed, 2 insertions(+), 28 deletions(-)
+
+diff --git a/boost/asio/detail/impl/descriptor_ops.ipp b/boost/asio/detail/impl/descriptor_ops.ipp
+index d700b22..1d0b73e 100644
+--- a/boost/asio/detail/impl/descriptor_ops.ipp
++++ b/boost/asio/detail/impl/descriptor_ops.ipp
+@@ -58,14 +58,9 @@ int close(int d, state_type& state, boost::system::error_code& ec)
+       // current OS where this behaviour is seen, Windows, says that the socket
+       // remains open. Therefore we'll put the descriptor back into blocking
+       // mode and have another attempt at closing it.
+-#if defined(__SYMBIAN32__)
+       int flags = ::fcntl(d, F_GETFL, 0);
+       if (flags >= 0)
+         ::fcntl(d, F_SETFL, flags & ~O_NONBLOCK);
+-#else // defined(__SYMBIAN32__)
+-      ioctl_arg_type arg = 0;
+-      ::ioctl(d, FIONBIO, &arg);
+-#endif // defined(__SYMBIAN32__)
+       state &= ~non_blocking;
+ 
+       errno = 0;
+@@ -88,7 +83,6 @@ bool set_user_non_blocking(int d, state_type& state,
+   }
+ 
+   errno = 0;
+-#if defined(__SYMBIAN32__)
+   int result = error_wrapper(::fcntl(d, F_GETFL, 0), ec);
+   if (result >= 0)
+   {
+@@ -96,10 +90,6 @@ bool set_user_non_blocking(int d, state_type& state,
+     int flag = (value ? (result | O_NONBLOCK) : (result & ~O_NONBLOCK));
+     result = error_wrapper(::fcntl(d, F_SETFL, flag), ec);
+   }
+-#else // defined(__SYMBIAN32__)
+-  ioctl_arg_type arg = (value ? 1 : 0);
+-  int result = error_wrapper(::ioctl(d, FIONBIO, &arg), ec);
+-#endif // defined(__SYMBIAN32__)
+ 
+   if (result >= 0)
+   {
+@@ -138,7 +128,6 @@ bool set_internal_non_blocking(int d, state_type& state,
+   }
+ 
+   errno = 0;
+-#if defined(__SYMBIAN32__)
+   int result = error_wrapper(::fcntl(d, F_GETFL, 0), ec);
+   if (result >= 0)
+   {
+@@ -146,10 +135,6 @@ bool set_internal_non_blocking(int d, state_type& state,
+     int flag = (value ? (result | O_NONBLOCK) : (result & ~O_NONBLOCK));
+     result = error_wrapper(::fcntl(d, F_SETFL, flag), ec);
+   }
+-#else // defined(__SYMBIAN32__)
+-  ioctl_arg_type arg = (value ? 1 : 0);
+-  int result = error_wrapper(::ioctl(d, FIONBIO, &arg), ec);
+-#endif // defined(__SYMBIAN32__)
+ 
+   if (result >= 0)
+   {
+diff --git a/boost/asio/detail/impl/socket_ops.ipp b/boost/asio/detail/impl/socket_ops.ipp
+index dc068e0..dcd0a55 100644
+--- a/boost/asio/detail/impl/socket_ops.ipp
++++ b/boost/asio/detail/impl/socket_ops.ipp
+@@ -333,14 +333,9 @@ int close(socket_type s, state_type& state,
+       ioctl_arg_type arg = 0;
+       ::ioctlsocket(s, FIONBIO, &arg);
+ #else // defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
+-# if defined(__SYMBIAN32__)
+       int flags = ::fcntl(s, F_GETFL, 0);
+       if (flags >= 0)
+         ::fcntl(s, F_SETFL, flags & ~O_NONBLOCK);
+-# else // defined(__SYMBIAN32__)
+-      ioctl_arg_type arg = 0;
+-      ::ioctl(s, FIONBIO, &arg);
+-# endif // defined(__SYMBIAN32__)
+ #endif // defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
+       state &= ~non_blocking;
+ 
+@@ -371,7 +366,7 @@ bool set_user_non_blocking(socket_type s,
+ #if defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
+   ioctl_arg_type arg = (value ? 1 : 0);
+   int result = error_wrapper(::ioctlsocket(s, FIONBIO, &arg), ec);
+-#elif defined(__SYMBIAN32__)
++#else
+   int result = error_wrapper(::fcntl(s, F_GETFL, 0), ec);
+   if (result >= 0)
+   {
+@@ -379,9 +374,6 @@ bool set_user_non_blocking(socket_type s,
+     int flag = (value ? (result | O_NONBLOCK) : (result & ~O_NONBLOCK));
+     result = error_wrapper(::fcntl(s, F_SETFL, flag), ec);
+   }
+-#else
+-  ioctl_arg_type arg = (value ? 1 : 0);
+-  int result = error_wrapper(::ioctl(s, FIONBIO, &arg), ec);
+ #endif
+ 
+   if (result >= 0)
+@@ -424,7 +416,7 @@ bool set_internal_non_blocking(socket_type s,
+ #if defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
+   ioctl_arg_type arg = (value ? 1 : 0);
+   int result = error_wrapper(::ioctlsocket(s, FIONBIO, &arg), ec);
+-#elif defined(__SYMBIAN32__)
++#else
+   int result = error_wrapper(::fcntl(s, F_GETFL, 0), ec);
+   if (result >= 0)
+   {
+@@ -432,9 +424,6 @@ bool set_internal_non_blocking(socket_type s,
+     int flag = (value ? (result | O_NONBLOCK) : (result & ~O_NONBLOCK));
+     result = error_wrapper(::fcntl(s, F_SETFL, flag), ec);
+   }
+-#else
+-  ioctl_arg_type arg = (value ? 1 : 0);
+-  int result = error_wrapper(::ioctl(s, FIONBIO, &arg), ec);
+ #endif
+ 
+   if (result >= 0)
+-- 
+2.0.1
+

--- a/resources/patches/boost/solaris-10-boost-build.patch
+++ b/resources/patches/boost/solaris-10-boost-build.patch
@@ -1,0 +1,59 @@
+From bcdb695438374428338f2c4dd7e61b8c8ef63692 Mon Sep 17 00:00:00 2001
+From: Matthaus Owens <matthaus@puppetlabs.com>
+Date: Mon, 10 Aug 2015 12:29:49 -0700
+Subject: [PATCH 1/2] Use sh compliant subshells
+
+In commit d21102f2a1cab05dbf97fcfefd3b37d1b2bbf666, the icc detection
+was updated to use bash style subshells, which breaks on systems that
+have just sh, such as solaris 10. This commit updates the detection to
+use `` style subshells instead of $().
+---
+ tools/build/src/engine/build.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/build/src/engine/build.sh b/tools/build/src/engine/build.sh
+index 612011d..4c19c10 100755
+--- a/tools/build/src/engine/build.sh
++++ b/tools/build/src/engine/build.sh
+@@ -152,9 +152,9 @@ case $BOOST_JAM_TOOLSET in
+     intel-linux)
+     which icc >/dev/null 2>&1
+     if test $? ; then
+-	BOOST_JAM_CC=$(which icc)
++	BOOST_JAM_CC=`which icc`
+ 	echo "Found $BOOST_JAM_CC in environment"
+-	BOOST_JAM_TOOLSET_ROOT=$(echo $BOOST_JAM_CC | sed -e 's/bin.*\/icc//')
++	BOOST_JAM_TOOLSET_ROOT=`echo $BOOST_JAM_CC | sed -e 's/bin.*\/icc//'`
+ 	# probably the most widespread
+ 	ARCH=intel64
+     else
+
+From eefd58579e1e7e777e90166d494e71bea8fc8b2e Mon Sep 17 00:00:00 2001
+From: Matthaus Owens <matthaus@puppetlabs.com>
+Date: Mon, 10 Aug 2015 12:35:17 -0700
+Subject: [PATCH 2/2] Use test_path instead of which
+
+which was used to detect icc, but on some platforms such as solaris 10
+which always returns 0, even when the command is not found on the path.
+This commit updates the invocation to use the test_path function
+instead, which does return non-zero on solaris 10 in the failure case.
+---
+ tools/build/src/engine/build.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/build/src/engine/build.sh b/tools/build/src/engine/build.sh
+index 4c19c10..bf3c695 100755
+--- a/tools/build/src/engine/build.sh
++++ b/tools/build/src/engine/build.sh
+@@ -150,9 +150,9 @@ case $BOOST_JAM_TOOLSET in
+     ;;
+ 
+     intel-linux)
+-    which icc >/dev/null 2>&1
++    test_path icc >/dev/null 2>&1
+     if test $? ; then
+-	BOOST_JAM_CC=`which icc`
++	BOOST_JAM_CC=`test_path icc`
+ 	echo "Found $BOOST_JAM_CC in environment"
+ 	BOOST_JAM_TOOLSET_ROOT=`echo $BOOST_JAM_CC | sed -e 's/bin.*\/icc//'`
+ 	# probably the most widespread

--- a/resources/patches/boost/solaris-aix-boost-filesystem-unique-path.patch
+++ b/resources/patches/boost/solaris-aix-boost-filesystem-unique-path.patch
@@ -1,0 +1,41 @@
+From 0050fa1b46c683d1b727e81dbd484a37c7f2518a Mon Sep 17 00:00:00 2001
+From: Enis Inan <enis.inan@enis.inan-C02M48DGFD57>
+Date: Fri, 8 Sep 2017 10:44:34 -0700
+Subject: [PATCH] Use string instead of wstring in unique_path
+
+When filesystem::unique_path is called on Solaris-10 machines, a
+runtime_error: locale::facet::_S_create_c_locale name not valid
+is thrown - see https://svn.boost.org/trac10/ticket/10205 for
+more details on the reason for this error. This commit applies
+the fix outlined in:
+https://svn.boost.org/trac10/attachment/ticket/10205/10205.patch.
+---
+ libs/filesystem/src/unique_path.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libs/filesystem/src/unique_path.cpp b/libs/filesystem/src/unique_path.cpp
+index 1b05c83..829f6b1 100644
+--- a/libs/filesystem/src/unique_path.cpp
++++ b/libs/filesystem/src/unique_path.cpp
+@@ -130,15 +130,15 @@ namespace boost { namespace filesystem { namespace detail {
+ BOOST_FILESYSTEM_DECL
+ path unique_path(const path& model, system::error_code* ec)
+ {
+-  std::wstring s (model.wstring());  // std::string ng for MBCS encoded POSIX
+-  const wchar_t hex[] = L"0123456789abcdef";
++  std::string s (model.string());  // std::string ng for MBCS encoded POSIX
++  const char hex[] = "0123456789abcdef";
+   char ran[] = "123456789abcdef";  // init to avoid clang static analyzer message
+                                    // see ticket #8954
+   assert(sizeof(ran) == 16);
+   const int max_nibbles = 2 * sizeof(ran);   // 4-bits per nibble
+ 
+   int nibbles_used = max_nibbles;
+-  for(std::wstring::size_type i=0; i < s.size(); ++i)
++  for(std::string::size_type i=0; i < s.size(); ++i)
+   {
+     if (s[i] == L'%')                        // digit request
+     {
+-- 
+2.11.0 (Apple Git-81)
+


### PR DESCRIPTION
Changes to support builds on AIX:
- AIX builds now fetch from artifactory, not OSMIRROR
- AIX builds now only specify build requirements in the platform file