### PR TITLE
(maint) enable pl-gcc on wrlinux-7

### DIFF
--- a/configs/platforms/cisco-wrlinux-7-x86_64.rb
+++ b/configs/platforms/cisco-wrlinux-7-x86_64.rb
@@ -9,6 +9,7 @@ platform "cisco-wrlinux-7-x86_64" do |plat|
     "make",
     "pkgconfig",
     "pl-cmake",
+    "pl-gcc",
     "readline-devel",
     "zlib-devel",
   ]


### PR DESCRIPTION
It seems like pl-cmake for wrlinux-7 does not have a dependency on pl-gcc. 
This PR re-enables pl-gcc for wrlinux-7