### PR TITLE
(PA-2126) Fix typo in ruby version string

### DIFF
--- a/resources/files/ruby_244/rbconfig/rbconfig-244-s390x-linux-gnu.rb
+++ b/resources/files/ruby_244/rbconfig/rbconfig-244-s390x-linux-gnu.rb
@@ -3,7 +3,7 @@
 # changes made to this file will be lost the next time ruby is built.
 
 module RbConfig
-  RUBY_VERSION == "2.4." or
+  RUBY_VERSION == "2.4.4" or
     raise "ruby lib version (2.4.4) doesn't match executable version (#{RUBY_VERSION})"
 
   TOPDIR = File.dirname(__FILE__).chomp!("/lib/ruby/2.4.0/s390x-linux")


### PR DESCRIPTION
Prior to this commit, running any `puppet foo` subcommand on s390x would fail with

`/opt/puppetlabs/puppet/lib/ruby/2.4.0/s390x-linux/rbconfig.rb:7:in <module:RbConfig>:
  ruby lib version (2.4.4) doesn't match executable version (2.4.4) (RuntimeError)`

This fixes the one-character typo and makes the version string match.