### PR TITLE
Revert "(maint) bump thor to 1.0.1 (#273)"

### DIFF
--- a/configs/components/rubygem-thor.rb
+++ b/configs/components/rubygem-thor.rb
@@ -1,6 +1,6 @@
 component 'rubygem-thor' do |pkg, settings, platform|
-  pkg.version '1.0.1'
-  pkg.md5sum '052eb36fd3e522331af98449556991dc'
+  pkg.version '0.20.3'
+  pkg.md5sum '0370f18c27c9fb0983d53e4c69c4eb77'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This reverts commit e2236fb73e288ca63e3238b294c81031e18a0961, reversing
changes made to 75a1b9e600d7939c176bb5c9f3a6bea2275b94c2.

facter-ng still depends on thor "~> 0.20.3" so the latter fails to install if
the runtime only includes thor 1.0.1.