### PR TITLE
(PA-2849) Raise EOFError if less than Content-Length bytes downloaded

### DIFF
--- a/configs/components/ruby-2.4.5.rb
+++ b/configs/components/ruby-2.4.5.rb
@@ -45,6 +45,8 @@ component 'ruby-2.4.5' do |pkg, settings, platform|
   # Patches for rubygems security fixes from March 2019.
   # See RE-12095 for more details.
   pkg.apply_patch "#{base}/cve-2019-8320_to_8325_r2.4.patch"
+  # Patch for https://bugs.ruby-lang.org/issues/14972
+  pkg.apply_patch "#{base}/net_http_eof_14972.patch"
 
   if platform.is_cross_compiled?
     pkg.apply_patch "#{base}/uri_generic_remove_safe_nav_operator_r2.4.patch"

--- a/configs/components/ruby-2.5.3.rb
+++ b/configs/components/ruby-2.5.3.rb
@@ -43,6 +43,8 @@ component 'ruby-2.5.3' do |pkg, settings, platform|
   # Patches for rubygems security fixes from March 2019.
   # See RE-12095 for more details.
   pkg.apply_patch "#{base}/cve-2019-8320_to_8325_r2.5.patch"
+  # Patch for https://bugs.ruby-lang.org/issues/14972
+  pkg.apply_patch "#{base}/net_http_eof_14972.patch"
 
   if platform.is_cross_compiled?
     pkg.apply_patch "#{base}/uri_generic_remove_safe_nav_operator_r2.5.patch"

--- a/resources/patches/ruby_245/net_http_eof_14972.patch
+++ b/resources/patches/ruby_245/net_http_eof_14972.patch
@@ -1,0 +1,53 @@
+From b5e6290e109cb9a2ad005e9537157921f191e0d8 Mon Sep 17 00:00:00 2001
+From: Josh Cooper <josh@puppet.com>
+Date: Mon, 19 Aug 2019 15:08:37 -0700
+Subject: [PATCH] (PA-2849) Raise EOF if response body content length is known
+
+If response body content length is known, then read the complete response body
+or raise EOF if it is truncated.
+
+[Bug #14972][ruby-core:88324]
+---
+ lib/net/http/response.rb           |  2 +-
+ test/net/http/test_httpresponse.rb | 15 +++++++++++++++
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/lib/net/http/response.rb b/lib/net/http/response.rb
+index 1351d7b..9f6c2a3 100644
+--- a/lib/net/http/response.rb
++++ b/lib/net/http/response.rb
+@@ -290,7 +290,7 @@ def read_body_0(dest)
+ 
+       clen = content_length()
+       if clen
+-        @socket.read clen, dest, true   # ignore EOF
++        @socket.read clen, dest
+         return
+       end
+       clen = range_length()
+diff --git a/test/net/http/test_httpresponse.rb b/test/net/http/test_httpresponse.rb
+index a67add7..ff6a824 100644
+--- a/test/net/http/test_httpresponse.rb
++++ b/test/net/http/test_httpresponse.rb
+@@ -401,6 +401,21 @@ def test_raises_exception_with_missing_reason
+     end
+   end
+ 
++  def test_raise_eof
++    io = dummy_io(<<EOS)
++HTTP/1.1 200
++Content-Length: 5
++Connection: close
++
++h
++EOS
++
++    res = Net::HTTPResponse.read_new(io)
++    assert_raise EOFError do
++      res.reading_body(io, true) {}
++    end
++  end
++
+ private
+ 
+   def dummy_io(str)

--- a/resources/patches/ruby_253/net_http_eof_14972.patch
+++ b/resources/patches/ruby_253/net_http_eof_14972.patch
@@ -1,0 +1,53 @@
+From d4d9d38216ce339a63e9ecb277f9ee3046876d93 Mon Sep 17 00:00:00 2001
+From: Josh Cooper <josh@puppet.com>
+Date: Mon, 19 Aug 2019 14:47:07 -0700
+Subject: [PATCH] (PA-2849) Raise EOF if response body content length is known
+
+If response body content length is known, then read the complete response body
+or raise EOF if it is truncated.
+
+[Bug #14972][ruby-core:88324]
+---
+ lib/net/http/response.rb           |  2 +-
+ test/net/http/test_httpresponse.rb | 15 +++++++++++++++
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/lib/net/http/response.rb b/lib/net/http/response.rb
+index 6a78272..c36c8a2 100644
+--- a/lib/net/http/response.rb
++++ b/lib/net/http/response.rb
+@@ -290,7 +290,7 @@ def read_body_0(dest)
+ 
+       clen = content_length()
+       if clen
+-        @socket.read clen, dest, true   # ignore EOF
++        @socket.read clen, dest
+         return
+       end
+       clen = range_length()
+diff --git a/test/net/http/test_httpresponse.rb b/test/net/http/test_httpresponse.rb
+index d99c361..18c6718 100644
+--- a/test/net/http/test_httpresponse.rb
++++ b/test/net/http/test_httpresponse.rb
+@@ -427,6 +427,21 @@ def test_raises_exception_with_missing_reason
+     end
+   end
+ 
++  def test_raise_eof
++    io = dummy_io(<<EOS)
++HTTP/1.1 200
++Content-Length: 5
++Connection: close
++
++h
++EOS
++
++    res = Net::HTTPResponse.read_new(io)
++    assert_raise EOFError do
++      res.reading_body(io, true) {}
++    end
++  end
++
+ private
+ 
+   def dummy_io(str)


### PR DESCRIPTION
The patch for Net::HTTP was based off of ruby#master and did not apply cleanly
to older branches. Redo each patch based on ruby 2.4.5 and 2.5.3. Also use `git
format-patch --no-signature` to match other puppet-runtime patches.