### PR TITLE
(BUILD-156) Add agent-runtime-master support for sles-15-x86_64

### DIFF
--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -32,6 +32,7 @@ project 'agent-runtime-master' do |proj|
   proj.component 'rubygem-trollop'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'rubygem-httpclient'
-  proj.component 'boost'
-  proj.component 'yaml-cpp'
+  # SLES 15 uses the OS distro versions of boost and yaml-cpp:
+  proj.component 'boost' unless platform.name =~ /sles-15/
+  proj.component 'yaml-cpp' unless platform.name =~ /sles-15/
 end


### PR DESCRIPTION
This platform uses the default OS distro toolchain and does not rely on
pl-build-tools.