### PR TITLE
(maint) Mark platforms which are community-supported

### DIFF
--- a/configs/platforms/el-7-ppc64.rb
+++ b/configs/platforms/el-7-ppc64.rb
@@ -1,4 +1,6 @@
 platform "el-7-ppc64" do |plat|
+  # Note: This is a community-maintained platform. It is not tested in Puppet's
+  # CI pipelines, and does not receive official releases.
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"


### PR DESCRIPTION
Add a note to the platform config for community-supported OS platforms.