### PR TITLE
(maint) Specify all Docker lints as data for Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ pool:
 variables:
   NAMESPACE: puppet
   CONTAINER_NAME: puppet-runtime
+  LINT_IGNORES: DL3008 DL3018 DL4000 DL4001
 
 steps:
 - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
@@ -38,7 +39,7 @@ steps:
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
-    Lint-Dockerfile -Name $ENV:CONTAINER_NAME
+    Lint-Dockerfile -Name $ENV:CONTAINER_NAME -Ignore ($ENV:LINT_IGNORES -split ' ')
   displayName: Lint $(CONTAINER_NAME) Dockerfile
   name: lint_dockerfile
 


### PR DESCRIPTION
 - Don't rely on defaults for Lint-Dockerfile as they will be removed.
   Instead, specify all explicitly.

   This further standardizes the YAML