### PR TITLE
(maint) Remove win32-eventlog from modern agents

### DIFF
--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -51,7 +51,6 @@ if platform.is_windows?
   proj.component 'rubygem-win32-process'
   proj.component 'rubygem-win32-security'
   proj.component 'rubygem-win32-service'
-  proj.component 'rubygem-win32-eventlog'
 end
 
 if platform.is_windows? || platform.is_solaris?

--- a/configs/projects/agent-runtime-1.10.x.rb
+++ b/configs/projects/agent-runtime-1.10.x.rb
@@ -57,4 +57,5 @@ project 'agent-runtime-1.10.x' do |proj|
 
   proj.component 'rubygem-gettext-setup'
   proj.component 'ruby-stomp'
+  proj.component 'rubygem-win32-eventlog' if platform.is_windows?
 end


### PR DESCRIPTION
According to PA-1129 / PUP-5756 we dont need this gem anymore. This commit removes it from shared agent components and only adds it to 1.10.x runtime.