### PR TITLE
(PDK-1546) Add Fedora 31 to platform configs

### DIFF
--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -41,7 +41,7 @@ if platform.is_cross_compiled_linux?
 end
 
 cflags = ""
-if platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+if platform.name =~ /sles-15|el-8|debian-10/ || (platform.is_fedora? && platform.os_version.to_i >= 29)
   cc = '/usr/bin/gcc'
   cflags += "#{settings[:cppflags]} #{settings[:cflags]}"
 end

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -96,7 +96,7 @@ component 'augeas' do |pkg, settings, platform|
     pkg.environment "CFLAGS" => settings[:cflags]
   end
 
-  if platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+  if platform.name =~ /sles-15|el-8|debian-10/ || (platform.is_fedora? && platform.os_version.to_i >= 29)
     pkg.environment 'CFLAGS', settings[:cflags]
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment "LDFLAGS", settings[:ldflags]

--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -99,7 +99,7 @@ component "boost" do |pkg, settings, platform|
   elsif platform.is_aix?
     pkg.environment "PATH" => "/opt/freeware/bin:/opt/pl-build-tools/bin:$(PATH)"
     linkflags = "-Wl,-L#{settings[:libdir]},-L/opt/pl-build-tools/lib"
-  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+  elsif platform.name =~ /sles-15|el-8|debian-10/ || (platform.is_fedora? && platform.os_version.to_i >= 29)
     pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
     linkflags = "#{settings[:ldflags]},-rpath=#{settings[:libdir]}64"
     gpp = '/usr/bin/g++'

--- a/configs/components/ruby-2.4.9.rb
+++ b/configs/components/ruby-2.4.9.rb
@@ -81,7 +81,7 @@ component 'ruby-2.4.9' do |pkg, settings, platform|
 
   special_flags = " --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
 
-  if platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+  if platform.name =~ /sles-15|el-8|debian-10/ || (platform.is_fedora? && platform.os_version.to_i >= 29)
     special_flags += " CFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}' CPPFLAGS='#{settings[:cppflags]}' "
   end
 
@@ -203,7 +203,7 @@ component 'ruby-2.4.9' do |pkg, settings, platform|
     end
   elsif platform.is_windows?
     rbconfig_changes["CC"] = "x86_64-w64-mingw32-gcc"
-  elsif platform.name =~ /fedora-(28|29|30)|el-8|debian-10/
+  elsif platform.name =~ /el-8|debian-10/ || (platform.is_fedora? && platform.os_version.to_i >= 28)
     # When building ruby C extensions (in
     # ruby-augeas, for example) with Native GCC >= 8.0.1, mkmf will fail when ruby 2.4.5's
     # CONFIG['warnflags'] are applied to a conftest with -Werror before

--- a/configs/components/ruby-2.5.7.rb
+++ b/configs/components/ruby-2.5.7.rb
@@ -83,7 +83,7 @@ component 'ruby-2.5.7' do |pkg, settings, platform|
 
   special_flags = " --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
 
-  if platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+  if platform.name =~ /sles-15|el-8|debian-10/ || (platform.is_fedora? && platform.os_version.to_i >= 29)
     special_flags += " CFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}' CPPFLAGS='#{settings[:cppflags]}' "
   end
 

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -23,7 +23,7 @@ component "runtime-agent" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
     pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
-  elsif platform.is_macos? || platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+  elsif platform.is_macos? || platform.name =~ /sles-15|el-8|debian-10/ || (platform.is_fedora? && platform.os_version.to_i >= 29)
     # Nothing to see here
   elsif platform.is_windows?
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"

--- a/configs/components/runtime-bolt.rb
+++ b/configs/components/runtime-bolt.rb
@@ -13,7 +13,7 @@ component "runtime-bolt" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
-  elsif platform.is_macos? or platform.name =~ /sles-15|fedora-(29|30)|el-8/
+  elsif platform.is_macos? or platform.name =~ /sles-15|el-8/ || (platform.is_fedora? && platform.os_version.to_i >= 29)
 
     # Do nothing for distros that have a suitable compiler do not use pl-build-tools
 

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -23,7 +23,7 @@ component "yaml-cpp" do |pkg, settings, platform|
   elsif platform.is_macos?
     cmake_toolchain_file = ""
     cmake = "/usr/local/bin/cmake"
-  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+  elsif platform.name =~ /sles-15|el-8|debian-10/ || (platform.is_fedora? && platform.os_version.to_i >= 29)
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment 'CFLAGS', settings[:cflags]
     pkg.environment 'LDFLAGS', settings[:ldflags]

--- a/configs/platforms/fedora-31-x86_64.rb
+++ b/configs/platforms/fedora-31-x86_64.rb
@@ -1,0 +1,16 @@
+platform 'fedora-31-x86_64' do |plat|
+  plat.servicedir '/usr/lib/systemd/system'
+  plat.defaultdir '/etc/sysconfig'
+  plat.servicetype 'systemd'
+  plat.dist 'fc31'
+
+  packages = %w[
+    autoconf automake bzip2-devel gcc gcc-c++ libselinux-devel
+    libsepol libsepol-devel make cmake pkgconfig readline-devel
+    rpm-libs rpmdevtools rsync swig zlib-devel systemtap-sdt-devel
+  ]
+  plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+
+  plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
+  plat.vmpooler_template 'fedora-31-x86_64'
+end

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -163,7 +163,7 @@ proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{
 # stack canary and full RELRO.
 # We only do this on platforms that use their default OS toolchain since pl-gcc versions
 # are too old to support these flags.
-if platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
+if platform.name =~ /sles-15|el-8|debian-10/ || (platform.is_fedora? && platform.os_version.to_i >= 29)
   proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
   proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
   proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -39,6 +39,6 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'rubygem-highline'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'ruby-stomp'
-  proj.component 'yaml-cpp' if platform.name =~ /fedora-(29|30)|el-8|debian-10/ || platform.is_macos?
-  proj.component 'boost' if platform.name =~ /fedora-(29|30)|el-8|debian-10/ || platform.is_macos?
+  proj.component 'yaml-cpp' if platform.name =~ /el-8|debian-10/ || platform.is_macos? || (platform.is_fedora? && platform.os_version.to_i >= 29)
+  proj.component 'boost' if platform.name =~ /el-8|debian-10/ || platform.is_macos? || (platform.is_fedora? && platform.os_version.to_i >= 29)
 end


### PR DESCRIPTION
Also adjusts the various regexes that are used to configure things like
pl-gcc vs gcc and extracted the Fedora matching into a more verbose
check that should require less ongoing maintenance.

Tested by building `pdk-runtime`, `bolt-runtime`, and
`agent-runtime-5.5.x`.