### PR TITLE
Revert "(packaging) Add x25519 gem to bolt-runtime, shared-pe-bolt-server"

### DIFF
--- a/configs/components/rubygem-x25519.rb
+++ b/configs/components/rubygem-x25519.rb
@@ -1,6 +1,0 @@
-component 'rubygem-x25519' do |pkg, settings, platform|
-  pkg.version '1.0.8'
-  pkg.md5sum '6d6fd1c422a6d1e370ea6aa2ee356982'
-
-  instance_eval File.read('configs/components/_base-rubygem.rb')
-end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -128,7 +128,6 @@ proj.component('rubygem-rubyzip')
 proj.component('rubygem-terminal-table')
 proj.component('rubygem-thor')
 proj.component('rubygem-unicode-display_width')
-proj.component('rubygem-x25519')
 proj.component('rubygem-yard')
 
 # Core Windows dependencies

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -191,7 +191,6 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-terminal-table'
   proj.component 'rubygem-thor'
   proj.component 'rubygem-unicode-display_width'
-  proj.component 'rubygem-x25519'
   proj.component 'rubygem-yard'
 
   # Core Windows dependencies


### PR DESCRIPTION
Reverts puppetlabs/puppet-runtime#330

`x25519` fails to build native extensions on several platforms, including el6, debian 8, ubuntu 1604, and windows. This reverts the update to the bolt-runtime and shared-pe-bolt-server projects so we can make the appropriate changes.