### PR TITLE
PA-2158 - Adding support for el-7-ppc64 puppet-runtime

### DIFF
--- a/configs/components/_base-ruby-augeas.rb
+++ b/configs/components/_base-ruby-augeas.rb
@@ -52,8 +52,11 @@ end
 # properly. This needs to be fixed, but I've spent over a week analyzing
 # every possible angle that could cause this, from rbconfig settings to
 # strace logs, and we need to move forward on this platform.
+#
+# This seems to apply directly to Linux on ppc64 - I've gotten successful builds
+# with this change.
 # FIXME: Scott Garman Jun 2016
-if platform.architecture == "s390x"
+if platform.architecture == "s390x" || platform.architecture == "ppc64"
   pkg.configure do
     [
       "mkdir #{settings[:libdir]}/hide",
@@ -94,7 +97,7 @@ if platform.is_solaris? || platform.is_cross_compiled_linux?
 end
 
 # Undo the gross hack from the configure step
-if platform.architecture == "s390x"
+if platform.architecture == "s390x" || platform.architecture == "ppc64"
   pkg.install do
     [
       "mv #{settings[:libdir]}/hide/* #{settings[:libdir]}/",

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -50,7 +50,7 @@ component 'augeas' do |pkg, settings, platform|
   end
 
   if platform.is_rpm? && !platform.is_aix?
-    if platform.architecture =~ /aarch64|ppc64le|s390x/
+    if platform.architecture =~ /aarch64|ppc64|ppc64le|s390x/
       pkg.build_requires "runtime-#{settings[:runtime_project]}"
       pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
       pkg.environment "CFLAGS", settings[:cflags]

--- a/configs/components/openssl-1.0.2.rb
+++ b/configs/components/openssl-1.0.2.rb
@@ -30,8 +30,10 @@ component 'openssl' do |pkg, settings, platform|
                'linux-aarch64'
              elsif platform.name =~ /debian-8-arm/
                'linux-armv4'
-             elsif platform.architecture =~ /ppc64/
+             elsif platform.architecture =~ /ppc64le/
                'linux-ppc64le'
+             elsif platform.architecture =~ /ppc64/
+               'linux-ppc64'
              elsif platform.architecture == 's390x'
                'linux64-s390x'
              end

--- a/configs/components/openssl-1.1.0.rb
+++ b/configs/components/openssl-1.1.0.rb
@@ -30,8 +30,10 @@ component 'openssl' do |pkg, settings, platform|
                 'linux-aarch64'
               elsif platform.name =~ /debian-8-arm/
                 'linux-armv4'
-              elsif platform.architecture =~ /ppc64/
+              elsif platform.architecture =~ /ppc64le/
                 'linux-ppc64le'
+              elsif platform.architecture =~ /ppc64/
+                'linux-ppc64'
               elsif platform.architecture == 's390x'
                 'linux64-s390x'
               end

--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -136,6 +136,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   target_doubles = {
     'powerpc-ibm-aix6.1.0.0' => 'powerpc-aix6.1.0.0',
     'aarch64-redhat-linux' => 'aarch64-linux',
+    'ppc64-redhat-linux' => 'powerpc64-linux',
     'ppc64le-redhat-linux' => 'powerpc64le-linux',
     'powerpc64le-suse-linux' => 'powerpc64le-linux',
     'powerpc64le-linux-gnu' => 'powerpc64le-linux',
@@ -161,9 +162,10 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   elsif platform.is_cross_compiled? || platform.is_solaris?
     rbconfig_changes["CC"] = "gcc"
     rbconfig_changes["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wno-maybe-uninitialized"
-    if platform.name =~ /el-7-ppc64le/
+    if platform.name =~ /el-7-ppc64/
       # EL 7 on POWER will fail with -Wl,--compress-debug-sections=zlib so this
       # will remove that entry
+      # Matches both endians
       rbconfig_changes["DLDFLAGS"] = "-Wl,-rpath=/opt/puppetlabs/puppet/lib -L/opt/puppetlabs/puppet/lib  -Wl,-rpath,/opt/puppetlabs/puppet/lib"
     elsif platform.name =~ /solaris-10-sparc/
       # ld on solaris 10 sparc does not understand `-Wl,-E` - this is what remains after removing it:

--- a/configs/components/ruby-2.4.4.rb
+++ b/configs/components/ruby-2.4.4.rb
@@ -113,6 +113,7 @@ component 'ruby-2.4.4' do |pkg, settings, platform|
   target_doubles = {
     'powerpc-ibm-aix6.1.0.0' => 'powerpc-aix6.1.0.0',
     'aarch64-redhat-linux' => 'aarch64-linux',
+    'ppc64-redhat-linux' => 'powerpc64-linux',
     'ppc64le-redhat-linux' => 'powerpc64le-linux',
     'powerpc64le-suse-linux' => 'powerpc64le-linux',
     'powerpc64le-linux-gnu' => 'powerpc64le-linux',
@@ -138,9 +139,10 @@ component 'ruby-2.4.4' do |pkg, settings, platform|
   elsif platform.is_cross_compiled? || platform.is_solaris?
     rbconfig_changes["CC"] = "gcc"
     rbconfig_changes["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wno-maybe-uninitialized"
-    if platform.name =~ /el-7-ppc64le/
+    if platform.name =~ /el-7-ppc64/
       # EL 7 on POWER will fail with -Wl,--compress-debug-sections=zlib so this
       # will remove that entry
+      # Matches both endians
       rbconfig_changes["DLDFLAGS"] = "-Wl,-rpath=/opt/puppetlabs/puppet/lib -L/opt/puppetlabs/puppet/lib  -Wl,-rpath,/opt/puppetlabs/puppet/lib"
     elsif platform.name =~ /solaris-10-sparc/
       # ld on solaris 10 sparc does not understand `-Wl,-E` - this is what remains after removing it:

--- a/configs/components/ruby-2.5.1.rb
+++ b/configs/components/ruby-2.5.1.rb
@@ -112,6 +112,7 @@ component 'ruby-2.5.1' do |pkg, settings, platform|
   target_doubles = {
     'powerpc-ibm-aix6.1.0.0' => 'powerpc-aix6.1.0.0',
     'aarch64-redhat-linux' => 'aarch64-linux',
+    'ppc64-redhat-linux' => 'powerpc64-linux',
     'ppc64le-redhat-linux' => 'powerpc64le-linux',
     'powerpc64le-suse-linux' => 'powerpc64le-linux',
     'powerpc64le-linux-gnu' => 'powerpc64le-linux',
@@ -137,9 +138,10 @@ component 'ruby-2.5.1' do |pkg, settings, platform|
   elsif platform.is_cross_compiled? || platform.is_solaris?
     rbconfig_changes["CC"] = "gcc"
     rbconfig_changes["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wno-maybe-uninitialized"
-    if platform.name =~ /el-7-ppc64le/
+    if platform.name =~ /el-7-ppc64/
       # EL 7 on POWER will fail with -Wl,--compress-debug-sections=zlib so this
       # will remove that entry
+      # Matches both endians
       rbconfig_changes["DLDFLAGS"] = "-Wl,-rpath=/opt/puppetlabs/puppet/lib -L/opt/puppetlabs/puppet/lib  -Wl,-rpath,/opt/puppetlabs/puppet/lib"
     elsif platform.name =~ /solaris-10-sparc/
       # ld on solaris 10 sparc does not understand `-Wl,-E` - this is what remains after removing it:

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -30,7 +30,8 @@ component "ruby-shadow" do |pkg, settings, platform|
   # every possible angle that could cause this, from rbconfig settings to
   # strace logs, and we need to move forward on this platform.
   # FIXME: Scott Garman Jun 2016
-  if platform.architecture == "s390x"
+  # Added to ppc64
+  if platform.architecture == "s390x" || platform.architecture == "ppc64"
     pkg.configure do
       [
         "mkdir #{settings[:libdir]}/hide",
@@ -50,7 +51,7 @@ component "ruby-shadow" do |pkg, settings, platform|
   end
 
   # Undo the gross hack from the configure step
-  if platform.architecture == "s390x"
+  if platform.architecture == "s390x" || platform.architecture == "ppc64"
     pkg.install do
       [
         "mv #{settings[:libdir]}/hide/* #{settings[:libdir]}/",

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -5,7 +5,7 @@ component "runtime-agent" do |pkg, settings, platform|
 
   if platform.is_cross_compiled?
     libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib")
-    libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib64") if platform.architecture =~ /aarch64|s390x|ppc64le/
+    libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib64") if platform.architecture =~ /aarch64|s390x|ppc64|ppc64le/
   elsif platform.is_aix?
     libdir = "/opt/pl-build-tools/lib/gcc/powerpc-ibm-aix#{platform.os_version}.0.0/5.2.0/"
   elsif platform.is_solaris? || platform.architecture =~ /i\d86/

--- a/configs/platforms/el-7-ppc64.rb
+++ b/configs/platforms/el-7-ppc64.rb
@@ -1,0 +1,37 @@
+platform "el-7-ppc64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  #plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/ppc64le/pl-build-tools-ppc64le.repo"
+  #plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/x86_64/pl-build-tools-x86_64.repo"
+  packages = [
+    "autoconf",
+    "automake",
+    "createrepo",
+    "gcc",
+    "imake",
+    "java-1.8.0-openjdk-devel",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "pkgconfig",
+    "pl-binutils-#{self._platform.architecture}",
+    "pl-cmake",
+    "pl-gcc-#{self._platform.architecture}",
+    "pl-ruby",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.cross_compiled true
+  plat.vmpooler_template "redhat-7-x86_64"
+end

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -86,6 +86,7 @@ proj.setting(:gem_home, File.join(proj.libdir, 'ruby', 'gems', ruby_base_version
 proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
 
 # Cross-compiled Linux platforms
+platform_triple = "ppc64-redhat-linux" if platform.architecture == "ppc64"
 platform_triple = "ppc64le-redhat-linux" if platform.architecture == "ppc64le"
 platform_triple = "powerpc64le-suse-linux" if platform.architecture == "ppc64le" && platform.name =~ /^sles-/
 platform_triple = "powerpc64le-linux-gnu" if platform.architecture == "ppc64el"


### PR DESCRIPTION
This pull includes a series of changes which add the big-endian variant of the powerpc platform to this build tool. 

Here's a high-level recap of the changes:
* Added the el-7-ppc64 profile based on the el-7-ppc64le profile
* Added the redhat ppc64 tuple alongside all instances of the existing ppc64le tuple
* Updated the rbconfig support files to include ppc64
* Extended that weird fix for s390x to include ppc64 as it applies here too...
* Corrected the targets for openssl so that both ppc64le and ppc64 are defined

These changes have been used to successfully cross-compile the master and 5.5.x runtime on a RHEL 7.5 x86_64 machine. Subsequently, I have been able to build the 5.5.x and 6.x versions of the puppet-agent package using these runtime libraries and I have tested the 5.5.4 and current 5.5.x (I believe it's actually 5.5.7 but it's partially updated)  in my ppc64 RHEL 7.5 environment. 

This change builds on the updates I've [submitted to the pl-build-tools](https://github.com/puppetlabs/pl-build-tools-vanagon/pull/55) repository.

Let me know if there's anything I can clarify!

Thanks,
Phil