### PR TITLE
(maint) remove pl-gcc from wrlinux-5 & 7

### DIFF
--- a/configs/platforms/cisco-wrlinux-5-x86_64.rb
+++ b/configs/platforms/cisco-wrlinux-5-x86_64.rb
@@ -9,7 +9,6 @@ platform "cisco-wrlinux-5-x86_64" do |plat|
     "make",
     "pkgconfig",
     "pl-cmake",
-    "pl-gcc",
     "readline-devel",
     "zlib-devel",
   ]

--- a/configs/platforms/cisco-wrlinux-7-x86_64.rb
+++ b/configs/platforms/cisco-wrlinux-7-x86_64.rb
@@ -9,7 +9,6 @@ platform "cisco-wrlinux-7-x86_64" do |plat|
     "make",
     "pkgconfig",
     "pl-cmake",
-    "pl-gcc",
     "readline-devel",
     "zlib-devel",
   ]


### PR DESCRIPTION
This PR fixes the intermediate build failures for wrlinux-5.
Removing pl-gcc should not impact our build process because it gets installed as a dependency for pl-cmake.