### PR TITLE
(CT-64) Build a pe-client-tools runtime for lovejoy

### DIFF
--- a/configs/projects/client-tools-runtime-lovejoy.rb
+++ b/configs/projects/client-tools-runtime-lovejoy.rb
@@ -1,0 +1,4 @@
+project 'client-tools-runtime-lovejoy' do |proj|
+  # Common settings
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-client-tools-runtime.rb'))
+end


### PR DESCRIPTION
The lovejoy runtime is currently the same as for kearney.