### PR TITLE
(BOLT-507) Add bolt runtime support for sles-15-x86_64

### DIFF
--- a/configs/components/runtime-bolt.rb
+++ b/configs/components/runtime-bolt.rb
@@ -13,7 +13,7 @@ component "runtime-bolt" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
-  elsif platform.is_macos?
+  elsif platform.is_macos? or platform.name =~ /sles-15/
 
     # Do nothing
 


### PR DESCRIPTION
This platform uses the default OS distro toolchain and does not rely on
pl-build-tools, so the runtime-bolt component is a no-op.