### PR TITLE
(maint) Bump minitar version for bolt runtime

### DIFF
--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -1,8 +1,19 @@
 component "rubygem-minitar" do |pkg, settings, platform|
+  # Projects may define a :rubygem_minitar_version setting, or we use 0.6.1 by default:
+  version = settings[:rubygem_minitar_version] || '0.6.1'
+  pkg.version version
+
+  case version
+  when "0.6.1"
+    pkg.md5sum "ce4ee63a94e80fb4e3e66b54b995beaa"
+  when "0.8"
+    pkg.md5sum "af220249c7dfe1774de3a81da4bb21d7"
+  else
+    raise "rubygem-minitar version #{version} has not been configured; Cannot continue."
+  end
+
   instance_eval File.read('configs/components/_base-rubygem.rb')
 
-  pkg.version "0.6.1"
-  pkg.md5sum "ce4ee63a94e80fb4e3e66b54b995beaa"
   pkg.url "https://rubygems.org/downloads/minitar-#{pkg.get_version}.gem"
   pkg.mirror "#{settings[:buildsources_url]}/minitar-#{pkg.get_version}.gem"
 

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -4,6 +4,7 @@ project 'bolt-runtime' do |proj|
   proj.setting(:ruby_version, '2.5.3')
   proj.setting(:openssl_version, '1.1.1')
   proj.setting(:rubygem_net_ssh_version, '5.1.0')
+  proj.setting(:rubygem_minitar_version, '0.8')
   platform = proj.get_platform
 
   proj.version_from_git


### PR DESCRIPTION
Bolt shares a dependency with puppet-runtime on the minitar gem. In order to build pe-bolt-server we were also adding the newer version in the bolt-vanagon project. This resulted in puppet-bolt and pe-bolt-server packages having different minitar versions. This commit allows us to specify the latest minitar version in bolt-runtime without affecting other projects that may use the older gem.