### PR TITLE
(BOLT-720) Include common R10k dependency for bolt-runtime

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -117,6 +117,9 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-fast_gettext'
   proj.component 'rubygem-semantic_puppet'
 
+  # R10k dependencies
+  proj.component 'rubygem-gettext-setup'
+
   # Core dependencies
   proj.component 'rubygem-ffi'
   proj.component 'rubygem-minitar'


### PR DESCRIPTION
Bolt started shipping R10k, which requires several extra gems.
gettext-setup is the only one that's a common dependency here so far.