### PR TITLE
(maint) add dependency to openssl-lib-1.0.2

### DIFF
--- a/configs/components/openssl-1.1.1-fips.rb
+++ b/configs/components/openssl-1.1.1-fips.rb
@@ -11,6 +11,16 @@ component 'openssl-1.1.1-fips' do |pkg, settings, _platform|
   pkg.build_requires 'perl-Test-Harness'
   pkg.build_requires 'perl-Module-Load-Conditional'
 
+  #############################
+  # ENVIRONMENT, FLAGS, TARGETS
+  #############################
+
+  # make sure openssl-lib compiles first, as we it only installs versioned libs and hopefully will not cause problems
+  # the other way around caused: # error "Inconsistency between crypto.h and cryptlib.c"
+  if settings[:provide_ssllib] && platform.is_linux?
+    pkg.build_requires 'openssl-lib'
+  end
+
   # FIXME: pkg.apply_patch is not usefull here as vanagon component does
   # not know how to extract rpm and patch happend before configure step
   # proper fix would be extension in vanagon for source rpm handling


### PR DESCRIPTION
 as on 5.5.x we still deliver openssl-lib-1.0.2, we need to make sure they
 are compiled before openssl-1.1.1-fips