### PR TITLE
Revert "(maint) bump thor to 1.0.1"

### DIFF
--- a/configs/components/rubygem-thor.rb
+++ b/configs/components/rubygem-thor.rb
@@ -1,6 +1,6 @@
 component 'rubygem-thor' do |pkg, settings, platform|
-  pkg.version '1.0.1'
-  pkg.md5sum '052eb36fd3e522331af98449556991dc'
+  pkg.version '0.20.3'
+  pkg.md5sum '0370f18c27c9fb0983d53e4c69c4eb77'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Reverts puppetlabs/puppet-runtime#273

We're reverting this until facter-ng dependencies are resolved.