### PR TITLE
Use linux-aarch64 openssl target on aarch64

### DIFF
--- a/configs/components/openssl-1.0.2.rb
+++ b/configs/components/openssl-1.0.2.rb
@@ -59,6 +59,8 @@ component 'openssl' do |pkg, settings, platform|
     if platform.architecture =~ /86$/
       target = 'linux-elf'
       sslflags = '386'
+    elsif platform.architecture =~ /aarch64$/
+      target = 'linux-aarch64'
     elsif platform.architecture =~ /64$/
       target = 'linux-x86_64'
     end

--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -72,6 +72,8 @@ component 'openssl' do |pkg, settings, platform|
     if platform.architecture =~ /86$/
       target = 'linux-elf'
       sslflags = '386'
+    elsif platform.architecture =~ /aarch64$/
+      target = 'linux-aarch64'
     elsif platform.architecture =~ /64$/
       target = 'linux-x86_64'
     end

--- a/configs/components/openssl-lib.rb
+++ b/configs/components/openssl-lib.rb
@@ -59,6 +59,8 @@ component 'openssl-lib' do |pkg, settings, platform|
     if platform.architecture =~ /86$/
       target = 'linux-elf'
       sslflags = '386'
+    elsif platform.architecture =~ /aarch64$/
+      target = 'linux-aarch64'
     elsif platform.architecture =~ /64$/
       target = 'linux-x86_64'
     end


### PR DESCRIPTION
Using the platform el-8-aarch64 openssl build target was being
incorrectly specified as linux-x86_64. Use the correct
openssl linux-aarch64 instead.