### PR TITLE
(maint) provide openssl-lib only for 5.5.x agent

### DIFF
--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -10,7 +10,9 @@ component 'openssl' do |pkg, settings, platform|
 
   # make sure openssl-lib compiles first, as we it only installs versioned libs and hopefully will not cause problems
   # the other way around caused: # error "Inconsistency between crypto.h and cryptlib.c"
-  pkg.build_requires 'openssl-lib' if platform.is_linux?
+  if settings[:provide_ssllib] && platform.is_linux?
+    pkg.build_requires 'openssl-lib'
+  end
 
   target = cflags = ldflags = sslflags = ''
 

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -9,6 +9,7 @@ project 'agent-runtime-5.5.x' do |proj|
   # In puppet-agent#master, install paths have been updated to more closely
   # match those used for *nix agents -- Use the old path style for this project:
   proj.setting :legacy_windows_paths, true
+  proj.setting :provide_ssllib, true
 
   ########
   # Load shared agent settings


### PR DESCRIPTION
Because the newly added component openssl-lib was not included in all the projects, vanagon tried to install it using the default package manager:
```
09:31:18 Executing 'yum install --assumeyes openssl-lib ' on 'root@unfunny-root.delivery.puppetlabs.net'
09:31:18 Warning: Permanently added 'unfunny-root.delivery.puppetlabs.net,10.16.119.196' (ECDSA) to the list of known hosts.
09:31:18 Loaded plugins: fastestmirror
09:31:18 Loading mirror speeds from cached hostfile
09:31:18 No package openssl-lib available.
```

This PR confines openssl-lib only to the puppet-agent-5.5.x runtime 