### PR TITLE
(maint) remove spec deletion on hocon gem install

### DIFF
--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -7,17 +7,4 @@ component "rubygem-hocon" do |pkg, settings, platform|
   # Overwrite the base rubygem's default GEM_HOME with the vendor gem directory
   # shared by puppet and puppetserver. Fall-back to gem_home for other projects.
   pkg.environment "GEM_HOME", (settings[:puppet_gem_vendor_dir] || settings[:gem_home])
-
-  # Special case for macOS:
-  if platform.is_macos?
-    # The normal installation step from the _base_rubygem component works fine
-    # here, but the unicode characters in one of the hocon gem's spec files
-    # will make tar blow up when extracting the runtime tarball on macOS if not
-    # using unicode. We don't need the spec files anyway, so remove them
-    # (note pkg.install is additive, so we're adding this command after the
-    # usual install step from _base_rubygem):
-    pkg.install do
-      "rm -rf #{settings[:gem_home]}/gems/hocon-#{pkg.get_version}/spec"
-    end
-  end
 end


### PR DESCRIPTION
https://github.com/puppetlabs/ruby-hocon/pull/115
removed spec shipping for hocon gem so this
workaround is not needed anymore.