### PR TITLE
(maint) remove devscripts update

### DIFF
--- a/configs/platforms/ubuntu-20.04-amd64.rb
+++ b/configs/platforms/ubuntu-20.04-amd64.rb
@@ -8,7 +8,6 @@ platform "ubuntu-20.04-amd64" do |plat|
 
   packages = [
     "build-essential",
-    "devscripts",
     "make",
     "quilt",
     "pkg-config",
@@ -27,6 +26,17 @@ platform "ubuntu-20.04-amd64" do |plat|
     "systemtap-sdt-dev",
     "zlib1g-dev"
   ]
+
+  # FIXME
+  # this is needed since `apt-get install devscripts` updated libc to a version that is not compatible
+  # with the version installed by default om vmpooler images.
+  # To overcome this:
+  # - `devscripts` package in no longer upgraded (since is already installed)
+  # - `libc6` marked as hold to detect early packages trying to update it
+  #
+  # This workaround should be removed when image is updated with released iso version
+  #
+  plat.provision_with "apt-mark hold libc6"
 
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq && apt-get install -qy --no-install-recommends #{packages.join(' ')}"
 


### PR DESCRIPTION
 this is needed since `apt-get install devscripts` updated libc to a version that is not compatible
 with the version installed by default om vmpooler images.
 To overcome this:
 - `devscripts` package in no longer upgraded (since is already installed)
 - `libc6` marked as hold to detect early packages trying to update it

 This workaround should be removed when image is updated with released iso version