### PR TITLE
(PE-28158) Add client-tools/bolt-server master projects

### DIFF
--- a/configs/projects/client-tools-runtime-master.rb
+++ b/configs/projects/client-tools-runtime-master.rb
@@ -1,0 +1,4 @@
+project 'client-tools-runtime-master' do |proj|
+  # Common settings
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-client-tools-runtime.rb'))
+end

--- a/configs/projects/pe-bolt-server-runtime-master.rb
+++ b/configs/projects/pe-bolt-server-runtime-master.rb
@@ -1,0 +1,6 @@
+project 'pe-bolt-server-runtime-master' do |proj|
+  proj.setting(:pe_version, 'master')
+
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server.rb'))
+end
+


### PR DESCRIPTION
This commit adds two new projects: client-tools-runtime-master and
pe-bolt-server-runtime-master.

These new projects will support the new master branch strategy for PE