### PR TITLE
(ct-66) Update curl to 7.65.1 to address CVEs

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -1,6 +1,6 @@
 component 'curl' do |pkg, settings, platform|
-  pkg.version '7.64.0'
-  pkg.md5sum 'a026740d599a32bcbbe6e70679397899'
+  pkg.version '7.65.1'
+  pkg.md5sum '6f31ec164741cc6aaac461d4b38ffdbe'
   pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/curl-#{pkg.get_version}.tar.gz"
 


### PR DESCRIPTION
See https://curl.haxx.se/changes.html for a full list of addressed
items in 7.65.1.