### PR TITLE
(maint) Add option in agent builds to enable debug sym

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -38,6 +38,10 @@ component 'curl' do |pkg, settings, platform|
     configure_options << "--disable-dependency-tracking"
   end
 
+  if settings[:debug_symbols]
+    configure_options << '--enable-debug'
+  end
+
   pkg.configure do
     ["CPPFLAGS='#{settings[:cppflags]}' \
       LDFLAGS='#{settings[:ldflags]}' \

--- a/configs/components/openssl-1.0.2.rb
+++ b/configs/components/openssl-1.0.2.rb
@@ -127,6 +127,10 @@ component 'openssl' do |pkg, settings, platform|
 
   configure_flags += ['fips', "--with-fipsdir=#{settings[:prefix]}/usr/local/ssl/fips-2.0"] if platform.name =~ /windowsfips-2012r2/
 
+  if settings[:debug_symbols]
+    configure_flags += ['-g3', '-O0', '-fno-omit-frame-pointer', '-fno-inline-functions']
+  end
+
   # Individual projects may provide their own openssl configure flags:
   project_flags = settings[:openssl_extra_configure_flags] || []
   configure_flags << project_flags << cflags << ldflags

--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -122,6 +122,10 @@ component 'openssl' do |pkg, settings, platform|
     'no-ssl3'
   ]
 
+  if settings[:debug_symbols]
+    configure_flags += ['-g3', '-O0', '-fno-omit-frame-pointer', '-fno-inline-functions']
+  end
+
   # Individual projects may provide their own openssl configure flags:
   project_flags = settings[:openssl_extra_configure_flags] || []
   perl_exec = ''

--- a/configs/components/openssl-lib.rb
+++ b/configs/components/openssl-lib.rb
@@ -124,6 +124,10 @@ component 'openssl-lib' do |pkg, settings, platform|
 
   configure_flags += ['fips', "--with-fipsdir=#{settings[:prefix]}/usr/local/ssl/fips-2.0"] if platform.name =~ /windowsfips-2012r2/
 
+  if settings[:debug_symbols]
+    configure_flags += ['-g3', '-O0', '-fno-omit-frame-pointer', '-fno-inline-functions']
+  end
+
   # Individual projects may provide their own openssl configure flags:
   project_flags = settings[:openssl_extra_configure_flags] || []
   configure_flags << project_flags << cflags << ldflags

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -9,6 +9,10 @@ end
 # Export the settings for the current project and platform as yaml during builds
 proj.publish_yaml_settings
 
+if ENV['CPP_COMPONENT_DEBUG_SYM']
+  proj.setting(:debug_symbols, true)
+end
+
 # Use sparingly in component configurations to conditionally include
 # dependencies that should not be in other projects that use puppet-runtime
 proj.setting(:runtime_project, 'agent')


### PR DESCRIPTION
This commit adds an option to the agent build that will build
openssl,curl,boost with debug symbols.

Set the environment var CPP_COMPONENT_DEBUG_SYM to enable debug symbols in the
build