### PR TITLE
(maint) Added openjdk 11 for ubuntu 18.04

### DIFF
--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -16,7 +16,8 @@ platform "ubuntu-18.04-amd64" do |plat|
     "pl-cmake",
     "pl-gcc",
     "zlib1g-dev",
-    "systemtap-sdt-dev"
+    "systemtap-sdt-dev",
+    "openjdk-11-jdk"
   ]
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends #{packages.join(' ')}"


### PR DESCRIPTION
This adds open jdk 11 that is needed to use java ca ceterificates using keytool