### PR TITLE
(maint) Update default vanagon version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def vanagon_location_for(place)
 end
 
 gem 'artifactory'
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.15.10')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.15.12')
 gem 'packaging', :github => 'puppetlabs/packaging', branch: '1.0.x'
 gem 'rake', '~> 12.0'
 


### PR DESCRIPTION
This update contains a [bugfix](https://github.com/puppetlabs/vanagon/pull/572) for `publish_yaml_settings`