### PR TITLE
(packaging) Add x25519 gem to bolt-runtime, shared-pe-bolt-server

### DIFF
--- a/configs/components/rubygem-x25519.rb
+++ b/configs/components/rubygem-x25519.rb
@@ -1,0 +1,6 @@
+component 'rubygem-x25519' do |pkg, settings, platform|
+  pkg.version '1.0.8'
+  pkg.md5sum '6d6fd1c422a6d1e370ea6aa2ee356982'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -128,6 +128,7 @@ proj.component('rubygem-rubyzip')
 proj.component('rubygem-terminal-table')
 proj.component('rubygem-thor')
 proj.component('rubygem-unicode-display_width')
+proj.component('rubygem-x25519')
 proj.component('rubygem-yard')
 
 # Core Windows dependencies

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -191,6 +191,7 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-terminal-table'
   proj.component 'rubygem-thor'
   proj.component 'rubygem-unicode-display_width'
+  proj.component 'rubygem-x25519'
   proj.component 'rubygem-yard'
 
   # Core Windows dependencies


### PR DESCRIPTION
This adds the `x25519` gem as a dependency in Bolt packaging. The gem
is needed by `net-ssh` to support the `curve25519-sha256` kex algorithm.

Part of puppetlabs/bolt#733