### PR TITLE
(PE-27107) Update pe-bolt-server runtime honor FIPS

### DIFF
--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -18,6 +18,11 @@ unless pe_version && !pe_version.empty?
   exit(1)
 end
 
+if platform.name =~ /^redhatfips-7-.*/
+  # Link against the system openssl instead of our vendored version:
+  proj.setting(:system_openssl, true)
+end
+
 proj.description('The PE Bolt runtime contains third-party components needed for PE Bolt server packaging')
 proj.license('See components')
 proj.vendor('Puppet, Inc.  <info@puppet.com>')


### PR DESCRIPTION
This commit updates the pe-bolt-server base config to set the :system_openssl
setting to true on redhatfips platforms.