### PR TITLE
(PDK-1358) Build pdk-runtime for el-8-x86_64

### DIFF
--- a/configs/components/git.rb
+++ b/configs/components/git.rb
@@ -42,6 +42,10 @@ component "git" do |pkg, settings, platform|
     ]
   end
 
+  if platform.name == 'el-8-x86_64'
+    build_deps.reject! { |r| r == 'dh-autoreconf' }
+  end
+
   build_deps.each do |dep|
     pkg.build_requires dep
   end

--- a/configs/components/runtime-pdk.rb
+++ b/configs/components/runtime-pdk.rb
@@ -33,7 +33,7 @@ component "runtime-pdk" do |pkg, settings, platform|
     # Do nothing
 
   else # Linux and Solaris systems
-    if platform.name =~ /fedora-29/
+    if platform.name =~ /(?:fedora-29|el-8)/
       # On newer linux platforms we are no longer using the pl-build-tools
       # package and instead relying on standard distribution versions of
       # gcc, etc.


### PR DESCRIPTION
Only a couple of minor changes needed to get pdk-runtime building on RHEL 8
 * Remove dh-autoreconf from the git build dependencies
 * Don't use pl-build-tools