### PR TITLE
(maint) Ignore symbol not in libselinux 2.9

### DIFF
--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -29,6 +29,7 @@ elsif platform.name =~ /el-(5|6|7)|fedora-28|debian-(8|9)|ubuntu-(16|18)/
 else
   pkg.version "2.9"
   pkg.md5sum "bb449431b6ed55a0a0496dbc366d6e31"
+  pkg.apply_patch "resources/patches/ruby-selinux/selinux-29-function.patch"
   pkg.url "https://github.com/SELinuxProject/selinux/releases/download/20190315/libselinux-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/libselinux-#{pkg.get_version}.tar.gz"
 end

--- a/resources/patches/ruby-selinux/selinux-29-function.patch
+++ b/resources/patches/ruby-selinux/selinux-29-function.patch
@@ -1,0 +1,14 @@
+diff --git a/src/selinuxswig.i b/src/selinuxswig.i
+index dbdb4c3..cb9b8ba 100644
+--- a/src/selinuxswig.i
++++ b/src/selinuxswig.i
+@@ -41,6 +41,9 @@
+ 	if (*$1) freeconary(*$1);
+ }
+ 
++/* Ignore function not in libselinux 2.8 */
++%ignore security_reject_unknown;
++
+ /* Ignore functions that don't make sense when wrapped */
+ %ignore freecon;
+ %ignore freeconary;


### PR DESCRIPTION
libselinux(-devel) was upgraded in our EL mirrors (from 2.8 to 2.9),
which made a new function appear: `security_reject_unknown`.

When requiring the `selinux` library with an older version of
libselinux, the following error appears:

```
undefined symbol: security_reject_unknown - ... selinux.so (LoadError)
```

To ensure our Ruby bindings work with older versions of libselinux, we
omit exporting the newer function to the Ruby library.