### PR TITLE
(PA-3067) use 2.9 selinux for non-pl-build-tools platforms

### DIFF
--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -21,10 +21,15 @@ if platform.name =~ /^el-5-.*$/
   pkg.install do
     ["cp ../libselinux-1.33.4.pc #{settings[:libdir]}/pkgconfig/libselinux.pc"]
   end
-else
+elsif platform.name =~ /el-(5|6|7)|fedora-28|debian-(8|9)|ubuntu-(16|18)/
   pkg.version "2.0.94"
   pkg.md5sum "544f75aab11c2af352facc51af12029f"
   pkg.url "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/20100525/devel/libselinux-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/libselinux-#{pkg.get_version}.tar.gz"
+else
+  pkg.version "2.9"
+  pkg.md5sum "bb449431b6ed55a0a0496dbc366d6e31"
+  pkg.url "https://github.com/SELinuxProject/selinux/releases/download/20190315/libselinux-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/libselinux-#{pkg.get_version}.tar.gz"
 end
 

--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -11,5 +11,5 @@ platform 'el-8-x86_64' do |plat|
   ]
   plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
   plat.install_build_dependencies_with 'dnf install -y --allowerasing'
-  plat.vmpooler_template 'redhat-8-x86_64'
+  plat.vmpooler_template 'centos-8-x86_64'
 end


### PR DESCRIPTION
Until now we were using a really old version of `selinuxswig_ruby.i,selinuxswig.i` for rubyselinux.
This causes the following exception on CentOS8 by requiring selinux:
```
[root@royal-labour ~]# /opt/puppetlabs/puppet/bin/ruby -e 'require "selinux"'
Traceback (most recent call last):
	2: from -e:1:in `<main>'
	1: from /opt/puppetlabs/puppet/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/opt/puppetlabs/puppet/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/2.5.0/x86_64-linux/selinux.so: undefined symbol: rpm_execcon - /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/2.5.0/x86_64-linux/selinux.so (LoadError)
```
This PR updates the Ruby selinuxswig to the lastest available for newer platforms while leaving the old file for platforms that still use pl-build-tools   