### PR TITLE
(maint) Download build repo from artifactory for bolt-server-runtime

### DIFF
--- a/configs/components/runtime-pe-bolt-server.rb
+++ b/configs/components/runtime-pe-bolt-server.rb
@@ -8,6 +8,15 @@ component "runtime-pe-bolt-server" do |pkg, settings, platform|
     platform.provision_with "echo 'Acquire::AllowInsecureRepositories \"true\";' > /etc/apt/apt.conf.d/90insecure"
   end
 
-  platform.add_build_repository("http://enterprise.delivery.puppetlabs.net/#{settings[:pe_version]}/repos/#{platform.name}/#{platform.name}.repo")
+  artifactory_url = 'https://artifactory.delivery.puppetlabs.net/artifactory'
+
+  if platform.is_rpm?
+    platform.add_build_repository "#{artifactory_url}/rpm_enterprise__local/#{settings[:pe_version]}/repos/#{platform.name}/#{platform.name}.repo"
+  end
+
+  if platform.is_deb?
+    platform.add_build_repository "#{artifactory_url}/debian_enterprise__local/#{settings[:pe_version]}/repos/#{platform.name}/#{platform.name}.list"
+  end
+
   pkg.build_requires('puppet-agent')
 end

--- a/configs/projects/pe-bolt-server-runtime-2019.0.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2019.0.x.rb
@@ -1,6 +1,0 @@
-project 'pe-bolt-server-runtime-2019.0.x' do |proj|
-  proj.setting(:pe_version, '2019.0')
-
-  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server.rb'))
-end
-

--- a/configs/projects/pe-bolt-server-runtime-2019.2.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2019.2.x.rb
@@ -1,6 +1,0 @@
-project 'pe-bolt-server-runtime-2019.2.x' do |proj|
-  proj.setting(:pe_version, '2019.2')
-
-  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server.rb'))
-end
-


### PR DESCRIPTION
This commit updates bolt-server to update repodata from artifactory instead of enterprise.d.p.n.