### PR TITLE
(maint) Bump net-ssh gem to 6.0.2 for Bolt

### DIFF
--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -4,6 +4,8 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.version version
 
   case version
+  when "6.0.2"
+    pkg.md5sum "20d6098cf1139c66c26d53f0c42456b3"
   when "5.2.0"
     pkg.md5sum "341114b3bf34257abd3b11bd16b0c99d"
   when "4.2.0"

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -42,7 +42,7 @@ proj.setting(:runtime_project, 'pe-bolt-server')
 # TODO: Can runtime projects use these updated versions?
 proj.setting(:rubygem_gettext_version, '3.2.9')
 proj.setting(:rubygem_deep_merge_version, '1.2.1')
-proj.setting(:rubygem_net_ssh_version, '5.2.0')
+proj.setting(:rubygem_net_ssh_version, '6.0.2')
 
 # (pe-bolt-server does not run on Windows, so only the *nix path is here)
 proj.setting(:prefix, '/opt/puppetlabs/server/apps/bolt-server')

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -3,7 +3,7 @@ project 'bolt-runtime' do |proj|
   proj.setting(:runtime_project, 'bolt')
   proj.setting(:ruby_version, '2.5.8')
   proj.setting(:openssl_version, '1.1.1')
-  proj.setting(:rubygem_net_ssh_version, '5.2.0')
+  proj.setting(:rubygem_net_ssh_version, '6.0.2')
   proj.setting(:augeas_version, '1.11.0')
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_gettext_version, '3.2.9')


### PR DESCRIPTION
The net-ssh gem release 6.0.2 which includes several improvements
relevant to Bolt, including support for the OpenSSH
`StrictHostKeyChecking` option, performance improvements, and
curve25519sha256 key support.