### PR TITLE
(PA-2243) Add redhatfips to the list of platforms for selinux

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -15,7 +15,7 @@ component 'augeas' do |pkg, settings, platform|
     when '1.10.1'
       pkg.md5sum '6c0b2ea6eec45e8bc374b283aedf27ce'
 
-      if platform.name =~ /^el-(5|6|7)-.*/ || platform.is_fedora?
+      if platform.name =~ platform.is_el? || platform.is_fedora?
         # Augeas 1.10.1 needs a libselinux pkgconfig file on these platforms:
         pkg.build_requires 'ruby-selinux'
       elsif platform.name =~ /solaris-10-sparc/

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -27,7 +27,7 @@ proj.component 'libxslt' unless platform.is_windows?
 proj.component 'ruby-augeas' unless platform.is_windows?
 proj.component 'ruby-shadow' unless platform.is_aix? || platform.is_windows?
 # We only build ruby-selinux for EL 5-7
-if platform.name =~ /^el-(5|6|7)-.*/ || platform.is_fedora?
+if platform.name =~ platform.is_el? || platform.is_fedora?
   proj.component 'ruby-selinux'
 end
 

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -167,7 +167,7 @@ project 'pdk-runtime' do |proj|
   proj.component "ruby-augeas" unless platform.is_windows?
 
   # We only build ruby-selinux for EL 5-7
-  if platform.name =~ /^el-(5|6|7)-.*/ || platform.is_fedora?
+  if platform.name =~ platform.is_el? || platform.is_fedora?
     proj.component "ruby-selinux"
   end
 


### PR DESCRIPTION
We were previously not building the ruby selinux bindings on the redhatfips
platform. We should do that.