### PR TITLE
Update openssl to fix numerous bugs

### DIFF
--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -1,6 +1,6 @@
 component 'openssl' do |pkg, settings, platform|
-  pkg.version '1.1.0h'
-  pkg.md5sum '5271477e4d93f4ea032b665ef095ff24'
+  pkg.version '1.1.1a'
+  pkg.md5sum '963deb2272d6be7d4c2458afd2517b73'
   pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/openssl-#{pkg.get_version}.tar.gz"
 

--- a/configs/projects/agent-runtime-6.0.x.rb
+++ b/configs/projects/agent-runtime-6.0.x.rb
@@ -2,7 +2,7 @@ project 'agent-runtime-6.0.x' do |proj|
   # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.5.3'
   proj.setting :augeas_version, '1.10.1'
-  proj.setting :openssl_version, '1.1.0'
+  proj.setting :openssl_version, '1.1.1'
 
   ########
   # Load shared agent settings

--- a/configs/projects/agent-runtime-6.1.x.rb
+++ b/configs/projects/agent-runtime-6.1.x.rb
@@ -2,7 +2,7 @@ project 'agent-runtime-6.1.x' do |proj|
   # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.5.3'
   proj.setting :augeas_version, '1.10.1'
-  proj.setting :openssl_version, '1.1.0'
+  proj.setting :openssl_version, '1.1.1'
 
   ########
   # Load shared agent settings

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -2,7 +2,7 @@ project 'agent-runtime-master' do |proj|
   # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.5.3'
   proj.setting :augeas_version, '1.10.1'
-  proj.setting :openssl_version, '1.1.0'
+  proj.setting :openssl_version, '1.1.1'
 
   ########
   # Load shared agent settings

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -2,7 +2,7 @@ project 'bolt-runtime' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'bolt')
   proj.setting(:ruby_version, '2.5.3')
-  proj.setting(:openssl_version, '1.1.0')
+  proj.setting(:openssl_version, '1.1.1')
   proj.setting(:rubygem_net_ssh_version, '5.0.2')
   platform = proj.get_platform
 

--- a/configs/projects/pe-installer-runtime.rb
+++ b/configs/projects/pe-installer-runtime.rb
@@ -2,7 +2,7 @@ project 'pe-installer-runtime' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'pe-installer')
   proj.setting(:ruby_version, '2.4.5')
-  proj.setting(:openssl_version, '1.1.0')
+  proj.setting(:openssl_version, '1.1.1')
   platform = proj.get_platform
 
   proj.version_from_git


### PR DESCRIPTION
I noticed this bug with missing quotes on c_rehash:

```
$ sudo /opt/puppetlabs/puppet/bin/c_rehash
Unknown regexp modifier "/e" at /opt/puppetlabs/puppet/bin/c_rehash line 15, at end of line
Unknown regexp modifier "/t" at /opt/puppetlabs/puppet/bin/c_rehash line 15, at end of line
Regexp modifiers "/u" and "/l" are mutually exclusive at /opt/puppetlabs/puppet/bin/c_rehash line 15, at end of line
Regexp modifiers "/u" and "/a" are mutually exclusive at /opt/puppetlabs/puppet/bin/c_rehash line 15, at end of line
Unknown regexp modifier "/b" at /opt/puppetlabs/puppet/bin/c_rehash line 15, at end of line
Unknown regexp modifier "/e" at /opt/puppetlabs/puppet/bin/c_rehash line 16, at end of line
Unknown regexp modifier "/t" at /opt/puppetlabs/puppet/bin/c_rehash line 16, at end of line
Regexp modifiers "/u" and "/l" are mutually exclusive at /opt/puppetlabs/puppet/bin/c_rehash line 16, at end of line
Regexp modifiers "/u" and "/a" are mutually exclusive at /opt/puppetlabs/puppet/bin/c_rehash line 16, at end of line
Unknown regexp modifier "/b" at /opt/puppetlabs/puppet/bin/c_rehash line 16, at end of line
/opt/puppetlabs/puppet/bin/c_rehash has too many errors.
```

The problem is that `$dir` and `$prefix` values aren't quoted. The fix can be found at https://github.com/openssl/openssl/commit/7ee2a43069913fb7c444c656048996ea92cc465e

However looking through the commits to 1.1.0 it really seems like updating 1.1.1 is much more effective fix.