### PR TITLE
Revert "(PA-2479) use /run for pid if exists"

### DIFF
--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -53,11 +53,7 @@ else
     proj.setting(:sysconfdir, "/etc/puppetlabs")
   end
   proj.setting(:logdir, "/var/log/puppetlabs")
-  if platform.name =~ /sles-11|el-(5|6)|osx/
-    proj.setting(:piddir, "/var/run/puppetlabs")
-  else
-    proj.setting(:piddir, "/run/puppetlabs")
-  end
+  proj.setting(:piddir, "/var/run/puppetlabs")
   proj.setting(:tmpfilesdir, "/usr/lib/tmpfiles.d")
 end
 


### PR DESCRIPTION
Reverts puppetlabs/puppet-runtime#189

Reverting this to further investigate the impact.