### PR TITLE
(maint) Reduce choco build log clutter 

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -13,7 +13,7 @@ platform "windows-2012r2-x64" do |plat|
   # dir for vsdevcmd.bat we create it for safety
   plat.provision_with "mkdir C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress"

--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -16,11 +16,11 @@ platform "windows-2012r2-x64" do |plat|
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug"
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
   # We use cache-location in the following install because msvc has several long paths
   # if we do not update the cache location choco will fail because paths get too long
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\""
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\" --no-progress"
   # The following creates a batch file that will execute the vsdevcmd batch file located within visual studio.
   # We create the following batch file under C:\tools\vsdevcmd.bat so we can avoid using both the %ProgramFiles(x86)%
   # evironment var, as well as any spaces in the path when executing things with cygwin. This makes command execution
@@ -29,7 +29,7 @@ platform "windows-2012r2-x64" do |plat|
   # Note that the unruly \'s in the following string escape the following sequence to literal chars: "\" and then \""
   plat.provision_with "touch C:/tools/vsdevcmd.bat && echo \"\\\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\#{visual_studio_version}\\BuildTools\\Common7\\Tools\\vsdevcmd\\\"\" >> C:/tools/vsdevcmd.bat"
 
-  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y"
+  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress"
 
   plat.make "/usr/bin/make"
   plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -13,7 +13,7 @@ platform "windows-2012r2-x86" do |plat|
   # dir for vsdevcmd.bat we create it for safety
   plat.provision_with "mkdir -p C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86 --no-progress"

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -16,11 +16,11 @@ platform "windows-2012r2-x86" do |plat|
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86"
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86 --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
   # We use cache-location in the following install because msvc has several long paths
   # if we do not update the cache location choco will fail because paths get too long
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\""
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\" --no-progress"
   # The following creates a batch file that will execute the vsdevcmd batch file located within visual studio.
   # We create the following batch file under C:\tools\vsdevcmd.bat so we can avoid using both the %ProgramFiles(x86)%
   # evironment var, as well as any spaces in the path when executing things with cygwin. This makes command execution
@@ -29,7 +29,7 @@ platform "windows-2012r2-x86" do |plat|
   # Note that the unruly /'s in the following string escape the following sequence to literal chars: "\" and then \""
   plat.provision_with "touch C:/tools/vsdevcmd.bat && echo \"\\\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\#{visual_studio_version}\\BuildTools\\Common7\\Tools\\vsdevcmd\\\"\" >> C:/tools/vsdevcmd.bat"
 
-  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y"
+  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress"
 
   plat.make "/usr/bin/make"
   plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"


### PR DESCRIPTION
 - Add the --no-progress switch in an effort to shrink the size of
   build logs. Choco describes the feature as:

   Do Not Show Progress - Do not show download progress percentages.

   Currently, build logs include extremely verbose output when choco
   packages are downloading, adding many lines per each 1% of a given
   package download. This commit removes that extraneous output.