### PR TITLE
(PA-2191) winruby UTF8 Fallback for no CodePage

### DIFF
--- a/configs/components/ruby-2.4.5.rb
+++ b/configs/components/ruby-2.4.5.rb
@@ -68,6 +68,7 @@ component 'ruby-2.4.5' do |pkg, settings, platform|
     pkg.apply_patch "#{base}/update_rbinstall_for_windows.patch"
     pkg.apply_patch "#{base}/PA-1124_add_nano_server_com_support-8feb9779182bd4285f3881029fe850dac188c1ac.patch"
     pkg.apply_patch "#{base}/windows_socket_compat_error_r2.4.patch"
+    pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.4.patch"
   end
 
   ####################

--- a/configs/components/ruby-2.5.3.rb
+++ b/configs/components/ruby-2.5.3.rb
@@ -68,6 +68,7 @@ component 'ruby-2.5.3' do |pkg, settings, platform|
   if platform.is_windows?
     pkg.apply_patch "#{base}/windows_ruby_2.5_fixup_generated_batch_files.patch"
     pkg.apply_patch "#{base}/windows_socket_compat_error_r2.5.patch"
+    pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
   end
 
   ####################

--- a/resources/patches/ruby_245/windows_nocodepage_utf8_fallback_r2.4.patch
+++ b/resources/patches/ruby_245/windows_nocodepage_utf8_fallback_r2.4.patch
@@ -1,0 +1,27 @@
+2010/05/13 - John O'Connor, Puppet Inc.
+
+This patch to Ruby is necessary to handle languages/regions on windows
+where the codepage is not supported by Ruby such as Arabic which uses 
+codepage 720.
+If the codepage is not found, the Locale falls back to UTF8.
+This is a well known Ruby/Ruby on Rails issue which is described at
+https://stackoverflow.com/questions/22815542/rails4-unknown-encoding-name-cp720
+---
+
+diff --git a/ext/win32/lib/win32/registry.rb b/ext/win32/lib/win32/registry.rb
+index a88d7e63d0..87c8f87614 100644
+--- a/ext/win32/lib/win32/registry.rb
++++ b/ext/win32/lib/win32/registry.rb
+@@ -69,7 +69,11 @@ module Win32
+   WCHAR_NUL = "\0".encode(WCHAR).freeze
+   WCHAR_CR = "\r".encode(WCHAR).freeze
+   WCHAR_SIZE = WCHAR_NUL.bytesize
+-  LOCALE = Encoding.find(Encoding.locale_charmap)
++  begin
++    LOCALE = Encoding.find(Encoding.locale_charmap)
++  rescue ArgumentError
++    LOCALE = Encoding::UTF_8
++  end
+ 
+   class Registry
+ 

--- a/resources/patches/ruby_253/windows_nocodepage_utf8_fallback_r2.5.patch
+++ b/resources/patches/ruby_253/windows_nocodepage_utf8_fallback_r2.5.patch
@@ -1,0 +1,27 @@
+2010/05/13 - John O'Connor, Puppet Inc.
+
+This patch to Ruby is necessary to handle languages/regions on windows
+where the codepage is not supported by Ruby such as Arabic which uses 
+codepage 720.
+If the codepage is not found, the Locale falls back to UTF8.
+This is a well known Ruby/Ruby on Rails issue which is described at
+https://stackoverflow.com/questions/22815542/rails4-unknown-encoding-name-cp720
+---
+
+diff --git a/ext/win32/lib/win32/registry.rb b/ext/win32/lib/win32/registry.rb
+index ea04bb34bf..87c8f87614 100644
+--- a/ext/win32/lib/win32/registry.rb
++++ b/ext/win32/lib/win32/registry.rb
+@@ -69,7 +69,11 @@ module Win32
+   WCHAR_NUL = "\0".encode(WCHAR).freeze
+   WCHAR_CR = "\r".encode(WCHAR).freeze
+   WCHAR_SIZE = WCHAR_NUL.bytesize
+-  LOCALE = Encoding.find(Encoding.locale_charmap)
++  begin
++    LOCALE = Encoding.find(Encoding.locale_charmap)
++  rescue ArgumentError
++    LOCALE = Encoding::UTF_8
++  end
+ 
+   class Registry
+ 


### PR DESCRIPTION
This is to deal specifically with setting the Region to Arabic which
sets the codepage to 720. This codepage isn't recognises by Ruby which
causes it to fail during initialisation when setting up LOCALE.

So patch Ruby for Windows Only to Fallback to UTF for THIS ERROR ONLY.
This also applies to any other languages that use a codepage not
recognised by Ruby.