### PR TITLE
(maint) Fix OpenSSL and runtime scripts for Ubuntu 16.04 on power

### DIFF
--- a/configs/components/openssl-1.0.2.rb
+++ b/configs/components/openssl-1.0.2.rb
@@ -30,9 +30,9 @@ component 'openssl' do |pkg, settings, platform|
                'linux-aarch64'
              elsif platform.name =~ /debian-8-arm/
                'linux-armv4'
-             elsif platform.architecture =~ /ppc64le/
+             elsif platform.architecture =~ /ppc64le|ppc64el/ # Litte-endian
                'linux-ppc64le'
-             elsif platform.architecture =~ /ppc64/
+             elsif platform.architecture =~ /ppc64/ # Big-endian
                'linux-ppc64'
              elsif platform.architecture == 's390x'
                'linux64-s390x'

--- a/configs/components/openssl-1.1.0.rb
+++ b/configs/components/openssl-1.1.0.rb
@@ -30,9 +30,9 @@ component 'openssl' do |pkg, settings, platform|
                 'linux-aarch64'
               elsif platform.name =~ /debian-8-arm/
                 'linux-armv4'
-              elsif platform.architecture =~ /ppc64le/
+              elsif platform.architecture =~ /ppc64le|ppc64el/ # Little-endian
                 'linux-ppc64le'
-              elsif platform.architecture =~ /ppc64/
+              elsif platform.architecture =~ /ppc64/ # Big-endian
                 'linux-ppc64'
               elsif platform.architecture == 's390x'
                 'linux64-s390x'

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -4,8 +4,11 @@ component "runtime-agent" do |pkg, settings, platform|
   pkg.add_source "file://resources/files/runtime/runtime.sh"
 
   if platform.is_cross_compiled?
-    libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib")
-    libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib64") if platform.architecture =~ /aarch64|s390x|ppc64|ppc64le/
+    if platform.architecture =~ /aarch64|s390x|ppc64$|ppc64le/
+      libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib64")
+    else
+      libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib")
+    end
   elsif platform.is_aix?
     libdir = "/opt/pl-build-tools/lib/gcc/powerpc-ibm-aix#{platform.os_version}.0.0/5.2.0/"
   elsif platform.is_solaris? || platform.architecture =~ /i\d86/


### PR DESCRIPTION
(Changes to regexes around PPC plaforms erroneously altered the libdir
for OpenSSL builds on ubuntu-16.04-ppc64el and the runtime script)

These changes seem to rectify the `inspect` diffs between the working and non-working tags while preserving the new changes -- I'll run this through the agent pipeline for all ppc platforms before requesting a merge, though.