### PR TITLE
(PA-2677) Add Fedora 30 (amd64) to puppet-runtime

### DIFF
--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -40,7 +40,7 @@ if platform.is_cross_compiled_linux?
   ruby = "#{host_ruby} -r#{settings[:datadir]}/doc/rbconfig-#{ruby_version}-orig.rb"
 end
 
-cc = '/usr/bin/gcc' if platform.name =~ /fedora-29|el-8|debian-10/
+cc = '/usr/bin/gcc' if platform.name =~ /fedora-(29|30)|el-8|debian-10/
 
 pkg.build do
   [

--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -102,7 +102,7 @@ component "boost" do |pkg, settings, platform|
   else
     pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
     linkflags = "-Wl,-rpath=#{settings[:libdir]},-rpath=#{settings[:libdir]}64"
-    gpp = "/usr/bin/g++" if platform.name =~ /fedora-29|el-8|debian-10/
+    gpp = "/usr/bin/g++" if platform.name =~ /fedora-(29|30)|el-8|debian-10/
   end
 
   # Set user-config.jam

--- a/configs/components/ruby-2.4.5.rb
+++ b/configs/components/ruby-2.4.5.rb
@@ -203,7 +203,7 @@ component 'ruby-2.4.5' do |pkg, settings, platform|
     end
   elsif platform.is_windows?
     rbconfig_changes["CC"] = "x86_64-w64-mingw32-gcc"
-  elsif platform.name =~ /fedora-28|fedora-29|el-8|debian-10/
+  elsif platform.name =~ /fedora-(28|29|30)|el-8|debian-10/
     # When building ruby C extensions (in
     # ruby-augeas, for example) with Native GCC >= 8.0.1, mkmf will fail when ruby 2.4.5's
     # CONFIG['warnflags'] are applied to a conftest with -Werror before

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -23,7 +23,7 @@ component "runtime-agent" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
     pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
-  elsif platform.is_macos? || platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  elsif platform.is_macos? || platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # Nothing to see here
   elsif platform.is_windows?
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"

--- a/configs/components/runtime-bolt.rb
+++ b/configs/components/runtime-bolt.rb
@@ -13,7 +13,7 @@ component "runtime-bolt" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
-  elsif platform.is_macos? or platform.name =~ /sles-15|fedora-29|el-8/
+  elsif platform.is_macos? or platform.name =~ /sles-15|fedora-(29|30)|el-8/
 
     # Do nothing for distros that have a suitable compiler do not use pl-build-tools
 

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -23,7 +23,7 @@ component "yaml-cpp" do |pkg, settings, platform|
   elsif platform.is_macos?
     cmake_toolchain_file = ""
     cmake = "/usr/local/bin/cmake"
-  elsif platform.name =~ /fedora-29|el-8|debian-10/
+  elsif platform.name =~ /fedora-(29|30)|el-8|debian-10/
     cmake_toolchain_file = ''
     cmake = '/usr/bin/cmake'
   elsif platform.is_windows?

--- a/configs/platforms/fedora-30-x86_64.rb
+++ b/configs/platforms/fedora-30-x86_64.rb
@@ -1,0 +1,16 @@
+platform 'fedora-30-x86_64' do |plat|
+  plat.servicedir '/usr/lib/systemd/system'
+  plat.defaultdir '/etc/sysconfig'
+  plat.servicetype 'systemd'
+  plat.dist 'fc30'
+
+  packages = %w[
+    autoconf automake bzip2-devel gcc gcc-c++ libselinux-devel
+    libsepol libsepol-devel make cmake pkgconfig readline-devel
+    rpm-libs rpmdevtools rsync swig zlib-devel systemtap-sdt-devel
+  ]
+  plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+
+  plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
+  plat.vmpooler_template 'fedora-30-x86_64'
+end

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -39,6 +39,6 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'rubygem-highline'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'ruby-stomp'
-  proj.component 'yaml-cpp' if platform.name =~ /fedora-29|el-8|debian-10/ || platform.is_macos?
-  proj.component 'boost' if platform.name =~ /fedora-29|el-8|debian-10/ || platform.is_macos?
+  proj.component 'yaml-cpp' if platform.name =~ /fedora-(29|30)|el-8|debian-10/ || platform.is_macos?
+  proj.component 'boost' if platform.name =~ /fedora-(29|30)|el-8|debian-10/ || platform.is_macos?
 end


### PR DESCRIPTION
This commit adds support for Fedora 30 (without pl-build-tools)