### PR TITLE
(PA-2364) bump augeas to 1.11.0 for agent-runtime-master

### DIFF
--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -1,7 +1,7 @@
 project 'agent-runtime-master' do |proj|
   # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.5.3'
-  proj.setting :augeas_version, '1.10.1'
+  proj.setting :augeas_version, '1.11.0'
   proj.setting :openssl_version, '1.1.1'
 
   ########


### PR DESCRIPTION
5.5.x pipline was passing
run the adhoc for master and everything seems to be ok besides some ubuntu artifactory issues
https://jenkins-master-prod-1.delivery.puppetlabs.net/view/Adhoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/529/