### PR TITLE
(BOLT-920) Update net-ssh to 5.1.0 for bolt-runtime

### DIFF
--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -4,8 +4,8 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.version version
 
   case version
-  when "5.0.2"
-    pkg.md5sum "1b57b817489b231f25ee9e1244618394"
+  when "5.1.0"
+    pkg.md5sum "b5cc4ab9a79e8a1b07f729489f368129"
   when "4.2.0"
     pkg.md5sum "fec5b151d84110b95ec0056017804491"
   when "4.1.0"

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -3,7 +3,7 @@ project 'bolt-runtime' do |proj|
   proj.setting(:runtime_project, 'bolt')
   proj.setting(:ruby_version, '2.5.3')
   proj.setting(:openssl_version, '1.1.1')
-  proj.setting(:rubygem_net_ssh_version, '5.0.2')
+  proj.setting(:rubygem_net_ssh_version, '5.1.0')
   platform = proj.get_platform
 
   proj.version_from_git


### PR DESCRIPTION
Upgrading to support using ecdsa keys with bolt.