### PR TITLE
(packaging) Update bolt/bolt-server component gems

### DIFF
--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.226.0"
-  pkg.md5sum "a8f0698cf66e21772b55da21e2712e72"
+  pkg.version "1.241.0"
+  pkg.md5sum "b2c106add516760c31de9c805a5fe6c5"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.69.1"
-  pkg.md5sum "d62dce4da0efc911a22554ad3b8e5a7d"
+  pkg.version "3.79.0"
+  pkg.md5sum "60f71df6cfcb95f22821412cffb61331"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.112.0"
-  pkg.md5sum "d9331fcb600fd64c27d6cd5f467821c6"
+  pkg.version "1.117.0"
+  pkg.md5sum "8eda3faf8c4a91d5f84a781cb92aafbd"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-hiera-eyaml.rb
+++ b/configs/components/rubygem-hiera-eyaml.rb
@@ -1,6 +1,6 @@
 component 'rubygem-hiera-eyaml' do |pkg, settings, platform|
-  pkg.version '3.0.0'
-  pkg.md5sum '5a05c893e223d56aa73d206f420357e0'
+  pkg.version '3.1.1'
+  pkg.md5sum 'a9f8669033ccb0220f3c3a6cbed9d7e6'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 

--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
-  pkg.version '6.10.1'
-  pkg.md5sum 'b9132e1c37b84be4397aa45e9574ad6c'
+  pkg.version '6.11.0'
+  pkg.md5sum '82b56da6c938b9bd05c3bf1bf4e00614'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-rubyzip.rb
+++ b/configs/components/rubygem-rubyzip.rb
@@ -1,6 +1,6 @@
 component 'rubygem-rubyzip' do |pkg, settings, platform|
-  pkg.version '1.3.0'
-  pkg.md5sum '73adcf1825fe53847d6c4b52c5f05722'
+  pkg.version '2.0.0'
+  pkg.md5sum 'c0746ad116eeca88c441819cfb24e446'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-winrm-fs.rb
+++ b/configs/components/rubygem-winrm-fs.rb
@@ -1,6 +1,6 @@
 component 'rubygem-winrm-fs' do |pkg, settings, platform|
-  pkg.version '1.3.3'
-  pkg.md5sum '43252a70db9727a47c840e40e0f75c26'
+  pkg.version '1.3.4'
+  pkg.md5sum 'b4916023c275a4673af9df92755d4848'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This commit updates the gems shipped with bolt/bolt-server. Notably it pulls in puppet6.11.0 which will be minimum puppet version for bolt gem moving forward.