### PR TITLE
(maint) Update gems that ship with bolt

### DIFF
--- a/configs/components/rubygem-deep_merge.rb
+++ b/configs/components/rubygem-deep_merge.rb
@@ -1,6 +1,16 @@
 component "rubygem-deep_merge" do |pkg, settings, platform|
-  pkg.version "1.0.1"
-  pkg.md5sum "6f30bc4727f1833410f6a508304ab3c1"
+  # Projects may define a :rubygem_deep_merge_version setting, or we use 1.0.1 by default:
+  version = settings[:rubygem_deep_merge_version] || '1.0.1'
+  pkg.version version
+
+  case version
+  when "1.0.1"
+    pkg.md5sum "6f30bc4727f1833410f6a508304ab3c1"
+  when "1.2.1"
+    pkg.md5sum "8d8396705375ac646454b1d64ad1239a"
+  else
+    raise "rubygem-deep_merge version #{version} has not been configured; Cannot continue."
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 

--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -1,6 +1,16 @@
 component "rubygem-gettext" do |pkg, settings, platform|
-  pkg.version "3.2.2"
-  pkg.md5sum "4cbb125f8d8206e9a8f3a90f6488e4da"
+  # Projects may define a :rubygem_gettext_version setting, or we use 3.2.2 by default:
+  version = settings[:rubygem_gettext_version] || '3.2.2'
+  pkg.version version
+
+  case version
+  when "3.2.2"
+    pkg.md5sum "4cbb125f8d8206e9a8f3a90f6488e4da"
+  when "3.2.9"
+    pkg.md5sum "09a755cd03ab617835e20a2e910581f4"
+  else
+    raise "rubygem-gettext version #{version} has not been configured; Cannot continue."
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-public_suffix.rb
+++ b/configs/components/rubygem-public_suffix.rb
@@ -1,6 +1,6 @@
 component 'rubygem-public_suffix' do |pkg, _settings, _platform|
-  pkg.version '3.1.0'
-  pkg.md5sum '51fd0abb35a8039341d8131598f845f5'
+  pkg.version '3.1.1'
+  pkg.md5sum 'df5c3a90582565bb91b035c771a58075'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet-resource_api.rb
+++ b/configs/components/rubygem-puppet-resource_api.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet-resource_api' do |pkg, settings, platform|
-  pkg.version '1.8.1'
-  pkg.md5sum 'e6c189b1610180ce0fbd6be5073e77e7'
+  pkg.version '1.8.4'
+  pkg.md5sum 'bc43e38b0a90638c959994f0223744f6'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
-  pkg.version '6.4.2'
-  pkg.md5sum '5ba04645242395e10d420cfeb3cd1d49'
+  pkg.version '6.6.0'
+  pkg.md5sum 'bc80b8ff8b92758d24fdc50f82121ff6'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-ruby_smb.rb
+++ b/configs/components/rubygem-ruby_smb.rb
@@ -1,6 +1,6 @@
 component 'rubygem-ruby_smb' do |pkg, settings, platform|
-  pkg.version '1.0.5'
-  pkg.md5sum '37fa07b0503066455695a8f8f86e516c'
+  pkg.version '1.1.0'
+  pkg.md5sum 'f926be4cb045b5984d02dc10e2b240ca'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -34,6 +34,9 @@ proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
 proj.setting(:runtime_project, 'pe-bolt-server')
 
 # Set desired versions for gem components that offer multiple versions:
+# TODO: Can runtime projects use these updated versions?
+proj.setting(:rubygem_gettext_version, '3.2.9')
+proj.setting(:rubygem_deep_merge_version, '1.2.1')
 proj.setting(:rubygem_minitar_version, '0.8')
 
 # (pe-bolt-server does not run on Windows, so only the *nix path is here)

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -4,8 +4,12 @@ project 'bolt-runtime' do |proj|
   proj.setting(:ruby_version, '2.5.3')
   proj.setting(:openssl_version, '1.1.1')
   proj.setting(:rubygem_net_ssh_version, '5.2.0')
-  proj.setting(:rubygem_minitar_version, '0.8')
   proj.setting(:augeas_version, '1.11.0')
+  # TODO: Can runtime projects use these updated versions?
+  proj.setting(:rubygem_gettext_version, '3.2.9')
+  proj.setting(:rubygem_deep_merge_version, '1.2.1')
+  proj.setting(:rubygem_minitar_version, '0.8')
+
   platform = proj.get_platform
 
   proj.version_from_git


### PR DESCRIPTION
Update gems that ship with bolt system packages. The most important update in this commit is the the latest puppet_resource-api which contains important bug fixes for supporting device modules.