### PR TITLE
(PA 2069) Restore the option to use semantic_puppet 0.1.2 and net-ssh 4.1.0

### DIFF
--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -1,8 +1,19 @@
 component "rubygem-net-ssh" do |pkg, settings, platform|
+  # Projects may define a :rubygem_net_ssh_version setting, or we use 4.2.0 by default:
+  version = settings[:rubygem_net_ssh_version] || '4.2.0'
+  pkg.version version
+
+  case version
+  when "4.2.0"
+    pkg.md5sum "fec5b151d84110b95ec0056017804491"
+  when "4.1.0"
+    pkg.md5sum "6af1ff8c42a07b11203058c9b74cbaef"
+  else
+    raise "rubygem-net-ssh version #{version} has not been configured; Cannot continue."
+  end
+
   instance_eval File.read('configs/components/_base-rubygem.rb')
 
-  pkg.version "4.2.0"
-  pkg.md5sum "fec5b151d84110b95ec0056017804491"
   pkg.url "https://rubygems.org/downloads/net-ssh-#{pkg.get_version}.gem"
   pkg.mirror "#{settings[:buildsources_url]}/net-ssh-#{pkg.get_version}.gem"
 

--- a/configs/components/rubygem-semantic_puppet.rb
+++ b/configs/components/rubygem-semantic_puppet.rb
@@ -1,12 +1,22 @@
 component "rubygem-semantic_puppet" do |pkg, settings, platform|
+  # Projects may define a :rubygem_semantic_puppet_version setting, or we use 1.0.2 by default
+  version = settings[:rubygem_semantic_puppet_version] || '1.0.2'
+  pkg.version version
+
+  case version
+  when '0.1.2'
+    pkg.md5sum '192ae7729997cb5d5364f64b99b13121'
+  when '1.0.2'
+    pkg.md5sum "48f4a060e6004604e2f46716bfeabcdc"
+  else
+    raise "rubygem-semantic_puppet version #{version} has not been configured; Cannot continue."
+  end
   instance_eval File.read('configs/components/_base-rubygem.rb')
 
-  pkg.version "1.0.2"
-  pkg.md5sum "48f4a060e6004604e2f46716bfeabcdc"
   pkg.url "https://rubygems.org/downloads/semantic_puppet-#{pkg.get_version}.gem"
   pkg.mirror "#{settings[:buildsources_url]}/semantic_puppet-#{pkg.get_version}.gem"
   pkg.environment "GEM_HOME", (settings[:puppet_gem_vendor_dir] || settings[:gem_home])
-  
+
   pkg.install do
     ["#{settings[:gem_install]} semantic_puppet-#{pkg.get_version}.gem"]
   end

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -1,9 +1,10 @@
 project 'agent-runtime-1.10.x' do |proj|
   # Set preferred component versions if they differ from defaults:
-  proj.setting :ruby_version, '2.1.9'
   proj.setting :augeas_version, '1.4.0'
-  proj.setting :rubygem_fast_gettext_version, '1.1.0'
   proj.setting :ruby_stomp_version, '1.3.3'
+  proj.setting :ruby_version, '2.1.9'
+  proj.setting :rubygem_fast_gettext_version, '1.1.0'
+  proj.setting :rubygem_semantic_puppet_version, '0.1.2'
 
   ########
   # Load shared agent settings

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -4,6 +4,7 @@ project 'agent-runtime-1.10.x' do |proj|
   proj.setting :ruby_stomp_version, '1.3.3'
   proj.setting :ruby_version, '2.1.9'
   proj.setting :rubygem_fast_gettext_version, '1.1.0'
+  proj.setting :rubygem_net_ssh_version, '4.1.0'
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'
 
   ########

--- a/configs/projects/agent-runtime-5.3.x.rb
+++ b/configs/projects/agent-runtime-5.3.x.rb
@@ -1,7 +1,8 @@
 project 'agent-runtime-5.3.x' do |proj|
   # Set preferred component versions if they differ from defaults:
-  proj.setting :ruby_version, '2.4.4'
   proj.setting :augeas_version, '1.8.1'
+  proj.setting :ruby_version, '2.4.4'
+  proj.setting :rubygem_semantic_puppet_version, '0.1.2'
 
   ########
   # Load shared agent settings

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -1,7 +1,8 @@
 project 'agent-runtime-5.5.x' do |proj|
   # Set preferred component versions if they differ from defaults:
-  proj.setting :ruby_version, '2.4.4'
   proj.setting :augeas_version, '1.10.1'
+  proj.setting :ruby_version, '2.4.4'
+  proj.setting :rubygem_semantic_puppet_version, '0.1.2'
 
   ########
   # Load shared agent settings

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -2,6 +2,7 @@ project 'agent-runtime-5.5.x' do |proj|
   # Set preferred component versions if they differ from defaults:
   proj.setting :augeas_version, '1.10.1'
   proj.setting :ruby_version, '2.4.4'
+  proj.setting :rubygem_net_ssh, '4.1.0'
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'
 
   ########


### PR DESCRIPTION
Fixes a few regressions in gem versions for some branches of puppet-agent:
- `rubygem-semantic_puppet` 0.1.2 should be in puppet-agent 1.10.x, 5.3.x, and 5.5.x -- this matches the versions for the 1.10.12, 5.3.6, and and 5.5.1 agent releases. The updated 1.0.2 version is retained for all other projects.
- `rubygem-net-ssh` 4.1.0 should be in puppet-agent 1.10.x and 5.5.x -- this matches the version for the 1.10.12 and 5.5.1 agent releases. The updated 4.2.0 version is retained for all other projects.