### PR TITLE
(BOLT-1244) Include SELinux in bolt-runtime

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -5,6 +5,7 @@ project 'bolt-runtime' do |proj|
   proj.setting(:openssl_version, '1.1.1')
   proj.setting(:rubygem_net_ssh_version, '5.2.0')
   proj.setting(:rubygem_minitar_version, '0.8')
+  proj.setting(:augeas_version, '1.11.0')
   platform = proj.get_platform
 
   proj.version_from_git
@@ -112,6 +113,7 @@ project 'bolt-runtime' do |proj|
   proj.component "ruby-#{proj.ruby_version}"
 
   # Puppet dependencies
+  proj.component 'rubygem-hocon'
   proj.component 'rubygem-deep-merge'
   proj.component 'rubygem-text'
   proj.component 'rubygem-locale'
@@ -139,6 +141,23 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-win32-process'
   proj.component 'rubygem-win32-security'
   proj.component 'rubygem-win32-service'
+
+  # Components from puppet-runtime included to support apply on localhost
+  # Only bundle SELinux gem for RHEL,Centos,Fedora
+  if platform.is_el? || platform.is_fedora?
+    proj.component 'ruby-selinux'
+  end
+
+  # Non-windows specific components
+  unless platform.is_windows?
+    # C Augeas + deps
+    proj.component 'augeas'
+    proj.component 'libxml2'
+    proj.component 'libxslt'
+    # Ruby Augeas and shadow
+    proj.component 'ruby-augeas'
+    proj.component 'ruby-shadow'
+  end
 
   # What to include in package?
   proj.directory proj.prefix


### PR DESCRIPTION
Including selinux will help support using bolt's puppet on localhost instead of relying on agent.