### PR TITLE
(BUILD-156) Add runtime support for sles-15-x86_64

### DIFF
--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -20,7 +20,7 @@ component "runtime-agent" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
     pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
-  elsif platform.is_macos?
+  elsif platform.is_macos? or platform.name =~ /sles-15/
     # Nothing to see here
   elsif platform.is_windows?
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"

--- a/configs/platforms/sles-15-x86_64.rb
+++ b/configs/platforms/sles-15-x86_64.rb
@@ -1,0 +1,26 @@
+platform "sles-15-x86_64" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "sysv"
+
+  # Note that SLES 15 runtime builds are using the OS toolchain by default
+  # and do not rely on pl-build-tools packages.
+  packages = [
+    "aaa_base",
+    "autoconf",
+    "automake",
+    "gcc",
+    "java-1_8_0-openjdk-devel",
+    "libbz2-devel",
+    "make",
+    "pkg-config",
+    "cmake",
+    "readline-devel",
+    "rpm-build",
+    "rsync",
+    "zlib-devel"
+  ]
+  plat.provision_with("zypper -n --no-gpg-checks install -y #{packages.join(' ')}")
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
+  plat.vmpooler_template "sles-15-x86_64"
+end


### PR DESCRIPTION
This platform uses the default OS distro toolchain and does not rely on
pl-build-tools, the runtime-agent component is a no-op.