### PR TITLE
(packaging) Update gettext_setup gem across shared runtimes

### DIFF
--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -1,6 +1,6 @@
 component "rubygem-gettext-setup" do |pkg, settings, platform|
-  pkg.version "0.30"
-  pkg.md5sum "b7de0e7af0f56ddc55c88435ee95fd47"
+  pkg.version "0.31"
+  pkg.md5sum "529706bf23b9c796d1ccad790764c41e"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This commit updates the `gettext_setup` gem which is shared by multiple runtime projects.