### PR TITLE
(maint) Add aws-sdk-ec2 gem to bolt projects

### DIFF
--- a/configs/components/rubygem-aws-eventstream.rb
+++ b/configs/components/rubygem-aws-eventstream.rb
@@ -1,0 +1,6 @@
+component "rubygem-aws-eventstream" do |pkg, settings, platform|
+  pkg.version "1.0.3"
+  pkg.md5sum "cf77589b3608786511a827d402c8a260"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,0 +1,6 @@
+component "rubygem-aws-partitions" do |pkg, settings, platform|
+  pkg.version "1.188.0"
+  pkg.md5sum "9814fe76b4de8158f255dd678cd3ff12"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,0 +1,6 @@
+component "rubygem-aws-sdk-core" do |pkg, settings, platform|
+  pkg.version "3.59.0"
+  pkg.md5sum "2574a5c354d515e37e0eec35ed98dda4"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,0 +1,6 @@
+component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
+  pkg.version "1.99.0"
+  pkg.md5sum "f4803000aa22776db7cfb4692cc595f8"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-aws-sigv4.rb
+++ b/configs/components/rubygem-aws-sigv4.rb
@@ -1,0 +1,6 @@
+component "rubygem-aws-sigv4" do |pkg, settings, platform|
+  pkg.version "1.1.0"
+  pkg.md5sum "f51d0073cbe030a489674374b24760d4"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-jmespath.rb
+++ b/configs/components/rubygem-jmespath.rb
@@ -1,0 +1,6 @@
+component "rubygem-jmespath" do |pkg, settings, platform|
+  pkg.version "1.4.0"
+  pkg.md5sum "16b17ebb02e229dd83138df36d6f2470"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -71,6 +71,11 @@ proj.component('rubygem-gettext-setup')
 
 # Core dependencies
 proj.component('rubygem-addressable')
+proj.component 'rubygem-aws-eventstream'
+proj.component 'rubygem-aws-partitions'
+proj.component 'rubygem-aws-sdk-core'
+proj.component 'rubygem-aws-sdk-ec2'
+proj.component 'rubygem-aws-sigv4'
 proj.component('rubygem-bcrypt_pbkdf')
 proj.component('rubygem-bindata')
 proj.component('rubygem-builder')
@@ -92,6 +97,7 @@ proj.component('rubygem-gyoku')
 proj.component('rubygem-hiera')
 proj.component('rubygem-hocon')
 proj.component('rubygem-httpclient')
+proj.component 'rubygem-jmespath'
 proj.component('rubygem-little-plugger')
 proj.component('rubygem-log4r')
 proj.component('rubygem-logging')

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -142,6 +142,11 @@ project 'bolt-runtime' do |proj|
 
   # Core dependencies
   proj.component 'rubygem-addressable'
+  proj.component 'rubygem-aws-eventstream'
+  proj.component 'rubygem-aws-partitions'
+  proj.component 'rubygem-aws-sdk-core'
+  proj.component 'rubygem-aws-sdk-ec2'
+  proj.component 'rubygem-aws-sigv4'
   proj.component 'rubygem-bindata'
   proj.component 'rubygem-builder'
   proj.component 'rubygem-CFPropertyList'
@@ -160,6 +165,7 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-gyoku'
   proj.component 'rubygem-hiera'
   proj.component 'rubygem-httpclient'
+  proj.component 'rubygem-jmespath'
   proj.component 'rubygem-little-plugger'
   proj.component 'rubygem-log4r'
   proj.component 'rubygem-logging'


### PR DESCRIPTION
We now depend on the aws-sdk-ec2 gem, as of
https://github.com/puppetlabs/bolt/pull/1073, which requires adding it
and it's dependencies to the bolt-runtime and pe-bolt-server-runtime