### PR TITLE
(maint) Patch ruby 2.1.9 to address Oct 2019 CVEs

### DIFF
--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -59,6 +59,12 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   pkg.apply_patch "#{base}/cve-2018-8777-2.patch"
   pkg.apply_patch "#{base}/cve-2017-17742.patch"
 
+  # Patches for https://www.debian.org/lts/security/2019/dla-2007
+  pkg.apply_patch "#{base}/cve-2019-16201.patch"
+  pkg.apply_patch "#{base}/cve-2019-16254.patch"
+  pkg.apply_patch "#{base}/cve-2019-16255.patch"
+  pkg.apply_patch "#{base}/cve-2019-15845.patch"
+
   if platform.is_aix?
     pkg.apply_patch "#{base}/aix_ruby_2.1_libpath_with_opt_dir.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_proctitle.patch"

--- a/resources/patches/ruby_219/cve-2019-15845.patch
+++ b/resources/patches/ruby_219/cve-2019-15845.patch
@@ -1,0 +1,28 @@
+Index: ruby2.1-2.1.5/dir.c
+===================================================================
+--- ruby2.1-2.1.5.orig/dir.c	2019-11-21 18:07:05.642708934 +0100
++++ ruby2.1-2.1.5/dir.c	2019-11-21 18:07:05.638708736 +0100
+@@ -2097,7 +2097,7 @@
+     else
+ 	flags = 0;
+ 
+-    StringValue(pattern);
++    StringValueCStr(pattern);
+     FilePathStringValue(path);
+ 
+     if (flags & FNM_EXTGLOB) {
+Index: ruby2.1-2.1.5/test/ruby/test_fnmatch.rb
+===================================================================
+--- ruby2.1-2.1.5.orig/test/ruby/test_fnmatch.rb	2019-11-21 18:07:05.642708934 +0100
++++ ruby2.1-2.1.5/test/ruby/test_fnmatch.rb	2019-11-21 18:07:05.638708736 +0100
+@@ -129,4 +129,10 @@
+     assert_file.fnmatch("[a-\u3042]*", "\u3042")
+     assert_file.not_fnmatch("[a-\u3042]*", "\u3043")
+   end
++
++  def test_nullchar
++    assert_raise(ArgumentError) {
++      File.fnmatch("a\0z", "a")
++    }
++  end
+ end

--- a/resources/patches/ruby_219/cve-2019-16201.patch
+++ b/resources/patches/ruby_219/cve-2019-16201.patch
@@ -1,0 +1,63 @@
+Index: ruby2.1-2.1.5/lib/webrick/httpauth/digestauth.rb
+===================================================================
+--- ruby2.1-2.1.5.orig/lib/webrick/httpauth/digestauth.rb	2019-11-21 18:07:16.851263479 +0100
++++ ruby2.1-2.1.5/lib/webrick/httpauth/digestauth.rb	2019-11-21 18:07:16.847263282 +0100
+@@ -290,23 +290,8 @@
+ 
+       def split_param_value(string)
+         ret = {}
+-        while string.bytesize != 0
+-          case string
+-          when /^\s*([\w\-\.\*\%\!]+)=\s*\"((\\.|[^\"])*)\"\s*,?/
+-            key = $1
+-            matched = $2
+-            string = $'
+-            ret[key] = matched.gsub(/\\(.)/, "\\1")
+-          when /^\s*([\w\-\.\*\%\!]+)=\s*([^,\"]*),?/
+-            key = $1
+-            matched = $2
+-            string = $'
+-            ret[key] = matched.clone
+-          when /^s*^,/
+-            string = $'
+-          else
+-            break
+-          end
++        string.scan(/\G\s*([\w\-.*%!]+)=\s*(?:\"((?>\\.|[^\"])*)\"|([^,\"]*))\s*,?/) do
++          ret[$1] = $3 || $2.gsub(/\\(.)/, "\\1")
+         end
+         ret
+       end
+Index: ruby2.1-2.1.5/test/webrick/test_httpauth.rb
+===================================================================
+--- ruby2.1-2.1.5.orig/test/webrick/test_httpauth.rb	2019-11-21 18:07:16.851263479 +0100
++++ ruby2.1-2.1.5/test/webrick/test_httpauth.rb	2019-11-21 18:07:16.847263282 +0100
+@@ -257,6 +257,28 @@
+     }
+   end
+ 
++  def test_digest_auth_invalid
++    digest_auth = WEBrick::HTTPAuth::DigestAuth.new(Realm: 'realm', UserDB: '')
++
++    def digest_auth.error(fmt, *)
++    end
++
++    def digest_auth.try_bad_request(len)
++      request = {"Authorization" => %[Digest a="#{'\b'*len}]}
++      authenticate request, nil
++    end
++
++    bad_request = WEBrick::HTTPStatus::BadRequest
++    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
++    assert_raise(bad_request) {digest_auth.try_bad_request(10)}
++    limit = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0)
++    [20, 50, 100, 200].each do |len|
++      assert_raise(bad_request) do
++        Timeout.timeout(len*limit) {digest_auth.try_bad_request(len)}
++      end
++    end
++  end
++
+   private
+   def credentials_for_request(user, password, params, body = nil)
+     cnonce = "hoge"

--- a/resources/patches/ruby_219/cve-2019-16254.patch
+++ b/resources/patches/ruby_219/cve-2019-16254.patch
@@ -1,0 +1,82 @@
+Index: ruby2.1-2.1.5/lib/webrick/httpresponse.rb
+===================================================================
+--- ruby2.1-2.1.5.orig/lib/webrick/httpresponse.rb	2019-11-21 18:07:35.292175854 +0100
++++ ruby2.1-2.1.5/lib/webrick/httpresponse.rb	2019-11-21 18:07:35.284175458 +0100
+@@ -366,7 +366,8 @@
+     private
+ 
+     def check_header(header_value)
+-      if header_value =~ /\r\n/
++      header_value = header_value.to_s
++      if /[\r\n]/ =~ header_value
+         raise InvalidHeader
+       else
+         header_value
+Index: ruby2.1-2.1.5/test/webrick/test_httpresponse.rb
+===================================================================
+--- ruby2.1-2.1.5.orig/test/webrick/test_httpresponse.rb	2019-11-21 18:07:35.292175854 +0100
++++ ruby2.1-2.1.5/test/webrick/test_httpresponse.rb	2019-11-21 18:10:10.147837880 +0100
+@@ -28,7 +28,7 @@
+       @res.keep_alive  = true
+     end
+ 
+-    def test_prevent_response_splitting_headers
++    def test_prevent_response_splitting_headers_crlf
+       res['X-header'] = "malicious\r\nCookie: hack"
+       io = StringIO.new
+       res.send_response io
+@@ -38,11 +38,53 @@
+       refute_match 'hack', io.string
+     end
+ 
+-    def test_prevent_response_splitting_cookie_headers
++    def test_prevent_response_splitting_cookie_headers_crlf
+       user_input = "malicious\r\nCookie: hack"
+       res.cookies << WEBrick::Cookie.new('author', user_input)
+       io = StringIO.new
+       res.send_response io
++      io.rewind
++      res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
++      assert_equal '500', res.code
++      refute_match 'hack', io.string
++    end
++
++    def test_prevent_response_splitting_headers_cr
++      res['X-header'] = "malicious\rCookie: hack"
++      io = StringIO.new
++      res.send_response io
++      io.rewind
++      res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
++      assert_equal '500', res.code
++      refute_match 'hack', io.string
++    end
++
++    def test_prevent_response_splitting_cookie_headers_cr
++      user_input = "malicious\rCookie: hack"
++      res.cookies << WEBrick::Cookie.new('author', user_input)
++      io = StringIO.new
++      res.send_response io
++      io.rewind
++      res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
++      assert_equal '500', res.code
++      refute_match 'hack', io.string
++    end
++
++    def test_prevent_response_splitting_headers_lf
++      res['X-header'] = "malicious\nCookie: hack"
++      io = StringIO.new
++      res.send_response io
++      io.rewind
++      res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
++      assert_equal '500', res.code
++      refute_match 'hack', io.string
++    end
++
++    def test_prevent_response_splitting_cookie_headers_lf
++      user_input = "malicious\nCookie: hack"
++      res.cookies << WEBrick::Cookie.new('author', user_input)
++      io = StringIO.new
++      res.send_response io
+       io.rewind
+       res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
+       assert_equal '500', res.code

--- a/resources/patches/ruby_219/cve-2019-16255.patch
+++ b/resources/patches/ruby_219/cve-2019-16255.patch
@@ -1,0 +1,42 @@
+Index: ruby2.1-2.1.5/lib/shell/command-processor.rb
+===================================================================
+--- ruby2.1-2.1.5.orig/lib/shell/command-processor.rb	2019-11-23 19:20:32.174782871 +0100
++++ ruby2.1-2.1.5/lib/shell/command-processor.rb	2019-11-23 19:20:32.170782673 +0100
+@@ -181,6 +181,9 @@
+             top_level_test(command, file1)
+           end
+         else
++          unless FileTest.methods(false).include?(command.to_sym)
++            raise "unsupported command: #{ command }"
++          end
+           if file2
+             FileTest.send(command, file1, file2)
+           else
+Index: ruby2.1-2.1.5/test/shell/test_command_processor.rb
+===================================================================
+--- ruby2.1-2.1.5.orig/test/shell/test_command_processor.rb	2019-11-23 19:20:32.174782871 +0100
++++ ruby2.1-2.1.5/test/shell/test_command_processor.rb	2019-11-23 19:21:17.225018088 +0100
+@@ -66,4 +66,23 @@
+     Process.waitall
+     Dir.rmdir(path)
+   end
++
++  def test_test
++    name = "foo#{exeext}"
++    path = File.join(@tmpdir, name)
++    open(path, "w", 0644) {}
++
++    assert_equal(true, @shell[?e, path])
++    assert_equal(true, @shell[:e, path])
++    assert_equal(true, @shell["e", path])
++    assert_equal(true, @shell[:exist?, path])
++    assert_equal(true, @shell["exist?", path])
++    assert_raise_with_message(RuntimeError, /unsupported command/) do
++      assert_equal(true, @shell[:instance_eval, path])
++    end
++  ensure
++    Process.waitall
++    File.unlink(path)
++  end
++
+ end


### PR DESCRIPTION
Four CVEs were announced in October affecting Ruby 2.1
(https://www.ruby-lang.org/en/security/). This takes the patches from
the Debian Jessie source package for ruby 2.1.5-2+deb8u8.