### PR TITLE
(PUP-10013) Update minitar to 0.9

### DIFF
--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -1,16 +1,6 @@
-component "rubygem-minitar" do |pkg, settings, platform|
-  # Projects may define a :rubygem_minitar_version setting, or we use 0.6.1 by default:
-  version = settings[:rubygem_minitar_version] || '0.6.1'
-  pkg.version version
-
-  case version
-  when "0.6.1"
-    pkg.md5sum "ce4ee63a94e80fb4e3e66b54b995beaa"
-  when "0.8"
-    pkg.md5sum "af220249c7dfe1774de3a81da4bb21d7"
-  else
-    raise "rubygem-minitar version #{version} has not been configured; Cannot continue."
-  end
+component 'rubygem-minitar' do |pkg, settings, platform|
+  pkg.version '0.9'
+  pkg.md5sum '4ab2c278183c9a83f3ad97066c381d84'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -42,7 +42,6 @@ proj.setting(:runtime_project, 'pe-bolt-server')
 # TODO: Can runtime projects use these updated versions?
 proj.setting(:rubygem_gettext_version, '3.2.9')
 proj.setting(:rubygem_deep_merge_version, '1.2.1')
-proj.setting(:rubygem_minitar_version, '0.8')
 
 # (pe-bolt-server does not run on Windows, so only the *nix path is here)
 proj.setting(:prefix, '/opt/puppetlabs/server/apps/bolt-server')

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -8,7 +8,6 @@ project 'bolt-runtime' do |proj|
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_gettext_version, '3.2.9')
   proj.setting(:rubygem_deep_merge_version, '1.2.1')
-  proj.setting(:rubygem_minitar_version, '0.8')
 
   platform = proj.get_platform
 


### PR DESCRIPTION
We can use the new options hash in minitar 0.9 to set `fsync=false`which should speed things up for folks