### PR TITLE
Revert "(PA-2864) Set GEM_HOME for concurrent"

### DIFF
--- a/configs/components/rubygem-concurrent-ruby.rb
+++ b/configs/components/rubygem-concurrent-ruby.rb
@@ -3,6 +3,4 @@ component 'rubygem-concurrent-ruby' do |pkg, settings, platform|
   pkg.md5sum '4409c2d6925d8448cb34a947eacaa29b'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
-
-  pkg.environment "GEM_HOME", (settings[:puppet_gem_vendor_dir] || settings[:gem_home])
 end


### PR DESCRIPTION
Reverts puppetlabs/puppet-runtime#216

The `concurrent-ruby` gem has native extensions, so we need to keep installing two separate versions of it, one for MRI and one for JRuby.