### PR TITLE
(maint) Improve Dockerfile organization / build caching

### DIFF
--- a/docker/puppet-runtime/Dockerfile
+++ b/docker/puppet-runtime/Dockerfile
@@ -29,10 +29,10 @@ RUN yum clean all && \
 
 WORKDIR /runtime
 
-RUN wget https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.tar.gz && \
-    wget https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.tar.gz.sha1 && \
-    wget https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.settings.yaml && \
-    wget https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.settings.yaml.sha1
+RUN wget --no-verbose https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.tar.gz && \
+    wget --no-verbose https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.tar.gz.sha1 && \
+    wget --no-verbose https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.settings.yaml && \
+    wget --no-verbose https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.settings.yaml.sha1
 
 COPY validate_downloads.sh /runtime
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/puppet-runtime/Dockerfile
+++ b/docker/puppet-runtime/Dockerfile
@@ -6,38 +6,32 @@ ARG version="201904091"
 ARG project="agent"
 ARG project_branch="master"
 
-ENV RUNTIME_FILE="${project}-runtime-${project_branch}-${version}.el-7-x86_64.tar.gz"
-ENV SETTINGS_FILE="${project}-runtime-${project_branch}-${version}.el-7-x86_64.settings.yaml"
-
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-runtime" \
-      org.label-schema.name="$project Runtime, $project_branch branch" \
       org.label-schema.license="Apache-2.0" \
-      org.label-schema.version="$version" \
       org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-runtime" \
-      org.label-schema.vcs-ref="$vcs_ref" \
-      org.label-schema.build-date="$build_date" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
-RUN mkdir /runtime
-  
+COPY validate_downloads.sh /runtime/validate_downloads.sh
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV RUNTIME_FILE="${project}-runtime-${project_branch}-${version}.el-7-x86_64.tar.gz" \
+    SETTINGS_FILE="${project}-runtime-${project_branch}-${version}.el-7-x86_64.settings.yaml"
+
+LABEL org.label-schema.name="$project Runtime, $project_branch branch" \
+      org.label-schema.version="$version" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date"
+
 RUN yum clean all && \
     yum install -y wget && \
-    yum clean all
-
-WORKDIR /runtime
-
-RUN wget --no-verbose https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.tar.gz && \
+    yum clean all && \
+    wget --no-verbose https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.tar.gz && \
     wget --no-verbose https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.tar.gz.sha1 && \
     wget --no-verbose https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.settings.yaml && \
-    wget --no-verbose https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.settings.yaml.sha1
-
-COPY validate_downloads.sh /runtime
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN chmod +x /runtime/validate_downloads.sh && \
+    wget --no-verbose https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-runtime/$version/el-7-x86_64/${project}-runtime-${project_branch}-${version}.el-7-x86_64.settings.yaml.sha1 && \
+    chmod +x /runtime/validate_downloads.sh && \
     /runtime/validate_downloads.sh && \
     gunzip -c ${project}-runtime-${project_branch}-${version}.el-7-x86_64.tar.gz | tar -k -C / -xf -
-
-WORKDIR /


### PR DESCRIPTION
- Disable wget progress bar
- Reduce Dockerfile build steps to 12, and move steps that can't be cached later in the Dockerfile