### PR TITLE
(maint) Update net-ssh dependencies for pe-installer-runtime

### DIFF
--- a/configs/projects/pe-installer-runtime.rb
+++ b/configs/projects/pe-installer-runtime.rb
@@ -128,6 +128,14 @@ project 'pe-installer-runtime' do |proj|
   proj.setting(:rubygem_net_ssh_version, '5.2.0')
   proj.component 'rubygem-net-ssh'
 
+  # net-ssh dependencies for el8's OpenSSH default key format
+  # since we do not need these for Windows (`puppet infra run` does not work for Windows platforms),
+  #   and building these can finicky, don't install for Windows
+  unless platform.is_windows?
+    proj.component 'rubygem-bcrypt_pbkdf'
+    proj.component 'rubygem-ed25519'
+  end
+
   # Core Windows dependencies
   proj.component 'rubygem-win32-dir'
   proj.component 'rubygem-win32-process'


### PR DESCRIPTION
This commit updates the dependencies for pe-installer-runtime, so that
net-ssh is able to properly handle the new default format for private
keys shipped in the version of OpenSSH that comes as the default on el8
platforms. This is (again, unfortunately) for our version of Bolt, which
isn't installed as a package and as such does not come with some of the
handy dependencies that should be present.