### PR TITLE
(PA-2864) Set GEM_HOME for concurrent

### DIFF
--- a/configs/components/rubygem-concurrent-ruby.rb
+++ b/configs/components/rubygem-concurrent-ruby.rb
@@ -3,4 +3,6 @@ component 'rubygem-concurrent-ruby' do |pkg, settings, platform|
   pkg.md5sum '4409c2d6925d8448cb34a947eacaa29b'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
+
+  pkg.environment "GEM_HOME", (settings[:puppet_gem_vendor_dir] || settings[:gem_home])
 end


### PR DESCRIPTION
When building the agent runtime we want this setting so the gem is in a location
that will be read by jruby. Since bolt doesn't set puppet_gem_vendor_dir it
should be unaffected.