### PR TITLE
(BOLT-789) Update Bolt to use Ruby 2.5 and OpenSSL 1.1

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -1,8 +1,8 @@
 project 'bolt-runtime' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'bolt')
-  proj.setting(:ruby_version, '2.4.4')
-  proj.setting(:openssl_version, '1.0.2')
+  proj.setting(:ruby_version, '2.5.1')
+  proj.setting(:openssl_version, '1.1.0')
   platform = proj.get_platform
 
   proj.version_from_git
@@ -96,7 +96,6 @@ project 'bolt-runtime' do |proj|
     'no-dtls1',
     'no-idea',
     'no-seed',
-    'no-ssl2-method',
     'no-weak-ssl-ciphers',
     '-DOPENSSL_NO_HEARTBEATS',
   ])


### PR DESCRIPTION
Updates Bolt to use the latest releases of these core libraries.