### PR TITLE
Add puppet-strings and its dependencies to bolt-runtime

### DIFF
--- a/configs/components/rubygem-puppet-strings.rb
+++ b/configs/components/rubygem-puppet-strings.rb
@@ -1,0 +1,7 @@
+component 'rubygem-puppet-strings' do |pkg, settings, platform|
+  pkg.version '2.3.1'
+  pkg.md5sum '8f026b9e089e03571a3be59e25b137fd'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end
+

--- a/configs/components/rubygem-rgen.rb
+++ b/configs/components/rubygem-rgen.rb
@@ -1,0 +1,7 @@
+component 'rubygem-rgen' do |pkg, settings, platform|
+  pkg.version '0.8.2'
+  pkg.md5sum '89e5cb40cef4f86ec297df14c3073885'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end
+

--- a/configs/components/rubygem-yard.rb
+++ b/configs/components/rubygem-yard.rb
@@ -1,0 +1,7 @@
+component 'rubygem-yard' do |pkg, settings, platform|
+  pkg.version '0.9.20'
+  pkg.md5sum 'cff24461a59d5ac123d65c332d3ba271'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end
+

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -178,12 +178,15 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-puppet'
   proj.component 'rubygem-puppet_forge'
   proj.component 'rubygem-puppet-resource_api'
+  proj.component 'rubygem-puppet-strings'
   proj.component 'rubygem-r10k'
+  proj.component 'rubygem-rgen'
   proj.component 'rubygem-rubyntlm'
   proj.component 'rubygem-ruby_smb'
   proj.component 'rubygem-rubyzip'
   proj.component 'rubygem-terminal-table'
   proj.component 'rubygem-unicode-display_width'
+  proj.component 'rubygem-yard'
 
   # Core Windows dependencies
   proj.component 'rubygem-win32-dir'


### PR DESCRIPTION
These are needed for `bolt plan show`.