### PR TITLE
(packaging) Update Bolt package component gems

### DIFF
--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.274.0"
-  pkg.md5sum "a258d84bac1e3538c0de8ec2df39c0cb"
+  pkg.version "1.292.0"
+  pkg.md5sum "e5d1428f47d35c01fe2023a14c189f45"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.90.1"
-  pkg.md5sum "213c66e288aa97b209b5ec53f9f28c11"
+  pkg.version "3.92.0"
+  pkg.md5sum "118c7a146f65f09122c20601b4d12892"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.144.0"
-  pkg.md5sum "e0ddd0df7d44c738c62294561a325222"
+  pkg.version "1.151.0"
+  pkg.md5sum "1344705f32bb9f1f19f4fb068a10ad61"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sigv4.rb
+++ b/configs/components/rubygem-aws-sigv4.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sigv4" do |pkg, settings, platform|
-  pkg.version "1.1.0"
-  pkg.md5sum "f51d0073cbe030a489674374b24760d4"
+  pkg.version "1.1.1"
+  pkg.md5sum "516d8371db693d375dcdc57e862aa930"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-bindata.rb
+++ b/configs/components/rubygem-bindata.rb
@@ -1,6 +1,6 @@
 component 'rubygem-bindata' do |pkg, settings, platform|
-  pkg.version '2.4.4'
-  pkg.md5sum '132d77d64bedd315acff3b28b1129877'
+  pkg.version '2.4.7'
+  pkg.md5sum '5803f4525dc4e2687b97aa37f0602a08'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-cri.rb
+++ b/configs/components/rubygem-cri.rb
@@ -1,6 +1,6 @@
 component 'rubygem-cri' do |pkg, settings, platform|
-  pkg.version '2.15.6'
-  pkg.md5sum 'ece5235f0dc2e0e20cc7c7b4a07437b7'
+  pkg.version '2.15.10'
+  pkg.md5sum '5f74856e3a41ba0f9822bb586470838d'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '4.0.13'
-  pkg.md5sum 'b75e5f9a0f13bfeec9c7e7b29a7e6625'
+  pkg.version '4.0.14'
+  pkg.md5sum '98ab3184789da98bd5e053555f7807ba'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-faraday_middleware.rb
+++ b/configs/components/rubygem-faraday_middleware.rb
@@ -1,6 +1,6 @@
 component 'rubygem-faraday_middleware' do |pkg, settings, platform|
-  pkg.version '0.12.2'
-  pkg.md5sum 'd083c60e4c844472fd68572ef2333012'
+  pkg.version '0.14.0'
+  pkg.md5sum '70d2826ffc3f0280e336c97e79ad8e54'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet-resource_api.rb
+++ b/configs/components/rubygem-puppet-resource_api.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet-resource_api' do |pkg, settings, platform|
-  pkg.version '1.8.7'
-  pkg.md5sum '1e592e960934d59cacc7d3b443074a8a'
+  pkg.version '1.8.12'
+  pkg.md5sum '3e4412252e4574bbf86dd9e85a318f22'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet-strings.rb
+++ b/configs/components/rubygem-puppet-strings.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet-strings' do |pkg, settings, platform|
-  pkg.version '2.3.1'
-  pkg.md5sum '8f026b9e089e03571a3be59e25b137fd'
+  pkg.version '2.4.0'
+  pkg.md5sum '62aa815177bd9a1c3808faccbb5ed1b8'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
-  pkg.version '6.13.0'
-  pkg.md5sum 'c1981c24c9d9733abf602504891682e5'
+  pkg.version '6.14.0'
+  pkg.md5sum '229ebd984b38668c8ac16b22d03a1f2a'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet_forge.rb
+++ b/configs/components/rubygem-puppet_forge.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet_forge' do |pkg, settings, platform|
-  pkg.version '2.3.2'
-  pkg.md5sum '13452e071eea03546e99e5a33c0092e5'
+  pkg.version '2.3.4'
+  pkg.md5sum '28a74b4f97fbd3ce8ee184ad81317beb'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,6 +1,6 @@
 component 'rubygem-r10k' do |pkg, settings, platform|
-  pkg.version '3.4.0'
-  pkg.md5sum '03068b228381f7a8f9bf74cacaedda57'
+  pkg.version '3.4.1'
+  pkg.md5sum '0dec8b5602673ef8076166d9407bb77e'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-rubyzip.rb
+++ b/configs/components/rubygem-rubyzip.rb
@@ -1,6 +1,6 @@
 component 'rubygem-rubyzip' do |pkg, settings, platform|
-  pkg.version '2.2.0'
-  pkg.md5sum '291c5f31a564aab24180473c34482b45'
+  pkg.version '2.3.0'
+  pkg.md5sum '3a836c8f901f875882dde4e58178bbf8'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-unicode-display_width.rb
+++ b/configs/components/rubygem-unicode-display_width.rb
@@ -1,6 +1,6 @@
 component 'rubygem-unicode-display_width' do |pkg, settings, platform|
-  pkg.version '1.6.1'
-  pkg.md5sum '2892f7d0f315d6da30c2d4bdd1c6f216'
+  pkg.version '1.7.0'
+  pkg.md5sum 'fc5d1a566bb85b63054e7dcd2b40661a'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This updates the version of gem dependencies of Bolt to their latest
versions. This PR is limited to gems that are only included in the Bolt
and pe-bolt-server packages.