### PR TITLE
(PA-2860) Fix ruby-augeas Artifactory mirror URL

### DIFF
--- a/configs/components/_base-ruby-augeas.rb
+++ b/configs/components/_base-ruby-augeas.rb
@@ -12,7 +12,7 @@ ruby_bindir ||= settings[:ruby_bindir]
 pkg.version "0.5.0"
 pkg.md5sum "a132eace43ce13ccd059e22c0b1188ac"
 pkg.url "http://download.augeas.net/ruby/ruby-augeas-#{pkg.get_version}.tgz"
-pkg.mirror "#{settings[:buildsources_url]}/ruby-augeas-#{pkg.get_version}.tar.gz"
+pkg.mirror "#{settings[:buildsources_url]}/ruby-augeas-#{pkg.get_version}.tgz"
 
 pkg.build_requires "ruby-#{ruby_version}"
 pkg.build_requires "augeas"


### PR DESCRIPTION
ruby-augeas has a filename mismatch between what it's looking for in Artifactory and the actual filename that it pulls from upstream (actual filename has .tgz extension, it's trying to pull .tar.gz from Artifactory, but it doesn't exist)

```
Attempting to fetch from mirror URL "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/ruby-augeas-0.5.0.tar.gz"
--
Downloading file 'ruby-augeas-0.5.0.tar.gz' from url 'https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/ruby-augeas-0.5.0.tar.gz'
Unable to retrieve mirror URL "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/ruby-augeas-0.5.0.tar.gz"
Attempting to fetch from canonical URL "http://download.augeas.net/ruby/ruby-augeas-0.5.0.tgz"
Downloading file 'ruby-augeas-0.5.0.tgz' from url 'http://download.augeas.net/ruby/ruby-augeas-0.5.0.tgz'
Verifying file: ruby-augeas-0.5.0.tgz against sum: 'a132eace43ce13ccd059e22c0b1188ac'
```