### PR TITLE
(BOLT-978) Dont use pl-build-tools for bolt-runtime on fedora 29

### DIFF
--- a/configs/components/runtime-bolt.rb
+++ b/configs/components/runtime-bolt.rb
@@ -13,9 +13,9 @@ component "runtime-bolt" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
-  elsif platform.is_macos? or platform.name =~ /sles-15/
+  elsif platform.is_macos? or platform.name =~ /sles-15|fedora-29/
 
-    # Do nothing
+    # Do nothing for distros that have a suitable compiler do not use pl-build-tools
 
   else # Linux and Solaris systems
     libbase = platform.architecture =~ /64/ ? 'lib64' : 'lib'


### PR DESCRIPTION
As part of the work packaging and shipping puppet-bolt for fedora we use build tools that exist in the newer distros.