### PR TITLE
(PUP-9573) Bump win32-service gem to 2.1.4

### DIFF
--- a/configs/components/rubygem-ffi-win32-extensions.rb
+++ b/configs/components/rubygem-ffi-win32-extensions.rb
@@ -1,0 +1,6 @@
+component "rubygem-ffi-win32-extensions" do |pkg, settings, platform|
+  pkg.version '1.0.3'
+  pkg.md5sum "4fa31ebfa5ecb8e490064696cd2af88c"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -1,6 +1,6 @@
 component "rubygem-win32-service" do |pkg, settings, platform|
-  pkg.version "0.8.8"
-  pkg.md5sum "24cc05fed398eb931e14b8ee22196634"
+  pkg.version "2.1.4"
+  pkg.md5sum "757db04649b7032ee5975467d81e43ab"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -47,6 +47,7 @@ proj.component 'rubygem-fast_gettext'
 
 if platform.is_windows?
   proj.component 'rubygem-ffi'
+  proj.component 'rubygem-ffi-win32-extensions'
   proj.component 'rubygem-win32-dir'
   proj.component 'rubygem-win32-process'
   proj.component 'rubygem-win32-security'

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -152,6 +152,7 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-faraday'
   proj.component 'rubygem-faraday_middleware'
   proj.component 'rubygem-ffi'
+  proj.component 'rubygem-ffi-win32-extensions'
   proj.component 'rubygem-gssapi'
   proj.component 'rubygem-gyoku'
   proj.component 'rubygem-hiera'
@@ -178,7 +179,7 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-terminal-table'
   proj.component 'rubygem-unicode-display_width'
 
-  # Core Windows dependencies
+  # Core Windows dependenciesq
   proj.component 'rubygem-win32-dir'
   proj.component 'rubygem-win32-process'
   proj.component 'rubygem-win32-security'


### PR DESCRIPTION
This also add a dependency to ffi-win32-extensions gem
which is needed by win32-service > 1.0.0