### PR TITLE
(PA-2780) CFProperty List gem in wrong directory

### DIFF
--- a/configs/components/rubygem-CFPropertyList.rb
+++ b/configs/components/rubygem-CFPropertyList.rb
@@ -3,4 +3,5 @@ component 'rubygem-CFPropertyList' do |pkg, settings, platform|
   pkg.md5sum 'ae4086185992f293ffab1641b83286a5'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
+  pkg.environment "GEM_HOME", (settings[:puppet_gem_vendor_dir] || settings[:gem_home])
 end

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -59,3 +59,7 @@ if platform.is_windows?
   proj.component 'rubygem-win32-security'
   proj.component 'rubygem-win32-service'
 end
+
+if platform.is_macos?
+  proj.component 'rubygem-CFPropertyList'
+end


### PR DESCRIPTION
CFProperty List gem will be installer by puppet-runtime, and CFProperty List
component will be removed from puppet-agent.