### PR TITLE
(CPR-391) Add alternate Fedora 26, 27 platforms

### DIFF
--- a/configs/platforms/fedora-26-x86_64.rb
+++ b/configs/platforms/fedora-26-x86_64.rb
@@ -1,10 +1,11 @@
-platform "fedora-f27-x86_64" do |plat|
+platform "fedora-26-x86_64" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
   plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
-  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-27.noarch.rpm"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-26.noarch.rpm"
   plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
-  plat.vmpooler_template "fedora-27-x86_64"
+  plat.vmpooler_template "fedora-26-x86_64"
+  plat.dist "fc26"
 end

--- a/configs/platforms/fedora-27-x86_64.rb
+++ b/configs/platforms/fedora-27-x86_64.rb
@@ -1,10 +1,11 @@
-platform "fedora-f26-x86_64" do |plat|
+platform "fedora-27-x86_64" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
   plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
-  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-26.noarch.rpm"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-27.noarch.rpm"
   plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
-  plat.vmpooler_template "fedora-26-x86_64"
+  plat.vmpooler_template "fedora-27-x86_64"
+  plat.dist "fc27"
 end

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -7,6 +7,17 @@ project 'agent-runtime-1.10.x' do |proj|
   proj.setting :rubygem_net_ssh_version, '4.1.0'
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'
 
+  platform = proj.get_platform
+
+  # This modification to the platform definition is for compatibility with
+  # pre-puppet6 puppet-agent packaging. Fedora platforms for PC1 have have an
+  # `f` prefix before their version numbers and do not use an explicit .dist
+  # string.
+  if platform.name =~ /^fedora-([\d]+)/
+    platform.instance_variable_set(:@name, platform.name.sub(/\d+/, 'f\\0'))
+    platform.instance_variable_set(:@dist, nil)
+  end
+
   ########
   # Load shared agent settings
   ########

--- a/configs/projects/agent-runtime-5.3.x.rb
+++ b/configs/projects/agent-runtime-5.3.x.rb
@@ -4,6 +4,17 @@ project 'agent-runtime-5.3.x' do |proj|
   proj.setting :ruby_version, '2.4.4'
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'
 
+  platform = proj.get_platform
+
+  # This modification to the platform definition is for compatibility with
+  # pre-puppet6 puppet-agent packaging. Fedora platforms for puppet5 must have
+  # have an `f` prefix before their version numbers and do not use an explicit
+  # .dist string.
+  if platform.name =~ /^fedora-([\d]+)/
+    platform.instance_variable_set(:@name, platform.name.sub(/\d+/, 'f\\0'))
+    platform.instance_variable_set(:@dist, nil)
+  end
+
   ########
   # Load shared agent settings
   ########

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -5,6 +5,17 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.setting :rubygem_net_ssh, '4.1.0'
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'
 
+  platform = proj.get_platform
+
+  # This modification to the platform definition is for compatibility with
+  # pre-puppet6 puppet-agent packaging. Fedora platforms for puppet5 must have
+  # have an `f` prefix before their version numbers and do not use an explicit
+  # .dist string.
+  if platform.name =~ /^fedora-([\d]+)/
+    platform.instance_variable_set(:@name, platform.name.sub(/\d+/, 'f\\0'))
+    platform.instance_variable_set(:@dist, nil)
+  end
+
   ########
   # Load shared agent settings
   ########


### PR DESCRIPTION
CPR-391 has updated repositories consuming runtime projects so that they
no longer require the `f` prefix on Fedora platform names, but only in
master branches. This change adds new platform definitions for Fedora 26
and 27 without the prefix, but retains the old definitions, since
earlier branches of puppet-agent still require them.