### PR TITLE
Revert "Merge pull request #131 from puppetlabs/revert-128-master"

### DIFF
--- a/configs/platforms/osx-10.13-x86_64.rb
+++ b/configs/platforms/osx-10.13-x86_64.rb
@@ -1,28 +1,28 @@
-platform "osx-10.13-x86_64" do |plat|
+platform 'osx-10.13-x86_64' do |plat|
   plat.servicetype 'launchd'
   plat.servicedir '/Library/LaunchDaemons'
-  plat.codename "highsierra"
+  plat.codename 'highsierra'
 
-  plat.provision_with 'export HOMEBREW_NO_AUTO_UPDATE=true'
   plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
   plat.provision_with 'export HOMEBREW_VERBOSE=true'
 
-  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew_sierra.tar.gz | tar -x --strip 1 -C /usr/local -f -'
-  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0001-Add-needs-cxx14.patch | patch -p0'
-  plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
-  plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
-  plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
-  plat.provision_with '/usr/local/bin/osx-deps pkg-config'
+  plat.provision_with 'sudo dscl . -create /Users/test'
+  plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+  plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+  plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+  plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+  plat.provision_with 'sudo dscl . -passwd /Users/test password'
+  plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+  plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+  plat.provision_with 'mkdir -p /etc/homebrew'
+  plat.provision_with 'cd /etc/homebrew'
+  plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''  
+  plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
 
-  packages = [
-    "cmake",
-    "makedepend",
-    "pl-gcc"
-  ]
+  packages = %w[cmake pkg-config yaml-cpp]
+  
+  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 
-  plat.provision_with "/usr/local/bin/osx-deps #{packages.join(' ')}}"
-
-  plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
-  plat.vmpooler_template "osx-1012-x86_64"
-  plat.output_dir File.join("apple", "10.13", "PC1", "x86_64")
+  plat.vmpooler_template 'osx-1012-x86_64'
+  plat.output_dir File.join('apple', '10.13', 'PC1', 'x86_64')
 end

--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -1,29 +1,28 @@
 platform 'osx-10.14-x86_64' do |plat|
-    plat.servicetype 'launchd'
-    plat.servicedir '/Library/LaunchDaemons'
-    plat.codename 'mojave'
-  
-    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-    plat.provision_with 'export HOMEBREW_VERBOSE=true'
-  
-    plat.provision_with 'sudo dscl . -create /Users/test'
-    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-    plat.provision_with 'sudo dscl . -passwd /Users/test password'
-    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-    plat.provision_with 'mkdir -p /etc/homebrew'
-    plat.provision_with 'cd /etc/homebrew'
-    plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
-    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'    
-  
-    packages = %w[cmake pkg-config yaml-cpp]
-  
-    plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
-  
-    plat.vmpooler_template 'osx-1012-x86_64'
-    plat.output_dir File.join('apple', '10.14', 'PC1', 'x86_64')
-  end
-  
+  plat.servicetype 'launchd'
+  plat.servicedir '/Library/LaunchDaemons'
+  plat.codename 'mojave'
+
+  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+  plat.provision_with 'export HOMEBREW_VERBOSE=true'
+
+  plat.provision_with 'sudo dscl . -create /Users/test'
+  plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+  plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+  plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+  plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+  plat.provision_with 'sudo dscl . -passwd /Users/test password'
+  plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+  plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+  plat.provision_with 'mkdir -p /etc/homebrew'
+  plat.provision_with 'cd /etc/homebrew'
+  plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
+  plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'    
+
+  packages = %w[cmake pkg-config yaml-cpp]
+
+  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+
+  plat.vmpooler_template 'osx-1012-x86_64'
+  plat.output_dir File.join('apple', '10.14', 'PC1', 'x86_64')
+end

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -39,6 +39,6 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'rubygem-trollop'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'ruby-stomp'
-  proj.component 'yaml-cpp' if platform.name =~ /osx-10.12|osx-10.14|fedora-29|el-8/
+  proj.component 'yaml-cpp' if platform.name =~ /fedora-29|el-8/ || platform.is_macos?
   proj.component 'boost' if platform.name =~ /fedora-29|el-8/
 end


### PR DESCRIPTION
This reverts commit 1b752d605dc8021c931fc956997a136d6e338db7, reversing
changes made to 933c99524d929361b5a88b86de19a9146de1042d.

The changes to the projects and platforms here are fine, but the removal
of OS X 10.10 and 10.11 should happen separately or not at all.

I'm going to run a few tests on all the macOS platforms to make sure everything's still okay before I remove the do not merge label.