### PR TITLE
(PA-2849) Raise EOFError if less than Content-Length bytes downloaded

### DIFF
--- a/configs/components/ruby-2.4.5.rb
+++ b/configs/components/ruby-2.4.5.rb
@@ -45,6 +45,8 @@ component 'ruby-2.4.5' do |pkg, settings, platform|
   # Patches for rubygems security fixes from March 2019.
   # See RE-12095 for more details.
   pkg.apply_patch "#{base}/cve-2019-8320_to_8325_r2.4.patch"
+  # Patch for https://bugs.ruby-lang.org/issues/14972
+  pkg.apply_patch "#{base}/net_http_eof_14972.patch"
 
   if platform.is_cross_compiled?
     pkg.apply_patch "#{base}/uri_generic_remove_safe_nav_operator_r2.4.patch"

--- a/configs/components/ruby-2.5.3.rb
+++ b/configs/components/ruby-2.5.3.rb
@@ -43,6 +43,8 @@ component 'ruby-2.5.3' do |pkg, settings, platform|
   # Patches for rubygems security fixes from March 2019.
   # See RE-12095 for more details.
   pkg.apply_patch "#{base}/cve-2019-8320_to_8325_r2.5.patch"
+  # Patch for https://bugs.ruby-lang.org/issues/14972
+  pkg.apply_patch "#{base}/net_http_eof_14972.patch"
 
   if platform.is_cross_compiled?
     pkg.apply_patch "#{base}/uri_generic_remove_safe_nav_operator_r2.5.patch"

--- a/resources/patches/ruby_245/net_http_eof_14972.patch
+++ b/resources/patches/ruby_245/net_http_eof_14972.patch
@@ -1,0 +1,49 @@
+commit 615565a92519a83ff8433e7667c620505ba57f66
+Author: Josh Cooper <josh@puppet.com>
+Date:   Tue Jan 22 15:24:55 2019 -0800
+
+    Raise EOF if response body content length is known
+    
+    If response body content length is known, then read the complete
+    response body or raise EOF if it is truncated.
+    
+    [Bug #14972][ruby-core:88324]
+
+diff --git a/lib/net/http/response.rb b/lib/net/http/response.rb
+index 66132985d9..7c744d02f4 100644
+--- a/lib/net/http/response.rb
++++ b/lib/net/http/response.rb
+@@ -290,7 +290,7 @@ def read_body_0(dest)
+ 
+       clen = content_length()
+       if clen
+-        @socket.read clen, dest, true   # ignore EOF
++        @socket.read clen, dest
+         return
+       end
+       clen = range_length()
+diff --git a/test/net/http/test_httpresponse.rb b/test/net/http/test_httpresponse.rb
+index a03bb2e152..9d00276514 100644
+--- a/test/net/http/test_httpresponse.rb
++++ b/test/net/http/test_httpresponse.rb
+@@ -457,6 +457,20 @@ def test_inspect_response
+     assert_equal '#<Net::HTTPUnknownResponse ??? test response readbody=true>', res.inspect
+   end
+ 
++  def test_raise_eof
++    io = dummy_io(<<EOS)
++HTTP/1.1 200
++Content-Length: 5
++Connection: close
++
++h
++EOS
++
++    res = Net::HTTPResponse.read_new(io)
++    assert_raise EOFError do
++      res.reading_body(io, true) {}
++    end
++  end
+ private
+ 
+   def dummy_io(str)

--- a/resources/patches/ruby_253/net_http_eof_14972.patch
+++ b/resources/patches/ruby_253/net_http_eof_14972.patch
@@ -1,0 +1,49 @@
+commit 615565a92519a83ff8433e7667c620505ba57f66
+Author: Josh Cooper <josh@puppet.com>
+Date:   Tue Jan 22 15:24:55 2019 -0800
+
+    Raise EOF if response body content length is known
+    
+    If response body content length is known, then read the complete
+    response body or raise EOF if it is truncated.
+    
+    [Bug #14972][ruby-core:88324]
+
+diff --git a/lib/net/http/response.rb b/lib/net/http/response.rb
+index 66132985d9..7c744d02f4 100644
+--- a/lib/net/http/response.rb
++++ b/lib/net/http/response.rb
+@@ -290,7 +290,7 @@ def read_body_0(dest)
+ 
+       clen = content_length()
+       if clen
+-        @socket.read clen, dest, true   # ignore EOF
++        @socket.read clen, dest
+         return
+       end
+       clen = range_length()
+diff --git a/test/net/http/test_httpresponse.rb b/test/net/http/test_httpresponse.rb
+index a03bb2e152..9d00276514 100644
+--- a/test/net/http/test_httpresponse.rb
++++ b/test/net/http/test_httpresponse.rb
+@@ -457,6 +457,20 @@ def test_inspect_response
+     assert_equal '#<Net::HTTPUnknownResponse ??? test response readbody=true>', res.inspect
+   end
+ 
++  def test_raise_eof
++    io = dummy_io(<<EOS)
++HTTP/1.1 200
++Content-Length: 5
++Connection: close
++
++h
++EOS
++
++    res = Net::HTTPResponse.read_new(io)
++    assert_raise EOFError do
++      res.reading_body(io, true) {}
++    end
++  end
+ private
+ 
+   def dummy_io(str)


### PR DESCRIPTION
Net::HTTP has a bug where it will silently ignore EOF if it downloads
fewer than <Content-Length> bytes[1]. Patch ruby 2.4 and 2.5 on all
platforms. This is the same as the upstream PR[2].

[1] https://bugs.ruby-lang.org/issues/14972
[2] https://github.com/ruby/ruby/pull/2074