### PR TITLE
(maint) Fix rubygem-ffi on cross compiled builds

### DIFF
--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -53,15 +53,17 @@ component "rubygem-ffi" do |pkg, settings, platform|
     # solaris 10 uses ruby 2.0 which doesn't install native extensions based on architecture
     unless platform.name =~ /solaris-10/
       # weird architecture naming conventions...
-      target_architecture = if platform.architecture =~ /ppc64el|ppc64le/
-                              "powerpc64le"
-                            else
-                              platform.architecture
-                            end
+      target_triple = if platform.architecture =~ /ppc64el|ppc64le/
+                        "powerpc64le-linux"
+                      elsif platform.name =~ /solaris-11-sparc/
+                        "sparc-solaris-2.11"
+                      else
+                        "#{platform.architecture}-linux"
+                      end
 
       pkg.build do
         [
-          %(#{platform[:sed]} -i 's/Gem::Platform.local.to_s/"#{target_architecture}-linux"/' #{base_ruby}/rubygems/basic_specification.rb),
+          %(#{platform[:sed]} -i 's/Gem::Platform.local.to_s/"#{target_triple}"/' #{base_ruby}/rubygems/basic_specification.rb),
           %(#{platform[:sed]} -i 's/Gem.extension_api_version/"#{ruby_api_version}"/' #{base_ruby}/rubygems/basic_specification.rb)
         ]
       end

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -51,7 +51,7 @@ basedir=default" > /var/tmp/vanagon-noask;
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake libgcc_s1 libreadline6 pkgconfig ggrep libffi_dev ruby20 ruby20_dev || exit 1;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake libgcc_s1 libreadline6 pkgconfig ggrep ruby20 ruby20_dev || exit 1;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
@@ -65,11 +65,6 @@ basedir=default" > /var/tmp/vanagon-noask;
   for pkg in #{build_pkgs.join(' ')}; do \
   tmpdir=$(mktemp -p /var/tmp -d); (cd ${tmpdir} && curl -O #{build_url}/${pkg} && gunzip -c ${pkg} | pkgadd -d /dev/stdin -a /var/tmp/vanagon-noask all); \
   done
-
-  # Download the SPARC version of libffi.so
-  /opt/csw/bin/pkgutil --stream --download -T sparc:5.10 libffi6 -y
-  pkgtrans /var/opt/csw/pkgutil/packages/libffi6.sparc.5.10.pkg /opt/csw/lib all
-  cp /opt/csw/lib/CSWlibffi6/root/opt/csw/lib/libffi.so.6.0.4 /opt/csw/lib/libffi.so.6.0.4
 
   ntpdate pool.ntp.org]
 

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -46,6 +46,7 @@ action=nocheck
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
   pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev || exit 1;
 
   ntpdate pool.ntp.org]
 

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -46,7 +46,6 @@ action=nocheck
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
   pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev || exit 1;
 
   ntpdate pool.ntp.org]
 


### PR DESCRIPTION
Apparently we don't need `libffi` when building the `ffi` gem. The gem will also build `libffi` for us which makes things simpler in the long run.

We still need to patch rubygems to think we're on the destination architecture.

Still testing this...