### PR TITLE
(PA-3186) Bump OpenSSL to 1.1.1g

### DIFF
--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -1,6 +1,6 @@
 component 'openssl' do |pkg, settings, platform|
-  pkg.version '1.1.1f'
-  pkg.sha256sum '186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35'
+  pkg.version '1.1.1g'
+  pkg.sha256sum 'ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46'
   pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/openssl-#{pkg.get_version}.tar.gz"
 


### PR DESCRIPTION
Fixes segmentation fault in SSL_check_chain (CVE-2020-1967)