### PR TITLE
(maint) bump hocon gem to 1.3.0

### DIFF
--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -1,6 +1,6 @@
 component "rubygem-hocon" do |pkg, settings, platform|
-  pkg.version "1.2.6"
-  pkg.md5sum "938b38e4029f024745cc9767ff0d94f4"
+  pkg.version "1.3.0"
+  pkg.md5sum "b76bcbc11fb2c76395d127a16d947645"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 


### PR DESCRIPTION
 - This release adds support for specifying lists with environment
   variables, which was necessary to support parameterizing the
   whitelist from bolt-server.conf in the Bolt docker container

   The pe-bolt-vanagon repo relies on loading the puppet-runtime
   configuration and hence uses this component definition for the
   hocon inclusion

Changelog for the diff between 1.2.6 and 1.3.0: https://github.com/puppetlabs/ruby-hocon/compare/1.2.6...1.3.0