### PR TITLE
(ORCH-2296) Include net-ssh optional dependencies for *nix

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -112,6 +112,13 @@ project 'bolt-runtime' do |proj|
   proj.component "puppet-ca-bundle"
   proj.component "ruby-#{proj.ruby_version}"
 
+  # Building native gems on Windows has some issues right now.
+  # Include for non-Windows platforms only.
+  unless platform.is_windows?
+    proj.component 'rubygem-bcrypt_pbkdf'
+    proj.component 'rubygem-ed25519'
+  end
+
   # Puppet dependencies
   proj.component 'rubygem-hocon'
   proj.component 'rubygem-deep_merge'


### PR DESCRIPTION
The PR to transition the gems included in bolt-vanagon to bolt-runtime missed optionally including these gems on non-windows platforms.