### PR TITLE
(PE-27431) Do not build openssl on fips for client tools runtime

### DIFF
--- a/configs/projects/_shared-client-tools-runtime.rb
+++ b/configs/projects/_shared-client-tools-runtime.rb
@@ -8,6 +8,11 @@ end
 
 proj.setting(:runtime_project, 'client-tools')
 proj.setting(:openssl_version, '1.0.2')
+if platform.name =~ /^redhatfips-7-.*/
+  # Link against the system openssl instead of our vendored version:
+  proj.setting(:system_openssl, true)
+end
+
 
 proj.generate_archives true
 proj.generate_packages false
@@ -79,7 +84,9 @@ end
 
 # Common deps
 proj.component "runtime-client-tools"
-proj.component "openssl-#{proj.openssl_version}"
+unless platform.name =~ /^redhatfips-7-.*/
+  proj.component "openssl-#{proj.openssl_version}"
+end
 proj.component "curl"
 proj.component "puppet-ca-bundle"
 proj.component "libicu"


### PR DESCRIPTION
FIPS packages are required to use the system openssl package for SSL
operations, so this commit removes the vendored version in the client-tools
FIPS package