### PR TITLE
(BOLT-1026) Replace trollop with optimist for hiera-eyaml 0.3.x

### DIFF
--- a/configs/projects/agent-runtime-6.0.x.rb
+++ b/configs/projects/agent-runtime-6.0.x.rb
@@ -30,7 +30,6 @@ project 'agent-runtime-6.0.x' do |proj|
   proj.component 'rubygem-multi_json'
   proj.component 'rubygem-optimist'
   proj.component 'rubygem-highline'
-  proj.component 'rubygem-trollop'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'rubygem-httpclient'
   # SLES 15 uses the OS distro versions of boost and yaml-cpp:


### PR DESCRIPTION
The original PR ( https://github.com/puppetlabs/puppet-runtime/pull/154 )to replace trollop missed removing the dependency from puppet-agent6.x. This removes it.