### PR TITLE
(PA-2325) Add Redhat 8 to puppet-runtime

### DIFF
--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -40,7 +40,7 @@ if platform.is_cross_compiled_linux?
   ruby = "#{host_ruby} -r#{settings[:datadir]}/doc/rbconfig-#{ruby_version}-orig.rb"
 end
 
-cc = '/usr/bin/gcc' if platform.name =~ /fedora-29/
+cc = '/usr/bin/gcc' if platform.name =~ /fedora-29|el-8/
 
 pkg.build do
   [

--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -102,7 +102,7 @@ component "boost" do |pkg, settings, platform|
   else
     pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
     linkflags = "-Wl,-rpath=#{settings[:libdir]},-rpath=#{settings[:libdir]}64"
-    gpp = "/usr/bin/g++" if platform.name =~ /fedora-29/
+    gpp = "/usr/bin/g++" if platform.name =~ /fedora-29|el-8/
   end
 
   # Set user-config.jam

--- a/configs/components/ruby-2.4.5.rb
+++ b/configs/components/ruby-2.4.5.rb
@@ -176,9 +176,9 @@ component 'ruby-2.4.5' do |pkg, settings, platform|
     end
   elsif platform.is_windows?
     rbconfig_changes["CC"] = "x86_64-w64-mingw32-gcc"
-  elsif platform.name =~ /fedora-28|fedora-29/
-    # Fedora 28 uses native GCC 8.0.1. When building ruby C extensions (in
-    # ruby-augeas, for example) mkmf will fail when ruby 2.4.5's
+  elsif platform.name =~ /fedora-28|fedora-29|el-8/
+    # When building ruby C extensions (in
+    # ruby-augeas, for example) with Native GCC >= 8.0.1, mkmf will fail when ruby 2.4.5's
     # CONFIG['warnflags'] are applied to a conftest with -Werror before
     # generating the Makefile. This patch removes a few flags from
     # CONFIG['warnflags'] that are no longer valid and ignores a few new

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -23,7 +23,7 @@ component "runtime-agent" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
     pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
-  elsif platform.is_macos? || platform.name =~ /sles-15|fedora-29/
+  elsif platform.is_macos? || platform.name =~ /sles-15|fedora-29|el-8/
     # Nothing to see here
   elsif platform.is_windows?
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -23,7 +23,7 @@ component "yaml-cpp" do |pkg, settings, platform|
   elsif platform.is_macos?
     cmake_toolchain_file = ""
     cmake = "/usr/local/bin/cmake"
-  elsif platform.name =~ /fedora-29/
+  elsif platform.name =~ /fedora-29|el-8/
     cmake_toolchain_file = ''
     cmake = '/usr/bin/cmake'
   elsif platform.is_windows?

--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -1,0 +1,14 @@
+platform 'el-8-x86_64' do |plat|
+  plat.servicedir '/usr/lib/systemd/system'
+  plat.defaultdir '/etc/sysconfig'
+  plat.servicetype 'systemd'
+
+  packages = %w[
+    autoconf automake createrepo gcc gcc-c++ java-1.8.0-openjdk-devel
+    libsepol libsepol-devel libselinux-devel make pkgconfig cmake readline-devel
+    rsync rpm-build rpm-libs rpm-sign rpmdevtools swig yum-utils zlib-devel
+  ]
+  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
+  plat.install_build_dependencies_with 'dnf install -y --allowerasing'
+  plat.vmpooler_template 'redhat-8-x86_64'
+end

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -202,7 +202,6 @@ proj.timeout 7200 if platform.is_windows?
 proj.setting(:boost_libs, ["chrono", "date_time", "filesystem", "locale", "log", "program_options",
                            "random", "regex", "system", "thread"])
 
-
 # Most branches of puppet-agent use these openssl flags in addition to the defaults in configs/components/openssl.rb -
 # Individual projects can override these if necessary.
 proj.setting(:openssl_extra_configure_flags, [
@@ -228,6 +227,4 @@ proj.directory proj.install_root
 proj.directory proj.prefix
 proj.directory proj.sysconfdir
 proj.directory proj.link_bindir
-if platform.is_windows? || platform.is_macos?
-  proj.directory proj.bindir
-end
+proj.directory proj.bindir if platform.is_windows? || platform.is_macos?

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -39,6 +39,6 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'rubygem-trollop'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'ruby-stomp'
-  proj.component 'yaml-cpp' if platform.name =~ /osx-10.12|osx-10.14|fedora-29/
-  proj.component 'boost' if platform.name =~ /fedora-29/
+  proj.component 'yaml-cpp' if platform.name =~ /osx-10.12|osx-10.14|fedora-29|el-8/
+  proj.component 'boost' if platform.name =~ /fedora-29|el-8/
 end


### PR DESCRIPTION
This needs to be tested alongside puppet-agent.
Waiting for the release of beaker-hostgenerator containing redhat-8. 