### PR TITLE
(maint) Exclude logdir and piddir from agent tarballs

### DIFF
--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -219,8 +219,6 @@ proj.directory proj.install_root
 proj.directory proj.prefix
 proj.directory proj.sysconfdir
 proj.directory proj.link_bindir
-proj.directory proj.logdir unless platform.is_windows?
-proj.directory proj.piddir unless platform.is_windows?
 if platform.is_windows? || platform.is_macos?
   proj.directory proj.bindir
 end


### PR DESCRIPTION
These don't contain anything useful and can easily break build systems consuming the runtime tarballs.