### PR TITLE
Revert "(PUP-10166) upgrade openssl version"

### DIFF
--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -46,7 +46,6 @@ component "boost" do |pkg, settings, platform|
   addtl_flags = ""
   gpp = "#{settings[:tools_root]}/bin/g++"
   b2flags = ""
-  link_option = settings[:boost_link_option]
   b2location = "#{settings[:prefix]}/bin/b2"
   bjamlocation = "#{settings[:prefix]}/bin/bjam"
 
@@ -135,7 +134,7 @@ component "boost" do |pkg, settings, platform|
       "./b2 \
       install \
       variant=release \
-      #{link_option} \
+      link=shared \
       toolset=#{toolset} \
       #{b2flags} \
       -d+2 \
@@ -149,7 +148,7 @@ component "boost" do |pkg, settings, platform|
       "#{b2location} \
       install \
       variant=release \
-      #{link_option} \
+      link=shared \
       toolset=#{toolset} \
       #{b2flags} \
       -d+2 \

--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -120,7 +120,11 @@ component 'openssl' do |pkg, settings, platform|
   project_flags = settings[:openssl_extra_configure_flags] || []
   perl_exec = ''
   if platform.is_aix?
-    perl_exec = '/opt/freeware/bin/perl'
+    if platform.name =~ /^aix-6.1/
+      perl_exec = '/opt/freeware/bin/perl'
+    else
+      perl_exec = '/usr/bin/perl'
+    end
   elsif platform.is_solaris? && platform.os_version == '10'
     perl_exec = '/opt/csw/bin/perl'
   end

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -10,7 +10,7 @@ component "runtime-agent" do |pkg, settings, platform|
       libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib")
     end
   elsif platform.is_aix?
-    libdir = "/opt/pl-build-tools/lib/gcc/powerpc-ibm-aix6.1.0.0/5.2.0/"
+    libdir = "/opt/pl-build-tools/lib/gcc/powerpc-ibm-aix#{platform.os_version}.0.0/5.2.0/"
   elsif platform.is_solaris? || platform.architecture =~ /i\d86/
     libdir = "/opt/pl-build-tools/lib"
   elsif platform.architecture =~ /64/

--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -21,11 +21,8 @@ platform "aix-7.1-ppc" do |plat|
     "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/zlib/zlib-1.2.3-4.aix5.2.ppc.rpm",
     "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/zlib/zlib-devel-1.2.3-4.aix5.2.ppc.rpm",
     "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/gawk/gawk-3.1.3-1.aix5.1.ppc.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/db/db-4.8.24-3.aix6.1.ppc.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/gdbm/gdbm-1.8.3-5.aix5.2.ppc.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/perl/perl-5.22.0-1.aix6.1.ppc.rpm",
-    "http://pl-build-tools.delivery.puppetlabs.net/aix/6.1/ppc/pl-gcc-5.2.0-11.aix6.1.ppc.rpm",
-    "http://pl-build-tools.delivery.puppetlabs.net/aix/6.1/ppc/pl-cmake-3.2.3-2.aix6.1.ppc.rpm",
+    "http://pl-build-tools.delivery.puppetlabs.net/aix/#{os_version}/ppc/pl-gcc-5.2.0-11.aix#{os_version}.ppc.rpm",
+    "http://pl-build-tools.delivery.puppetlabs.net/aix/#{os_version}/ppc/pl-cmake-3.2.3-2.aix#{os_version}.ppc.rpm",
   ]
 
   packages.each do |uri|
@@ -41,5 +38,5 @@ platform "aix-7.1-ppc" do |plat|
   # for pl-autoconf) we'll need to force the installation
   #                                         Sean P. McD.
   plat.install_build_dependencies_with "rpm -Uvh --replacepkgs --force "
-  plat.vmpooler_template "aix-6.1-power"
+  plat.vmpooler_template "aix-7.1-power"
 end

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -215,7 +215,6 @@ proj.timeout 7200 if platform.is_windows?
 # These are the boost libraries we care about for facter and friends
 proj.setting(:boost_libs, ["chrono", "date_time", "filesystem", "locale", "log", "program_options",
                            "random", "regex", "system", "thread"])
-proj.setting(:boost_link_option, "link=shared")
 
 # Most branches of puppet-agent use these openssl flags in addition to the defaults in configs/components/openssl.rb -
 # Individual projects can override these if necessary.

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -4,7 +4,7 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.setting :ruby_version, '2.4.9'
   proj.setting :rubygem_net_ssh, '4.1.0'
   proj.setting :rubygem_semantic_puppet_version, '0.1.2'
-  proj.setting :openssl_version, platform.name =~ /windowsfips-2012r2/ ? '1.0.2' : '1.1.1'
+  proj.setting :openssl_version, '1.0.2'
 
   # In puppet-agent#master, install paths have been updated to more closely
   # match those used for *nix agents -- Use the old path style for this project:
@@ -23,8 +23,6 @@ project 'agent-runtime-5.5.x' do |proj|
   # Directory for gems shared by puppet and puppetserver
   proj.setting(:puppet_gem_vendor_dir, File.join(proj.libdir, "ruby", "vendor_gems"))
 
-  proj.setting(:boost_link_option, "") if platform.is_windows?
-
   ########
   # Load shared agent components
   ########
@@ -41,7 +39,6 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'rubygem-highline'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'ruby-stomp'
-  # SLES 15 uses the OS distro versions of boost and yaml-cpp:
-  proj.component 'boost' unless platform.name =~ /sles-15/
-  proj.component 'yaml-cpp' unless platform.name =~ /sles-15/
+  proj.component 'yaml-cpp' if platform.name =~ /el-8|debian-10/ || platform.is_macos? || (platform.is_fedora? && platform.os_version.to_i >= 29)
+  proj.component 'boost' if platform.name =~ /el-8|debian-10/ || platform.is_macos? || (platform.is_fedora? && platform.os_version.to_i >= 29)
 end


### PR DESCRIPTION
This reverts commit ~888cce2f06326b40f5895d7b46c819689e1500d5.~ 71291eefead882d17fb6b57860b785dd5db8353f

the openssl update has caused some issues in PE smoke tests and we need to pull it out until we can figure out how to fix it/the best path forward

/cc @ciprianbadescu @mihaibuzgau @shrug @joshcooper @melissa 