### PR TITLE
(PA-1923) Update Windows agent install paths to more closely match equivalent *nix paths

### DIFF
--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -8,6 +8,10 @@ project 'agent-runtime-1.10.x' do |proj|
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'
   proj.setting :openssl_version, '1.0.2'
 
+  # In puppet-agent#master, install paths have been updated to more closely
+  # match those used for *nix agents -- Use the old path style for this project:
+  proj.setting :legacy_windows_paths, true
+
   platform = proj.get_platform
 
   # This modification to the platform definition is for compatibility with

--- a/configs/projects/agent-runtime-5.3.x.rb
+++ b/configs/projects/agent-runtime-5.3.x.rb
@@ -5,6 +5,10 @@ project 'agent-runtime-5.3.x' do |proj|
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'
   proj.setting :openssl_version, '1.0.2'
 
+  # In puppet-agent#master, install paths have been updated to more closely
+  # match those used for *nix agents -- Use the old path style for this project:
+  proj.setting :legacy_windows_paths, true
+
   platform = proj.get_platform
 
   # This modification to the platform definition is for compatibility with

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -6,6 +6,10 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'
   proj.setting :openssl_version, '1.0.2'
 
+  # In puppet-agent#master, install paths have been updated to more closely
+  # match those used for *nix agents -- Use the old path style for this project:
+  proj.setting :legacy_windows_paths, true
+
   ########
   # Load shared agent settings
   ########


### PR DESCRIPTION
These changes support https://github.com/puppetlabs/puppet-agent/pull/1517 -- a full description of the pathing updates in this PR can be found in the corresponding puppet-specifications PR [here](https://github.com/puppetlabs/puppet-specifications/pull/123), but in short, install paths are changed as follows:

- The base of the ruby installation has moved from `C:\Program Files\Puppet Labs\Puppet\sys\ruby` to `C:\Program Files\Puppet Labs\Puppet\puppet`
- Tools (like `elevate.exe`) have similarly moved from `C:\Program Files\Puppet Labs\Puppet\sys\tools` to `C:\Program Files\Puppet Labs\Puppet\puppet\bin`
- The agent components facter, hiera, and pxp-agent no longer have their own dedicated install locations at `C:\Program Files\Puppet Labs\Puppet\<component-name>`; they are installed to the same prefix as other projects (`C:\Program Files\Puppet Labs\Puppet\puppet`)