### PR TITLE
(BOLT-126) Upgrade winrm gem to 2.3.2

### DIFF
--- a/configs/components/rubygem-winrm.rb
+++ b/configs/components/rubygem-winrm.rb
@@ -1,6 +1,6 @@
 component 'rubygem-winrm' do |pkg, settings, platform|
-  pkg.version '2.3.0'
-  pkg.md5sum '884f5a5d2cd8e49e5eca8f79694bcfd3'
+  pkg.version '2.3.2'
+  pkg.md5sum '543925c13da3c3e46bf489a8b4795322'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
 - WinRM gem 2.3.2 is necessary to enable Kerberos. Earlier versions of
   the gem contained a bug with decrypting Kerberos payloads that would
   result in decryption failures / corruptions about 10% of the time.

   10% of the time is enough to make Kerberos completely unusable.

   See https://github.com/WinRb/WinRM/pull/302 for more info

Artifact is already published in Artifactory at:

https://artifactory.delivery.puppetlabs.net/artifactory/webapp/#/artifacts/browse/tree/General/rubygems__remote-cache/gems/winrm-2.3.2.gem