### PR TITLE
(PE-26585) Add logic for using correct openssl for FIPS

### DIFF
--- a/configs/projects/pe-installer-runtime.rb
+++ b/configs/projects/pe-installer-runtime.rb
@@ -102,9 +102,16 @@ project 'pe-installer-runtime' do |proj|
 
   # What to build?
   # --------------
+  #
+  if platform.name =~ /^redhatfips-7-.*/
+    # Link against the system openssl instead of our vendored version.
+    # This is also used by components within this vanagon project (i.e. curl, ruby, ca-bundle)
+    proj.setting(:system_openssl, true)
+  else
+    proj.component "openssl-#{proj.openssl_version}"
+  end
 
   # Ruby and deps
-  proj.component "openssl-#{proj.openssl_version}"
   proj.component "runtime-pe-installer"
   proj.component "puppet-ca-bundle"
   proj.component "ruby-#{proj.ruby_version}"


### PR DESCRIPTION
This pr links FIPS boxes to use system openssl in contrast to the binaries that ship with puppet.