### PR TITLE
(ORCH-2296) Create pe-bolt-server 2019.{1,2}.x projects

### DIFF
--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -1,0 +1,126 @@
+# This "project" is a common basis for all pe-bolt-server branches. It should
+# not be built on its own. Instead, other project files should load it with
+# instance_eval. See configs/projects/pe-bolt-server-runtime-<branchname>.rb
+# for branch-specific details.
+unless defined?(proj)
+  warn("'#{File.basename(__FILE__)}' is a set of basic configuration values" \
+       " shared by all pe-bolt-server projects; It cannot be built as a" \
+       " standalone project.")
+  warn("Please choose one of the other pe-bolt-server projects instead.")
+  exit(1)
+end
+
+pe_version = settings[:pe_version]
+unless pe_version && !pe_version.empty?
+  warn("You must set the `pe_version` setting in your pe-bolt-server project" \
+       " file before instance_eval'ing '#{File.basename(__FILE__)}'. This should" \
+       " be an x.y version like '2019.1' or similar.")
+  exit(1)
+end
+
+proj.description('The PE Bolt runtime contains third-party components needed for PE Bolt server packaging')
+proj.license('See components')
+proj.vendor('Puppet, Inc.  <info@puppet.com>')
+proj.homepage('https://puppet.com')
+proj.identifier('com.puppetlabs')
+proj.version_from_git
+proj.generate_archives(true)
+proj.generate_packages(false)
+
+proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
+proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
+
+# This setting can be used sparingly in component configurations to conditionally include dependencies:
+proj.setting(:runtime_project, 'pe-bolt-server')
+
+# Set desired versions for gem components that offer multiple versions:
+proj.setting(:rubygem_minitar_version, '0.8')
+
+# (pe-bolt-server does not run on Windows, so only the *nix path is here)
+proj.setting(:prefix, '/opt/puppetlabs/server/apps/bolt-server')
+proj.setting(:bindir, File.join(proj.prefix, 'bin'))
+proj.setting(:libdir, File.join(proj.prefix, 'lib'))
+
+# pe-bolt-server's gems are built with puppet-agent's ruby installation, so
+# puppet-agent is installed as a build dependency. Here we Set the paths to
+# ruby executables so that they match puppet-agent's:
+proj.setting(:ruby_dir, '/opt/puppetlabs/puppet')  # this is puppet-agent's prefix
+proj.setting(:ruby_bindir, File.join(proj.ruby_dir, 'bin'))
+proj.setting(:host_ruby, File.join(proj.ruby_bindir, 'ruby'))
+proj.setting(:host_gem, File.join(proj.ruby_bindir, 'gem'))
+proj.setting(:gem_build, "#{proj.host_gem} build")
+
+# These gem_* paths are specific to pe-bolt-server -- they allow gems built for
+# this runtime to be installed to pe-bolt-server's paths instead of
+# puppet-agent's:
+proj.setting(:gem_install, "#{proj.host_gem} install --no-rdoc --no-ri --local --bindir=#{proj.bindir}")
+proj.setting(:gem_home, File.join(proj.libdir, 'ruby'))
+
+
+# What to build?
+# --------------
+
+# This component installs the puppet-agent build dependency:
+proj.component('runtime-pe-bolt-server')
+
+# R10k dependencies
+proj.component('rubygem-gettext-setup')
+
+# Core dependencies
+proj.component('rubygem-addressable')
+proj.component('rubygem-bcrypt_pbkdf')
+proj.component('rubygem-bindata')
+proj.component('rubygem-builder')
+proj.component('rubygem-CFPropertyList')
+proj.component('rubygem-colored')
+proj.component('rubygem-concurrent-ruby')
+proj.component('rubygem-connection_pool')
+proj.component('rubygem-cri')
+proj.component('rubygem-docker-api')
+proj.component('rubygem-ed25519')
+proj.component('rubygem-erubis')
+proj.component('rubygem-excon')
+proj.component('rubygem-facter')
+proj.component('rubygem-faraday')
+proj.component('rubygem-faraday_middleware')
+proj.component('rubygem-ffi')
+proj.component('rubygem-gssapi')
+proj.component('rubygem-gyoku')
+proj.component('rubygem-hiera')
+proj.component('rubygem-hocon')
+proj.component('rubygem-httpclient')
+proj.component('rubygem-little-plugger')
+proj.component('rubygem-log4r')
+proj.component('rubygem-logging')
+proj.component('rubygem-minitar')
+proj.component('rubygem-multipart-post')
+proj.component('rubygem-net-http-persistent')
+proj.component('rubygem-net-scp')
+proj.component('rubygem-nori')
+proj.component('rubygem-orchestrator_client')
+proj.component('rubygem-public_suffix')
+proj.component('rubygem-puppet')
+proj.component('rubygem-puppet_forge')
+proj.component('rubygem-puppet-resource_api')
+proj.component('rubygem-r10k')
+proj.component('rubygem-rubyntlm')
+proj.component('rubygem-ruby_smb')
+proj.component('rubygem-rubyzip')
+proj.component('rubygem-terminal-table')
+proj.component('rubygem-unicode-display_width')
+
+# Core Windows dependencies
+proj.component('rubygem-windows_error')
+proj.component('rubygem-winrm')
+proj.component('rubygem-winrm-fs')
+
+# Export the settings for the current project and platform as yaml during builds
+proj.publish_yaml_settings
+
+if platform.name =~ /^el-(8)-.*/
+  # Disable build-id generation since it's currently generating conflicts
+  # with system libgcc and libstdc++
+  proj.package_override("# Disable build-id generation to avoid conflicts\n%global _build_id_links none")
+end
+
+proj.directory(proj.prefix)

--- a/configs/projects/pe-bolt-server-runtime-2019.1.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2019.1.x.rb
@@ -1,5 +1,5 @@
-project 'pe-bolt-server-runtime-2019.0.x' do |proj|
-  proj.setting(:pe_version, '2019.0')
+project 'pe-bolt-server-runtime-2019.1.x' do |proj|
+  proj.setting(:pe_version, '2019.1')
 
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server.rb'))
 end

--- a/configs/projects/pe-bolt-server-runtime-2019.2.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2019.2.x.rb
@@ -1,5 +1,5 @@
-project 'pe-bolt-server-runtime-2019.0.x' do |proj|
-  proj.setting(:pe_version, '2019.0')
+project 'pe-bolt-server-runtime-2019.2.x' do |proj|
+  proj.setting(:pe_version, '2019.2')
 
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server.rb'))
 end


### PR DESCRIPTION
Extracts configuration from the 2019.0.x pe-bolt-server project that is
shared between all pe-bolt-server branches and moves it to a shared
_pe_bolt_server_shared component; Reuses that shared configuration in
two new projects for PE 2019.1.x (kearney) and 2019.2.x (lovejoy).