### PR TITLE
(maint) Update net-ssh dependency in pe-installer-runtime

### DIFF
--- a/configs/projects/pe-installer-runtime.rb
+++ b/configs/projects/pe-installer-runtime.rb
@@ -124,6 +124,8 @@ project 'pe-installer-runtime' do |proj|
   proj.component 'rubygem-ffi'
   proj.component 'rubygem-minitar'
   proj.component 'rubygem-multi_json'
+
+  proj.setting(:rubygem_net_ssh_version, '5.2.0')
   proj.component 'rubygem-net-ssh'
 
   # Core Windows dependencies


### PR DESCRIPTION
This commit updates the net-ssh gem dependency in pe-installer-runtime
from 4.2.0 to the more current 5.2.0. This change is motivated in
particular by the fact that this version update should allow the
installer's Bolt installation to respect known_hosts files as expected.