### PR TITLE
(PDK-1397) Build pdk-runtime on fedora 30

### DIFF
--- a/configs/components/runtime-pdk.rb
+++ b/configs/components/runtime-pdk.rb
@@ -33,7 +33,8 @@ component "runtime-pdk" do |pkg, settings, platform|
     # Do nothing
 
   else # Linux and Solaris systems
-    if platform.name =~ /(?:fedora-29|el-8)/
+    if (platform.is_fedora? && platform.os_version.to_i >= 29) ||
+        (platform.is_el? && platform.os_version.to_i >= 8)
       # On newer linux platforms we are no longer using the pl-build-tools
       # package and instead relying on standard distribution versions of
       # gcc, etc.


### PR DESCRIPTION
Changes this conditional so that we don't have to change it again for future fedora or rhel releases

https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppet-runtime/view/pdk-runtime/job/platform_pdk-runtime_runtime-vanagon-packaging_master/BUILD_TARGET=fedora-30-x86_64,SLAVE_LABEL=worker/95/console