### PR TITLE
(maint) Bump facter to 4.0.13 for bolt, pe-bolt-server

### DIFF
--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '2.5.7'
-  pkg.md5sum '13b29436cc50caa7a8eeef8c4e1c8d36'
+  pkg.version '4.0.13'
+  pkg.md5sum 'b75e5f9a0f13bfeec9c7e7b29a7e6625'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Closes puppetlabs/bolt#1674