### PR TITLE
(packaging) Bump shared rubygem component versions to latest

### DIFF
--- a/configs/components/rubygem-bcrypt_pbkdf.rb
+++ b/configs/components/rubygem-bcrypt_pbkdf.rb
@@ -1,6 +1,6 @@
 component 'rubygem-bcrypt_pbkdf' do |pkg, _settings, _platform|
-  pkg.version '1.0.0'
-  pkg.md5sum '5ce3ccb9d550b78a8bca4d208f7ee619'
+  pkg.version '1.0.1'
+  pkg.md5sum '6de346254ec38dd5408e5feeb11b9dd8'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -41,6 +41,8 @@ component "rubygem-ffi" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/#{settings[:platform_triple]}/sysroot/usr/lib/libffi.so.5.0.10", "#{settings[:libdir]}/libffi.so"
   elsif platform.name =~ /solaris-11-i386/
     pkg.install_file "/usr/lib/libffi.so.5.0.10", "#{settings[:libdir]}/libffi.so"
+  elsif platform.name =~ /solaris-10-i386/
+    pkg.install_file "/opt/csw/lib/libffi.so.6", "#{settings[:libdir]}/libffi.so.6"
   end
 
   if platform.name =~ /el-5-x86_64/

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -1,6 +1,6 @@
 component "rubygem-ffi" do |pkg, settings, platform|
-  pkg.version '1.9.25'
-  pkg.md5sum "e8923807b970643d9e356a65038769ac"
+  pkg.version '1.12.2'
+  pkg.md5sum "28dc3d1294a04b728d24ba025e331b13"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -7,6 +7,9 @@ component "rubygem-ffi" do |pkg, settings, platform|
   # Windows versions of the FFI gem have custom filenames, so we overwite the
   # defaults that _base-rubygem provides here, just for Windows.
   if platform.is_windows?
+    # Pin ffi on Windows due to win32-service failures
+    # see: https://github.com/chef/win32-service/issues/70
+    pkg.version '1.9.25'
     # Vanagon's `pkg.mirror` is additive, and the _base_rubygem sets the
     # non-Windows gem as the first mirror, which is incorrect. We need to unset
     # the list of mirrors before adding the Windows-appropriate ones here:

--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -1,6 +1,6 @@
 component "rubygem-gettext-setup" do |pkg, settings, platform|
-  pkg.version "0.31"
-  pkg.md5sum "529706bf23b9c796d1ccad790764c41e"
+  pkg.version "0.34"
+  pkg.md5sum "72e511431d138a7c3e062d5e06989a40"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-locale.rb
+++ b/configs/components/rubygem-locale.rb
@@ -1,6 +1,6 @@
 component "rubygem-locale" do |pkg, settings, platform|
-  pkg.version "2.1.2"
-  pkg.md5sum "def1e89d1d3126a0c684d3b7b20d88d4"
+  pkg.version "2.1.3"
+  pkg.md5sum "f5bef9eed8e8c40417a3ab68fa34f477"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 

--- a/configs/components/rubygem-multi_json.rb
+++ b/configs/components/rubygem-multi_json.rb
@@ -1,6 +1,6 @@
 component "rubygem-multi_json" do |pkg, settings, platform|
-  pkg.version '1.13.1'
-  pkg.md5sum 'b7702a827fd011461fbda6b80f2219d5'
+  pkg.version '1.14.1'
+  pkg.md5sum 'ff088e41a3af364202670f3afdead842'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 


### PR DESCRIPTION
This updates rubygem component versions to their latest for gems that
are shared across multiple projects.

Specifically the @puppetlabs/installer-and-management team includes:
bcrypt_pbkdf
ffi
gettext-setup
locale
multi_json

The puppet-agent package includes:
concurrent-ruby
ffi
gettext-setup
locale
multi_json

The @puppetlabs/pdk package includes:
ffi
gettext-setup