### PR TITLE
(PA-3179) fix ruby download url

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -5,7 +5,7 @@
 # Condensed version, e.g. '2.4.3' -> '243'
 ruby_version_condensed = pkg.get_version.tr('.', '')
 # Y version, e.g. '2.4.3' -> '2.4'
-ruby_version_y = pkg.get_version.gsub(/(\d)\.(\d)\.(\d)/, '\1.\2')
+ruby_version_y = pkg.get_version.gsub(/(\d)\.(\d)\.(\d+)/, '\1.\2')
 
 pkg.mirror "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
 pkg.url "https://cache.ruby-lang.org/pub/ruby/#{ruby_version_y}/ruby-#{pkg.get_version}.tar.gz"


### PR DESCRIPTION
Update the gsub on ruby version to handle multiple digits
z version

```
# before
>> "2.4.10".gsub(/(\d)\.(\d)\.(\d)/, '\1.\2') #=> "2.40"

# now
>> "2.4.10".gsub(/(\d)\.(\d)\.(\d+)/, '\1.\2') #=> "2.4"
>> "2.4.1".gsub(/(\d)\.(\d)\.(\d+)/, '\1.\2') #=> "2.4"
```