### PR TITLE
(PA-3005) move gettext and text to shared gem home

### DIFF
--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -13,4 +13,6 @@ component "rubygem-gettext" do |pkg, settings, platform|
   end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
+
+  pkg.environment "GEM_HOME", (settings[:puppet_gem_vendor_dir] || settings[:gem_home])
 end

--- a/configs/components/rubygem-text.rb
+++ b/configs/components/rubygem-text.rb
@@ -3,4 +3,6 @@ component "rubygem-text" do |pkg, settings, platform|
   pkg.md5sum "514c3d1db7a955fe793fc0cb149c164f"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
+
+  pkg.environment "GEM_HOME", (settings[:puppet_gem_vendor_dir] || settings[:gem_home])
 end


### PR DESCRIPTION
```diff
--- a.txt	2019-11-20 15:35:07.000000000 +0200
+++ b.txt	2019-11-20 15:35:15.000000000 +0200
@@ -2198,7 +2198,7 @@
     "conflicts": [

     ],
-    "environment": "GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/vendor_ruby:$(RUBYLIB)",
+    "environment": "GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0 RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/vendor_ruby:$(RUBYLIB)",
     "sources": [

     ],
@@ -2468,7 +2468,7 @@
     "conflicts": [

     ],
-    "environment": "GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/vendor_ruby:$(RUBYLIB)",
+    "environment": "GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0 RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/vendor_ruby:$(RUBYLIB)",
     "sources": [

     ],
```
