### PR TITLE
(PA-2864) Add concurrent-ruby to agent runtime

### DIFF
--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -27,6 +27,7 @@ project 'agent-runtime-master' do |proj|
   # Components specific to the master branch
   ########
 
+  proj.component 'rubygem-concurrent-ruby'
   proj.component 'rubygem-multi_json'
   proj.component 'rubygem-optimist'
   proj.component 'rubygem-highline'


### PR DESCRIPTION
Only on master as this is only used in current puppet master branch