### PR TITLE
(PA-2279) Patch Ruby CVE 2018-16395

### DIFF
--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -41,6 +41,9 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   base = 'resources/patches/ruby_219'
   pkg.apply_patch "#{base}/libyaml_cve-2014-9130.patch"
 
+  # Patches from Ruby 2.5 security fixes
+  pkg.apply_patch "#{base}/cve-2018-16395.patch"
+
   # Patches from Ruby 2.4 security fixes. See the description and
   # comments of RE-9323 for more details.
   pkg.apply_patch "#{base}/cve-2017-0898.patch"

--- a/configs/components/ruby-2.4.4.rb
+++ b/configs/components/ruby-2.4.4.rb
@@ -39,7 +39,10 @@ component 'ruby-2.4.4' do |pkg, settings, platform|
   #########
 
   base = 'resources/patches/ruby_244'
+
+  pkg.apply_patch "#{base}/cve-2018-16395.patch"
   pkg.apply_patch "#{base}/ostruct_remove_safe_nav_operator_r2.4.patch"
+
   # This patch creates our server/client shared Gem path, used for all gems
   # that are dependencies of the shared Ruby code.
   pkg.apply_patch "#{base}/rubygems_add_puppet_vendor_dir_r2.4.patch"

--- a/configs/components/ruby-2.5.1.rb
+++ b/configs/components/ruby-2.5.1.rb
@@ -36,8 +36,11 @@ component 'ruby-2.5.1' do |pkg, settings, platform|
   #########
 
   base = 'resources/patches/ruby_251'
+
+  pkg.apply_patch "#{base}/cve-2018-16395.patch"
   pkg.apply_patch "#{base}/ostruct_remove_safe_nav_operator_r2.5.patch"
   pkg.apply_patch "#{base}/Check-for-existance-of-O_CLOEXEC.patch"
+
   # This patch creates our server/client shared Gem path, used for all gems
   # that are dependencies of the shared Ruby code.
   pkg.apply_patch "#{base}/rubygems_add_puppet_vendor_dir_r2.5.patch"

--- a/resources/patches/ruby_219/cve-2018-16395.patch
+++ b/resources/patches/ruby_219/cve-2018-16395.patch
@@ -1,0 +1,13 @@
+diff --git a/ext/openssl/ossl_x509name.c b/ext/openssl/ossl_x509name.c
+index fd2ec122eb6d..1ea8400dbb93 100644
+--- a/ext/openssl/ossl_x509name.c
++++ b/ext/openssl/ossl_x509name.c
+@@ -400,7 +400,7 @@ ossl_x509name_cmp(VALUE self, VALUE other)
+ 
+     result = ossl_x509name_cmp0(self, other);
+     if (result < 0) return INT2FIX(-1);
+-    if (result > 1) return INT2FIX(1);
++    if (result > 0) return INT2FIX(1);
+ 
+     return INT2FIX(0);
+ }

--- a/resources/patches/ruby_244/cve-2018-16395.patch
+++ b/resources/patches/ruby_244/cve-2018-16395.patch
@@ -1,0 +1,13 @@
+diff --git a/ext/openssl/ossl_x509name.c b/ext/openssl/ossl_x509name.c
+index fd2ec122eb6d..1ea8400dbb93 100644
+--- a/ext/openssl/ossl_x509name.c
++++ b/ext/openssl/ossl_x509name.c
+@@ -400,7 +400,7 @@ ossl_x509name_cmp(VALUE self, VALUE other)
+ 
+     result = ossl_x509name_cmp0(self, other);
+     if (result < 0) return INT2FIX(-1);
+-    if (result > 1) return INT2FIX(1);
++    if (result > 0) return INT2FIX(1);
+ 
+     return INT2FIX(0);
+ }

--- a/resources/patches/ruby_251/cve-2018-16395.patch
+++ b/resources/patches/ruby_251/cve-2018-16395.patch
@@ -1,0 +1,13 @@
+diff --git a/ext/openssl/ossl_x509name.c b/ext/openssl/ossl_x509name.c
+index fd2ec122eb6d..1ea8400dbb93 100644
+--- a/ext/openssl/ossl_x509name.c
++++ b/ext/openssl/ossl_x509name.c
+@@ -400,7 +400,7 @@ ossl_x509name_cmp(VALUE self, VALUE other)
+ 
+     result = ossl_x509name_cmp0(self, other);
+     if (result < 0) return INT2FIX(-1);
+-    if (result > 1) return INT2FIX(1);
++    if (result > 0) return INT2FIX(1);
+ 
+     return INT2FIX(0);
+ }


### PR DESCRIPTION
Patches Ruby 2.1.9, 2.4.4, and 2.5.1 for CVE-2018-16395 (corrects name equality checks for `OpenSSL::X509::Name`) -- note that puppet does not appear to use this codepath, but this is worth fixing.

Some links:
- [The CVE](https://www.ruby-lang.org/en/news/2018/10/17/openssl-x509-name-equality-check-does-not-work-correctly-cve-2018-16395/)
- [The fix for it in Ruby](https://github.com/ruby/ruby/commit/93bc10272734cbbb9197470ca629cc4ea019f6f0)