### PR TITLE
Revert "(PA-2334) do not use root for homebrew on OSX"

### DIFF
--- a/configs/platforms/osx-10.10-x86_64.rb
+++ b/configs/platforms/osx-10.10-x86_64.rb
@@ -1,18 +1,13 @@
-platform "osx-10.13-x86_64" do |plat|
+platform "osx-10.10-x86_64" do |plat|
   plat.servicetype 'launchd'
   plat.servicedir '/Library/LaunchDaemons'
-  plat.codename "highsierra"
+  plat.codename "yosemite"
 
-  plat.provision_with 'export HOMEBREW_NO_AUTO_UPDATE=true'
-  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-  plat.provision_with 'export HOMEBREW_VERBOSE=true'
-
-  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew_sierra.tar.gz | tar -x --strip 1 -C /usr/local -f -'
-  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0001-Add-needs-cxx14.patch | patch -p0'
+  plat.provision_with 'mkdir /usr/local; curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew.tar.gz | tar -x --strip 1 -C /usr/local -f -'
   plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
   plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
   plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
-  plat.provision_with '/usr/local/bin/osx-deps pkg-config'
+  plat.provision_with '/usr/local/bin/osx-deps apple-clt-7.2 pkg-config'
 
   packages = [
     "cmake",
@@ -23,6 +18,6 @@ platform "osx-10.13-x86_64" do |plat|
   plat.provision_with "/usr/local/bin/osx-deps #{packages.join(' ')}}"
 
   plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
-  plat.vmpooler_template "osx-1012-x86_64"
-  plat.output_dir File.join("apple", "10.13", "PC1", "x86_64")
+  plat.vmpooler_template "osx-1010-x86_64"
+  plat.output_dir File.join("apple", "10.10", "PC1", "x86_64")
 end

--- a/configs/platforms/osx-10.11-x86_64.rb
+++ b/configs/platforms/osx-10.11-x86_64.rb
@@ -1,18 +1,13 @@
-platform "osx-10.13-x86_64" do |plat|
+platform "osx-10.11-x86_64" do |plat|
   plat.servicetype 'launchd'
   plat.servicedir '/Library/LaunchDaemons'
-  plat.codename "highsierra"
+  plat.codename "elcapitan"
 
-  plat.provision_with 'export HOMEBREW_NO_AUTO_UPDATE=true'
-  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-  plat.provision_with 'export HOMEBREW_VERBOSE=true'
-
-  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew_sierra.tar.gz | tar -x --strip 1 -C /usr/local -f -'
-  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0001-Add-needs-cxx14.patch | patch -p0'
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew.tar.gz | tar -x --strip 1 -C /usr/local -f -'
   plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
   plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
   plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
-  plat.provision_with '/usr/local/bin/osx-deps pkg-config'
+  plat.provision_with '/usr/local/bin/osx-deps apple-clt-7.3.1 pkg-config'
 
   packages = [
     "cmake",
@@ -23,6 +18,6 @@ platform "osx-10.13-x86_64" do |plat|
   plat.provision_with "/usr/local/bin/osx-deps #{packages.join(' ')}}"
 
   plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
-  plat.vmpooler_template "osx-1012-x86_64"
-  plat.output_dir File.join("apple", "10.13", "PC1", "x86_64")
+  plat.vmpooler_template "osx-1011-x86_64"
+  plat.output_dir File.join("apple", "10.11", "PC1", "x86_64")
 end

--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -1,28 +1,29 @@
 platform 'osx-10.14-x86_64' do |plat|
-  plat.servicetype 'launchd'
-  plat.servicedir '/Library/LaunchDaemons'
-  plat.codename 'mojave'
-
-  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-  plat.provision_with 'export HOMEBREW_VERBOSE=true'
-
-  plat.provision_with 'sudo dscl . -create /Users/test'
-  plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-  plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-  plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-  plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-  plat.provision_with 'sudo dscl . -passwd /Users/test password'
-  plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-  plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-  plat.provision_with 'mkdir -p /etc/homebrew'
-  plat.provision_with 'cd /etc/homebrew'
-  plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
-  plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'    
-
-  packages = %w[cmake pkg-config yaml-cpp]
-
-  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
-
-  plat.vmpooler_template 'osx-1012-x86_64'
-  plat.output_dir File.join('apple', '10.14', 'PC1', 'x86_64')
-end
+    plat.servicetype 'launchd'
+    plat.servicedir '/Library/LaunchDaemons'
+    plat.codename 'mojave'
+  
+    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+    plat.provision_with 'export HOMEBREW_VERBOSE=true'
+  
+    plat.provision_with 'sudo dscl . -create /Users/test'
+    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+    plat.provision_with 'sudo dscl . -passwd /Users/test password'
+    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+    plat.provision_with 'mkdir -p /etc/homebrew'
+    plat.provision_with 'cd /etc/homebrew'
+    plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
+    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'    
+  
+    packages = %w[cmake pkg-config yaml-cpp]
+  
+    plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+  
+    plat.vmpooler_template 'osx-1012-x86_64'
+    plat.output_dir File.join('apple', '10.14', 'PC1', 'x86_64')
+  end
+  

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -39,6 +39,6 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'rubygem-trollop'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'ruby-stomp'
-  proj.component 'yaml-cpp' if platform.name =~ /fedora-29|el-8/ || platform.is_macos?
+  proj.component 'yaml-cpp' if platform.name =~ /osx-10.12|osx-10.14|fedora-29|el-8/
   proj.component 'boost' if platform.name =~ /fedora-29|el-8/
 end


### PR DESCRIPTION
Reverts puppetlabs/puppet-runtime#128

CI for puppet-agent 1.10.x depends on macOS 10.10 and 10.11, and we haven't committed to removing it there. We'll need to keep these platforms in this repo until the puppet-agent 1.10.x branch is retired.