### PR TITLE
PA-2364 bump augeas to 1.11.0

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -4,32 +4,37 @@ component 'augeas' do |pkg, settings, platform|
   pkg.version version
 
   case version
-    when '1.4.0'
-      pkg.md5sum 'a2536a9c3d744dc09d234228fe4b0c93'
+  when '1.4.0'
+    pkg.md5sum 'a2536a9c3d744dc09d234228fe4b0c93'
 
-      pkg.apply_patch 'resources/patches/augeas/augeas-1.4.0-osx-stub-needed-readline-functions.patch'
-      pkg.apply_patch 'resources/patches/augeas/augeas-1.4.0-sudoers-negated-command-alias.patch'
-      pkg.apply_patch 'resources/patches/augeas/augeas-1.4.0-src-pathx.c-parse_name-correctly-handle-trailing-ws.patch'
-    when '1.8.1'
-      pkg.md5sum '623ff89d71a42fab9263365145efdbfa'
-    when '1.10.1'
-      pkg.md5sum '6c0b2ea6eec45e8bc374b283aedf27ce'
+    pkg.apply_patch 'resources/patches/augeas/augeas-1.4.0-osx-stub-needed-readline-functions.patch'
+    pkg.apply_patch 'resources/patches/augeas/augeas-1.4.0-sudoers-negated-command-alias.patch'
+    pkg.apply_patch 'resources/patches/augeas/augeas-1.4.0-src-pathx.c-parse_name-correctly-handle-trailing-ws.patch'
+  when '1.8.1'
+    pkg.md5sum '623ff89d71a42fab9263365145efdbfa'
+  when '1.10.1'
+    pkg.md5sum '6c0b2ea6eec45e8bc374b283aedf27ce'
+  when '1.11.0'
+    pkg.md5sum 'abf51f4c0cf3901d167f23687f60434a'
+  else
+    raise "augeas version #{version} has not been configured; Cannot continue."
+  end
 
-      if platform.is_el? || platform.is_fedora?
-        # Augeas 1.10.1 needs a libselinux pkgconfig file on these platforms:
-        pkg.build_requires 'ruby-selinux'
-      elsif platform.name =~ /solaris-10-sparc/
-        # This patch to gnulib fixes a linking error around symbol versioning in pthread.
-        pkg.add_source 'file://resources/patches/augeas/augeas-1.10.1-gnulib-pthread-in-use.patch'
+  if ['1.10.1', '1.11.0'].include?(version)
+    if platform.is_el? || platform.is_fedora?
+      # Augeas 1.10.1/1.11.0 needs a libselinux pkgconfig file on these platforms:
+      pkg.build_requires 'ruby-selinux'
+    end
 
-        pkg.configure do
-          # gnulib is a submodule, and its files don't exist until after configure,
-          # so we apply the patch manually here instead of using pkg.apply_patch.
-          ["/usr/bin/gpatch -p0 < ../augeas-1.10.1-gnulib-pthread-in-use.patch"]
-        end
+    if platform.name =~ /solaris-10-sparc/
+      # This patch to gnulib fixes a linking error around symbol versioning in pthread.
+      pkg.add_source "file://resources/patches/augeas/augeas-#{version}-gnulib-pthread-in-use.patch"
+      pkg.configure do
+        # gnulib is a submodule, and its files don't exist until after configure,
+        # so we apply the patch manually here instead of using pkg.apply_patch.
+        ["/usr/bin/gpatch -p0 < ../augeas-#{version}-gnulib-pthread-in-use.patch"]
       end
-    else
-      raise "augeas version #{version} has not been configured; Cannot continue."
+    end
   end
 
   pkg.url "http://download.augeas.net/augeas-#{pkg.get_version}.tar.gz"

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -1,6 +1,6 @@
 project 'agent-runtime-5.5.x' do |proj|
   # Set preferred component versions if they differ from defaults:
-  proj.setting :augeas_version, '1.10.1'
+  proj.setting :augeas_version, '1.11.0'
   proj.setting :ruby_version, '2.4.5'
   proj.setting :rubygem_net_ssh, '4.1.0'
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'

--- a/resources/patches/augeas/augeas-1.11.0-gnulib-pthread-in-use.patch
+++ b/resources/patches/augeas/augeas-1.11.0-gnulib-pthread-in-use.patch
@@ -1,0 +1,23 @@
+--- gnulib/lib/glthread/lock.h  2019-01-16 11:48:44.000000000 +0200
++++ lock.h  2019-01-16 11:49:34.000000000 +0200
+@@ -148,20 +148,7 @@
+ #   pragma weak pthread_self
+ #  endif
+
+-#  if !PTHREAD_IN_USE_DETECTION_HARD
+-    /* On most platforms, pthread_cancel or pthread_kill can be used to
+-       determine whether libpthread is in use.
+-       On newer versions of FreeBSD, however, this is no longer possible,
+-       because pthread_cancel and pthread_kill got added to libc.  Therefore
+-       use pthread_create to test whether libpthread is in use.  */
+-#   if defined __FreeBSD__ || defined __DragonFly__ /* FreeBSD */
+-#    pragma weak pthread_create
+-#    define pthread_in_use() (pthread_create != NULL)
+-#   else /* glibc, NetBSD, OpenBSD, IRIX, OSF/1, Solaris */
+-#    pragma weak pthread_cancel
+-#    define pthread_in_use() (pthread_cancel != NULL)
+-#   endif
+-#  endif
++# define pthread_in_use() 1
+
+ # else


### PR DESCRIPTION
- [x] Built the runtime with augeas 1.11.0 for all our supported platforms.
- [x] Run adhoc pipeline for puppet-agent using the runtime with augeas 1.11.0
- [x] Test the new puppet-agent against different modules(TODO)