### PR TITLE
(PA-2985) Build ruby-selinux for Debian and Ubuntu

### DIFF
--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -41,7 +41,9 @@ if platform.is_cross_compiled_linux?
 end
 
 cflags = ""
-if platform.name =~ /sles-15|el-8|debian-10/ || (platform.is_fedora? && platform.os_version.to_i >= 29)
+
+# The platforms below use pl-build-tools
+unless platform.name =~ /el-(5|6|7)|fedora-28|debian-(8|9)|ubuntu-(16|18)/
   cc = '/usr/bin/gcc'
   cflags += "#{settings[:cppflags]} #{settings[:cflags]}"
 end

--- a/configs/platforms/debian-10-amd64.rb
+++ b/configs/platforms/debian-10-amd64.rb
@@ -7,20 +7,22 @@ platform "debian-10-amd64" do |plat|
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
 
   packages = [
-      'libbz2-dev',
-      'libreadline-dev',
-      :make,
-      'openjdk-11-jdk',
-      'pkg-config',
-      'zlib1g-dev',
-      'devscripts',
-      'quilt',
-      'debhelper',
-      'rsync',
-      'fakeroot',
-      'cmake',
-      'build-essential',
-      'systemtap-sdt-dev'
+    'build-essential',
+    'cmake',
+    'debhelper',
+    'devscripts',
+    'fakeroot',
+    'libbz2-dev',
+    'libreadline-dev',
+    'libselinux1-dev',
+    'make',
+    'openjdk-11-jdk',
+    'pkg-config',
+    'quilt',
+    'rsync',
+    'swig',
+    'systemtap-sdt-dev',
+    'zlib1g-dev'
   ]
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"

--- a/configs/platforms/debian-8-amd64.rb
+++ b/configs/platforms/debian-8-amd64.rb
@@ -11,14 +11,15 @@ platform "debian-8-amd64" do |plat|
   packages = [
     "libbz2-dev",
     "libreadline-dev",
+    "libselinux1-dev",
     "make",
     "openjdk-7-jdk",
     "pkg-config",
     "pl-cmake",
     "pl-gcc",
-    "zlib1g-dev",
-    "systemtap-sdt-dev"
-
+    "swig",
+    "systemtap-sdt-dev",
+    "zlib1g-dev"
   ]
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"

--- a/configs/platforms/debian-8-i386.rb
+++ b/configs/platforms/debian-8-i386.rb
@@ -11,14 +11,15 @@ platform "debian-8-i386" do |plat|
   packages = [
     "libbz2-dev",
     "libreadline-dev",
+    "libselinux1-dev",
     "make",
     "openjdk-7-jdk",
     "pkg-config",
     "pl-cmake",
     "pl-gcc",
-    "zlib1g-dev",
-    "systemtap-sdt-dev"
-
+    "swig",
+    "systemtap-sdt-dev",
+    "zlib1g-dev"
   ]
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"

--- a/configs/platforms/debian-9-amd64.rb
+++ b/configs/platforms/debian-9-amd64.rb
@@ -11,13 +11,15 @@ platform "debian-9-amd64" do |plat|
   packages = [
     "libbz2-dev",
     "libreadline-dev",
+    "libselinux1-dev",
     "make",
     "openjdk-8-jdk",
     "pkg-config",
     "pl-cmake",
     "pl-gcc",
-    "zlib1g-dev",
-    "systemtap-sdt-dev"
+    "swig",
+    "systemtap-sdt-dev",
+    "zlib1g-dev"
   ]
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"

--- a/configs/platforms/debian-9-i386.rb
+++ b/configs/platforms/debian-9-i386.rb
@@ -11,13 +11,15 @@ platform "debian-9-i386" do |plat|
   packages = [
     "libbz2-dev",
     "libreadline-dev",
+    "libselinux1-dev",
     "make",
     "openjdk-8-jdk",
     "pkg-config",
     "pl-cmake",
     "pl-gcc",
-    "zlib1g-dev",
-    "systemtap-sdt-dev"
+    "swig",
+    "systemtap-sdt-dev",
+    "zlib1g-dev"
   ]
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"

--- a/configs/platforms/ubuntu-16.04-amd64.rb
+++ b/configs/platforms/ubuntu-16.04-amd64.rb
@@ -13,13 +13,15 @@ platform "ubuntu-16.04-amd64" do |plat|
   packages = [
     "libbz2-dev",
     "libreadline-dev",
+    "libselinux1-dev",
     "make",
     "openjdk-8-jdk",
     "pkg-config",
     "pl-cmake",
     "pl-gcc",
-    "zlib1g-dev",
-    "systemtap-sdt-dev"
+    "swig",
+    "systemtap-sdt-dev",
+    "zlib1g-dev"
   ]
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"

--- a/configs/platforms/ubuntu-16.04-i386.rb
+++ b/configs/platforms/ubuntu-16.04-i386.rb
@@ -11,13 +11,15 @@ platform "ubuntu-16.04-i386" do |plat|
   packages = [
     "libbz2-dev",
     "libreadline-dev",
+    "libselinux1-dev",
     "make",
     "openjdk-8-jdk",
     "pkg-config",
     "pl-cmake",
     "pl-gcc",
-    "zlib1g-dev",
-    "systemtap-sdt-dev"
+    "swig",
+    "systemtap-sdt-dev",
+    "zlib1g-dev"
   ]
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"

--- a/configs/platforms/ubuntu-16.04-ppc64el.rb
+++ b/configs/platforms/ubuntu-16.04-ppc64el.rb
@@ -16,9 +16,9 @@ platform "ubuntu-16.04-ppc64el" do |plat|
     "pl-cmake",
     "pl-gcc-ppc64el",
     "pl-ruby",
+    "systemtap-sdt-dev",
     "xutils-dev",
-    "zlib1g-dev",
-    "systemtap-sdt-dev"
+    "zlib1g-dev"
   ]
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends #{packages.join(' ')}"

--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -11,13 +11,15 @@ platform "ubuntu-18.04-amd64" do |plat|
   packages = [
     "libbz2-dev",
     "libreadline-dev",
+    "libselinux1-dev",
     "make",
+    "openjdk-8-jre-headless",
     "pkg-config",
     "pl-cmake",
     "pl-gcc",
-    "zlib1g-dev",
+    "swig",
     "systemtap-sdt-dev",
-    "openjdk-8-jre-headless"
+    "zlib1g-dev"
   ]
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends #{packages.join(' ')}"

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -27,9 +27,9 @@ proj.component 'libxslt' unless platform.is_windows?
 
 proj.component 'ruby-augeas' unless platform.is_windows?
 proj.component 'ruby-shadow' unless platform.is_aix? || platform.is_windows?
-# We only build ruby-selinux for EL 5-7
-if platform.is_el? || platform.is_fedora?
-  proj.component 'ruby-selinux'
+# We only build ruby-selinux for EL, Fedora, Debian and Ubuntu (amd64/i386)
+if platform.is_el? || platform.is_fedora? || platform.name =~ /debian|ubuntu/
+  proj.component 'ruby-selinux' if platform.name !~ /ubuntu-.*-ppc64el/
 end
 
 # libedit is used instead of readline on these platforms


### PR DESCRIPTION
Since selinux is also available on Debian and Ubuntu, we can build the `ruby-selinux` component for these platforms as well.

To build the selinux library we need the SELinux development headers (`libselinux1-dev`) and `swig`, which is a build dependency.

The extra added/removed lines are from me ordering the platform package names in alphabetical order.