### PR TITLE
(FACT-2027) Added thor as a dependency for agent-runtime

### DIFF
--- a/configs/components/rubygem-thor.rb
+++ b/configs/components/rubygem-thor.rb
@@ -1,0 +1,6 @@
+component 'rubygem-thor' do |pkg, settings, platform|
+  pkg.version '0.20.3'
+  pkg.md5sum '0370f18c27c9fb0983d53e4c69c4eb77'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -33,6 +33,7 @@ project 'agent-runtime-master' do |proj|
   proj.component 'rubygem-highline'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'rubygem-httpclient'
+  proj.component 'rubygem-thor'
   # SLES 15 uses the OS distro versions of boost and yaml-cpp:
   proj.component 'boost' unless platform.name =~ /sles-15/
   proj.component 'yaml-cpp' unless platform.name =~ /sles-15/


### PR DESCRIPTION
Thor gem is require by facter-ng.