### PR TITLE
(CPR-391) Remove fedora `f` for agent runtime 5.5.x

### DIFF
--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -5,17 +5,6 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.setting :rubygem_net_ssh, '4.1.0'
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'
 
-  platform = proj.get_platform
-
-  # This modification to the platform definition is for compatibility with
-  # pre-puppet6 puppet-agent packaging. Fedora platforms for puppet5 must have
-  # have an `f` prefix before their version numbers and do not use an explicit
-  # .dist string.
-  if platform.name =~ /^fedora-([\d]+)/
-    platform.instance_variable_set(:@name, platform.name.sub(/\d+/, 'f\\0'))
-    platform.instance_variable_set(:@dist, nil)
-  end
-
   ########
   # Load shared agent settings
   ########


### PR DESCRIPTION
We won't be keeping the `f` prefix for the fedora 28 platform in
puppet-agent 5.5.x -- this restricts the workaround in that project to
Fedora 26 and 27 only.