### PR TITLE
(PA-2986) Update GCC compiler/linker flags

### DIFF
--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -40,7 +40,11 @@ if platform.is_cross_compiled_linux?
   ruby = "#{host_ruby} -r#{settings[:datadir]}/doc/rbconfig-#{ruby_version}-orig.rb"
 end
 
-cc = '/usr/bin/gcc' if platform.name =~ /fedora-(29|30)|el-8|debian-10/
+cflags = ""
+if platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+  cc = '/usr/bin/gcc'
+  cflags += "#{settings[:cppflags]} #{settings[:cflags]}"
+end
 
 pkg.build do
   [
@@ -50,8 +54,8 @@ pkg.build do
     "export INCLUDESTR=\"-I#{settings[:includedir]} -I$${RUBYHDRDIR} -I$${ARCHDIR}\"",
     "cp -pr src/{selinuxswig_ruby.i,selinuxswig.i} .",
     "swig -Wall -ruby #{system_include} -o selinuxswig_ruby_wrap.c -outdir ./ selinuxswig_ruby.i",
-    "#{cc} $${INCLUDESTR} #{system_include} -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC -DSHARED -c -o selinuxswig_ruby_wrap.lo selinuxswig_ruby_wrap.c",
-    "#{cc} $${INCLUDESTR} #{system_include} -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -shared -o _rubyselinux.so selinuxswig_ruby_wrap.lo -lselinux -Wl,-soname,_rubyselinux.so",
+    "#{cc} $${INCLUDESTR} #{system_include} #{cflags} -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC -DSHARED -c -o selinuxswig_ruby_wrap.lo selinuxswig_ruby_wrap.c",
+    "#{cc} $${INCLUDESTR} #{system_include} -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -shared -o _rubyselinux.so selinuxswig_ruby_wrap.lo -lselinux -Wl,-z,relro,-z,now,-soname,_rubyselinux.so",
   ]
 end
 

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -96,6 +96,12 @@ component 'augeas' do |pkg, settings, platform|
     pkg.environment "CFLAGS" => settings[:cflags]
   end
 
+  if platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+    pkg.environment 'CFLAGS', settings[:cflags]
+    pkg.environment 'CPPFLAGS', settings[:cppflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
+  end
+
   pkg.configure do
     ["./configure #{extra_config_flags} --prefix=#{settings[:prefix]} #{settings[:host]}"]
   end

--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -34,8 +34,8 @@ component "boost" do |pkg, settings, platform|
                                          'graph', 'graph_parallel', 'iostreams', 'locale', 'log', 'math',
                                          'program_options', 'random', 'regex', 'serialization', 'signals', 'system',
                                          'test', 'thread', 'timer', 'wave']
-  cflags = "-fPIC -std=c99"
-  cxxflags = "-std=c++11 -fPIC"
+  cflags = settings[:cflags] + " -fPIC -std=c99"
+  cxxflags = settings[:cflags] + " -std=c++11 -fPIC"
 
   # These are all places where windows differs from *nix. These are the default *nix settings.
   toolset = 'gcc'
@@ -99,10 +99,13 @@ component "boost" do |pkg, settings, platform|
   elsif platform.is_aix?
     pkg.environment "PATH" => "/opt/freeware/bin:/opt/pl-build-tools/bin:$(PATH)"
     linkflags = "-Wl,-L#{settings[:libdir]},-L/opt/pl-build-tools/lib"
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+    pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
+    linkflags = "#{settings[:ldflags]},-rpath=#{settings[:libdir]}64"
+    gpp = '/usr/bin/g++'
   else
     pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
     linkflags = "-Wl,-rpath=#{settings[:libdir]},-rpath=#{settings[:libdir]}64"
-    gpp = "/usr/bin/g++" if platform.name =~ /fedora-(29|30)|el-8|debian-10/
   end
 
   # Set user-config.jam

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -49,6 +49,7 @@ component 'curl' do |pkg, settings, platform|
         --disable-ldap \
         --disable-ldaps \
         --with-ca-bundle=#{settings[:prefix]}/ssl/cert.pem \
+        CFLAGS='#{settings[:cflags]}' \
         #{settings[:host]}"]
   end
 

--- a/configs/components/ruby-2.4.9.rb
+++ b/configs/components/ruby-2.4.9.rb
@@ -81,6 +81,10 @@ component 'ruby-2.4.9' do |pkg, settings, platform|
 
   special_flags = " --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
 
+  if platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+    special_flags += " CFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}' CPPFLAGS='#{settings[:cppflags]}' "
+  end
+
   if platform.is_aix?
     # This normalizes the build string to something like AIX 7.1.0.0 rather
     # than AIX 7.1.0.2 or something

--- a/configs/components/ruby-2.5.7.rb
+++ b/configs/components/ruby-2.5.7.rb
@@ -83,6 +83,10 @@ component 'ruby-2.5.7' do |pkg, settings, platform|
 
   special_flags = " --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
 
+  if platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+    special_flags += " CFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}' CPPFLAGS='#{settings[:cppflags]}' "
+  end
+
   if platform.is_aix?
     # This normalizes the build string to something like AIX 7.1.0.0 rather
     # than AIX 7.1.0.2 or something

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -23,7 +23,10 @@ component "yaml-cpp" do |pkg, settings, platform|
   elsif platform.is_macos?
     cmake_toolchain_file = ""
     cmake = "/usr/local/bin/cmake"
-  elsif platform.name =~ /fedora-(29|30)|el-8|debian-10/
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+    pkg.environment 'CPPFLAGS', settings[:cppflags]
+    pkg.environment 'CFLAGS', settings[:cflags]
+    pkg.environment 'LDFLAGS', settings[:ldflags]
     cmake_toolchain_file = ''
     cmake = '/usr/bin/cmake'
   elsif platform.is_windows?

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -158,6 +158,17 @@ proj.setting(:cflags, "#{proj.cppflags}")
 proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
 
 # Platform specific overrides or settings, which may override the defaults
+
+# Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
+# stack canary and full RELRO.
+# We only do this on platforms that use their default OS toolchain since pl-gcc versions
+# are too old to support these flags.
+if platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+  proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
+  proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
+  proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
+end
+
 if platform.is_windows?
   arch = platform.architecture == "x64" ? "64" : "32"
   proj.setting(:gcc_root, "C:/tools/mingw#{arch}")


### PR DESCRIPTION
Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support, stack canary and full RELRO.

We only do this on platforms that use their default OS toolchain since pl-gcc versions are too old to support these flags.

Dependent on https://github.com/puppetlabs/vanagon/pull/629.

(something similar will need to be done for puppet-agent as well)