### PR TITLE
(FACT-1946) Build ffi gem on Solaris

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place)
 end
 
 gem 'artifactory'
-gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '0.15.17')
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15.17')
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.8')
 gem 'rake', '~> 12.0'
 

--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -43,7 +43,6 @@ action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep || exit 1;
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;
@@ -51,6 +50,7 @@ basedir=default" > /var/tmp/vanagon-noask;
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep libffi_dev libreadline6 || exit 1;
 
   # Install base build dependencies
   for pkg in #{base_pkgs.map { |pkg| "SUNW#{pkg}.pkg.gz" }.join(' ')}; do \

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -47,14 +47,14 @@ action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep ruby20 || exit 1;
-  # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
-  ln -sf /opt/csw/bin/ggrep /usr/bin/grep;
-  ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
   # RE-5250 - Solaris 10 templates are awful
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake libgcc_s1 libreadline6 pkgconfig ggrep libffi_dev ruby20 ruby20_dev || exit 1;
+  # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
+  ln -sf /opt/csw/bin/ggrep /usr/bin/grep;
+  ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
 
   # Install base build dependencies
   for pkg in #{base_pkgs.map { |pkg| "SUNW#{pkg}.pkg.gz" }.join(' ')}; do \
@@ -65,6 +65,11 @@ basedir=default" > /var/tmp/vanagon-noask;
   for pkg in #{build_pkgs.join(' ')}; do \
   tmpdir=$(mktemp -p /var/tmp -d); (cd ${tmpdir} && curl -O #{build_url}/${pkg} && gunzip -c ${pkg} | pkgadd -d /dev/stdin -a /var/tmp/vanagon-noask all); \
   done
+
+  # Download the SPARC version of libffi.so
+  /opt/csw/bin/pkgutil --stream --download -T sparc:5.10 libffi6 -y
+  pkgtrans /var/opt/csw/pkgutil/packages/libffi6.sparc.5.10.pkg /opt/csw/lib all
+  cp /opt/csw/lib/CSWlibffi6/root/opt/csw/lib/libffi.so.6.0.4 /opt/csw/lib/libffi.so.6.0.4
 
   ntpdate pool.ntp.org]
 

--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -14,6 +14,40 @@ platform "solaris-11-i386" do |plat|
 
   plat.provision_with("pkg install #{packages.join(' ')}")
 
+  plat.provision_with %[echo "# Write the noask file to a temporary directory
+# please see man -s 4 admin for details about this file:
+# http://www.opensolarisforum.org/man/man4/admin.html
+#
+# The key thing we don\'t want to prompt for are conflicting files.
+# The other nocheck settings are mostly defensive to prevent prompts
+# We _do_ want to check for available free space and abort if there is
+# not enough
+mail=
+# Overwrite already installed instances
+instance=overwrite
+# Do not bother checking for partially installed packages
+partial=nocheck
+# Do not bother checking the runlevel
+runlevel=nocheck
+# Do not bother checking package dependencies (We take care of this)
+idepend=nocheck
+rdepend=nocheck
+# DO check for available free space and abort if there isn\'t enough
+space=quit
+# Do not check for setuid files.
+setuid=nocheck
+# Do not check if files conflict with other packages
+conflict=nocheck
+# We have no action scripts.  Do not check for them.
+action=nocheck
+# Install to the default base directory.
+basedir=default" > /var/tmp/vanagon-noask;
+  echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
+  pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev || exit 1;
+
+  ntpdate pool.ntp.org]
+
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
   plat.output_dir File.join("solaris", "11", "PC1")
 end

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -16,6 +16,40 @@ platform "solaris-11-sparc" do |plat|
 
   plat.provision_with("pkg install #{packages.join(' ')}")
 
+  plat.provision_with %[echo "# Write the noask file to a temporary directory
+# please see man -s 4 admin for details about this file:
+# http://www.opensolarisforum.org/man/man4/admin.html
+#
+# The key thing we don\'t want to prompt for are conflicting files.
+# The other nocheck settings are mostly defensive to prevent prompts
+# We _do_ want to check for available free space and abort if there is
+# not enough
+mail=
+# Overwrite already installed instances
+instance=overwrite
+# Do not bother checking for partially installed packages
+partial=nocheck
+# Do not bother checking the runlevel
+runlevel=nocheck
+# Do not bother checking package dependencies (We take care of this)
+idepend=nocheck
+rdepend=nocheck
+# DO check for available free space and abort if there isn\'t enough
+space=quit
+# Do not check for setuid files.
+setuid=nocheck
+# Do not check if files conflict with other packages
+conflict=nocheck
+# We have no action scripts.  Do not check for them.
+action=nocheck
+# Install to the default base directory.
+basedir=default" > /var/tmp/vanagon-noask;
+  echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
+  pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev || exit 1;
+
+  ntpdate pool.ntp.org]
+
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
   plat.output_dir File.join("solaris", "11", "PC1")
 end

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -46,14 +46,14 @@ proj.component 'rubygem-locale'
 proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
 
-if platform.is_windows?
+if platform.is_windows? || platform.is_solaris?
   proj.component 'rubygem-ffi'
+  proj.component 'rubygem-minitar'
+end
+
+if platform.is_windows?
   proj.component 'rubygem-win32-dir'
   proj.component 'rubygem-win32-process'
   proj.component 'rubygem-win32-security'
   proj.component 'rubygem-win32-service'
-end
-
-if platform.is_windows? || platform.is_solaris?
-  proj.component 'rubygem-minitar'
 end


### PR DESCRIPTION
Add support for building the FFI gem on cross-compiled Solaris platforms (i386/x86_64 to sparc).

This can be achieved by monkey-patching rubygems and using a custom rbconfig to bypass version checks. This is necessary because in cross-compile situations we install gems with the system ruby which is usually an older version.

I tested this by building the runtime, then building the agent with this runtime, then explicitly requiring `ffi` in a `irb` session on `solaris-(10|11)-sparc`.

~~Also in scope of this PR would be to add support for x86 Solaris which I haven't tackled yet, but should be trivial.~~ Support for x86 was added.

Supersedes https://github.com/puppetlabs/puppet-runtime/pull/251.