### PR TITLE
(maint) Move httpclient dependency to bolt-runtime

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -125,6 +125,7 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-minitar'
   proj.component 'rubygem-multi_json'
   proj.component 'rubygem-net-ssh'
+  proj.component 'rubygem-httpclient'
 
   # Core Windows dependencies
   proj.component 'rubygem-win32-dir'


### PR DESCRIPTION
Now that `httpclient` is shipping in puppet-agent's runtime, we can
share the dependency with bolt-runtime.