### PR TITLE
(IMAGES-855) Fix nm/libtool build error

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -26,6 +26,7 @@ component 'curl' do |pkg, settings, platform|
     pkg.build_requires "runtime-#{settings[:runtime_project]}"
     pkg.environment "PATH" => "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
     pkg.environment "CYGWIN" => settings[:cygwin]
+    pkg.environment "NM" => "/bin/nm"
   else
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
   end


### PR DESCRIPTION
Cygwin 2.10.0 (soon to be updated vmpooler images) are using Cygwin
2.10.0 which breaks the libcurl build with a libtool "syntax error near
unexpected token `|`" eval error.

Defining NM for this component appears to resolve the issue in the
windows build.