### PR TITLE
(RE-12368) Update OpenSSL 1.0.2 to OpenSSL 1.0.2r

### DIFF
--- a/configs/components/openssl-1.0.2.rb
+++ b/configs/components/openssl-1.0.2.rb
@@ -1,6 +1,6 @@
 component 'openssl' do |pkg, settings, platform|
-  pkg.version '1.0.2n'
-  pkg.md5sum '13bdc1b1d1ff39b6fd42a255e74676a4'
+  pkg.version '1.0.2r'
+  pkg.md5sum '0d2baaf04c56d542f6cc757b9c2a2aac'
   pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/openssl-#{pkg.get_version}.tar.gz"
 


### PR DESCRIPTION
This will address some CVE fixes. See
https://www.openssl.org/news/vulnerabilities.html.