### PR TITLE
(maint) Keep minitar in pdk-runtime at 0.6.1

### DIFF
--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -1,6 +1,16 @@
 component 'rubygem-minitar' do |pkg, settings, platform|
-  pkg.version '0.9'
-  pkg.md5sum '4ab2c278183c9a83f3ad97066c381d84'
+  version = settings[:rubygem_minitar_version] || '0.9'
+
+  pkg.version version
+
+  case version
+  when '0.6.1'
+    pkg.md5sum 'ce4ee63a94e80fb4e3e66b54b995beaa'
+  when '0.9'
+    pkg.md5sum '4ab2c278183c9a83f3ad97066c381d84'
+  else
+    raise "rubygem-minitar version #{version} has not been configured; Cannot continue."
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -49,6 +49,7 @@ project 'pdk-runtime' do |proj|
 
   proj.setting(:ruby_version, "2.4.7")
   proj.setting(:ruby_api, "2.4.0")
+  proj.setting(:rubygem_minitar_version, '0.6.1')
 
   # this is the latest puppet that will be installed into the default ruby version above
   # newer versions of puppet will be installed into the Ruby 2.5.6 runtime


### PR DESCRIPTION
PDK runtime has to be able to run older versions of Puppet. The mingw
Puppet gems have a runtime dependency of minitar ~> 0.6.1 which is not
satisfied by minitar 0.9.

This somewhat reverts the change in #220, but the default behaviour is
now to include minitar 0.9 (so that this does not affect any other
runtimes) and allowing PDK to opt in to minitar 0.6.1.

I realise that we'll have to update this before the next Puppet release to install both versions of minitar side by side, but that is less pressing at the moment.