### PR TITLE
(maint) Use yum to install build dependencies on AIX

### DIFF
--- a/configs/components/_base-ruby-augeas.rb
+++ b/configs/components/_base-ruby-augeas.rb
@@ -19,8 +19,7 @@ pkg.build_requires "augeas"
 
 pkg.environment "PATH", "$(PATH):/opt/pl-build-tools/bin:/usr/local/bin:/opt/csw/bin:/usr/ccs/bin:/usr/sfw/bin"
 if platform.is_aix?
-  pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm"
-  pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
+#  pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
   pkg.environment "RUBY", host_ruby
   pkg.environment "LDFLAGS", " -brtl #{settings[:ldflags]}"
 end

--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -34,7 +34,7 @@ end
 #############
 
 if platform.is_aix?
-  pkg.environment 'CC', '/opt/pl-build-tools/bin/gcc'
+#  pkg.environment 'CC', '/opt/pl-build-tools/bin/gcc'
   pkg.environment 'LDFLAGS', "#{settings[:ldflags]} -Wl,-bmaxdata:0x80000000"
 elsif platform.is_solaris?
   pkg.environment 'PATH', "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
@@ -84,10 +84,7 @@ elsif platform.is_windows?
   pkg.build_requires "pl-pdcurses-#{platform.architecture}"
 end
 
-if platform.is_aix?
-  pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/zlib-1.2.3-4.aix5.2.ppc.rpm"
-  pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/zlib-devel-1.2.3-4.aix5.2.ppc.rpm"
-elsif platform.is_deb?
+if platform.is_deb?
   pkg.build_requires 'zlib1g-dev'
 elsif platform.is_rpm?
   pkg.build_requires 'zlib-devel'

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -41,8 +41,7 @@ component 'augeas' do |pkg, settings, platform|
   pkg.environment "PKG_CONFIG_PATH", "#{settings[:libdir]}/pkgconfig"
 
   if platform.is_aix?
-    pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm"
-    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
+#    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", "-I#{settings[:includedir]}"
     pkg.build_requires 'libedit'

--- a/configs/components/libedit.rb
+++ b/configs/components/libedit.rb
@@ -9,8 +9,7 @@ component 'libedit' do |pkg, settings, platform|
   if platform.is_solaris?
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
   elsif platform.is_aix?
-    pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gawk-3.1.3-1.aix5.1.ppc.rpm"
-    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
+#    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
     pkg.environment "LDFLAGS", settings[:ldflags]
   end
 

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -36,7 +36,7 @@ component 'openssl' do |pkg, settings, platform|
                'linux64-s390x'
              end
   elsif platform.is_aix?
-    pkg.environment 'CC', '/opt/pl-build-tools/bin/gcc'
+#    pkg.environment 'CC', '/opt/pl-build-tools/bin/gcc'
 
     cflags = '$${CFLAGS} -static-libgcc'
     target = 'aix-gcc'
@@ -76,7 +76,7 @@ component 'openssl' do |pkg, settings, platform|
     pkg.build_requires 'xorg-x11-util-devel' if platform.name =~ /^sles/
     pkg.build_requires 'xutils-dev' if platform.is_deb?
   elsif platform.is_aix?
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
+#    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_macos?
     pkg.build_requires 'makedepend'
   elsif platform.is_cross_compiled_linux?

--- a/configs/components/ruby-2.4.4.rb
+++ b/configs/components/ruby-2.4.4.rb
@@ -87,13 +87,6 @@ component 'ruby-2.4.4' do |pkg, settings, platform|
   # BUILD REQUIREMENTS
   ####################
 
-  if platform.is_aix?
-    pkg.build_requires 'http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/zlib-1.2.3-4.aix5.2.ppc.rpm'
-
-    # TODO: Remove this once PA-1607 is resolved.
-    pkg.build_requires 'http://pl-build-tools.delivery.puppetlabs.net/aix/5.3/ppc/pl-autoconf-2.69-1.aix5.3.ppc.rpm'
-  end
-
   #########
   # PATCHES
   #########
@@ -169,7 +162,7 @@ component 'ruby-2.4.4' do |pkg, settings, platform|
   ###########
 
   # TODO: Remove this once PA-1607 is resolved.
-  pkg.configure { ["/opt/pl-build-tools/bin/autoconf"] } if platform.is_aix?
+  pkg.configure { ["autoconf"] } if platform.is_aix?
 
   # Here we set --enable-bundled-libyaml to ensure that the libyaml included in
   # ruby is used, even if the build system has a copy of libyaml available

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -14,9 +14,9 @@ component "runtime-agent" do |pkg, settings, platform|
   elsif platform.is_cross_compiled_linux? || platform.name =~ /solaris-11/
     pkg.build_requires "pl-binutils-#{platform.architecture}"
     pkg.build_requires "pl-gcc-#{platform.architecture}"
-  elsif platform.is_aix?
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
-    libdir = "/opt/pl-build-tools/lib/gcc/powerpc-ibm-aix#{platform.os_version}.0.0/5.2.0/"
+#  elsif platform.is_aix?
+#    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
+#    libdir = "/opt/pl-build-tools/lib/gcc/powerpc-ibm-aix#{platform.os_version}.0.0/5.2.0/"
   elsif platform.is_windows?
     # We only need zlib because curl is dynamically linking against zlib
     pkg.build_requires "pl-zlib-#{platform.architecture}"
@@ -37,8 +37,9 @@ component "runtime-agent" do |pkg, settings, platform|
   pkg.environment "PATH", "$(PATH):/opt/csw/gnu" if platform.is_solaris?
 
   if platform.is_aix?
-    pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
-    pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
+#    pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
+#    pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
+# Nothing to see here
   elsif platform.is_macos?
     # Nothing to see here
   elsif platform.is_windows?

--- a/configs/platforms/aix-6.1-ppc.rb
+++ b/configs/platforms/aix-6.1-ppc.rb
@@ -7,14 +7,11 @@ platform "aix-6.1-ppc" do |plat|
   plat.patch "/opt/freeware/bin/patch"
 
   # Basic vanagon operations require mktemp, rsync, coreutils, make, tar and sed so leave this in there
-  plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
-
-  # We use --force with rpm because the pl-gettext and pl-autoconf
-  # packages conflict with a charset.alias file.
-  #
-  # Until we get those packages to not conflict (or we remove the need
-  # for pl-autoconf) we'll need to force the installation
-  #                                         Sean P. McD.
-  plat.install_build_dependencies_with "rpm -Uvh --replacepkgs --force "
+  plat.provision_with "curl http://pl-build-tools.delivery.puppetlabs.net/aix/yum_bootstrap/openssl-1.0.2.1500.tar | tar xvf - && cd openssl-1.0.2.1500 && installp -acXYgd . openssl.base all"
+  plat.provision_with "rpm --rebuilddb && updtvpkg"
+  plat.provision_with "curl http://pl-build-tools.delivery.puppetlabs.net/aix/yum_bootstrap/yum.sh | sh"
+  # plat.provision_with "yum update -y --skip-broken"
+  plat.provision_with "yum install -y rsync coreutils sed make tar pkg-config zlib zlib-devel gawk autoconf gcc glib2"
+  plat.install_build_dependencies_with "yum install -y "
   plat.vmpooler_template "aix-6.1-power"
 end

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -134,6 +134,7 @@ end
 # For AIX, we use the triple to install a better rbconfig
 if platform.is_aix?
   platform_triple = "powerpc-ibm-aix#{platform.os_version}.0.0"
+  platform.mktemp = "/opt/freeware/bin/mktemp --directory"
 end
 
 proj.setting(:platform_triple, platform_triple)


### PR DESCRIPTION
As a POC, update the AIX 6.1 platform config to bootstrap and use yum
to install build dependencies.