### PR TITLE
(PA-2479) use /run for pid if exists

### DIFF
--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -53,7 +53,11 @@ else
     proj.setting(:sysconfdir, "/etc/puppetlabs")
   end
   proj.setting(:logdir, "/var/log/puppetlabs")
-  proj.setting(:piddir, "/var/run/puppetlabs")
+  if platform.name =~ /sles-11|el-(5|6)|osx/
+    proj.setting(:piddir, "/var/run/puppetlabs")
+  else
+    proj.setting(:piddir, "/run/puppetlabs")
+  end
   proj.setting(:tmpfilesdir, "/usr/lib/tmpfiles.d")
 end
 


### PR DESCRIPTION
on new systemd based systems following warning is thrown when the system boots:
``` 
[/usr/lib/tmpfiles.d/puppet-agent.conf:1] Line references path below legacy directory /var/run/, updating /var/run/puppetlabs → /run/puppetlabs; please update the tmpfiles.d/ drop-in file accordingly.
```

This PR updates the piddir to be /run if the directory exists.
more info here: https://github.com/systemd/systemd/commit/a2d1fb882c4308bc10362d971f333c5031d60069
