### PR TITLE
(maint) Add x25519 gem dependency to bolt-runtime

### DIFF
--- a/configs/components/rubygem-x25519.rb
+++ b/configs/components/rubygem-x25519.rb
@@ -1,0 +1,6 @@
+component 'rubygem-x25519' do |pkg, settings, platform|
+  pkg.version '1.0.8'
+  pkg.md5sum '6d6fd1c422a6d1e370ea6aa2ee356982'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -122,6 +122,12 @@ project 'bolt-runtime' do |proj|
     proj.component 'rubygem-ed25519'
   end
 
+  # Building native extensions for the x25519 gem is only supported
+  # on 64-bit, non-Windows systems.
+  unless platform.is_windows? || platform.dist == 'el6' || platform.architecture == 'i386'
+    proj.component 'rubygem-x25519'
+  end
+
   # Puppet dependencies
   proj.component 'rubygem-hocon'
   proj.component 'rubygem-deep_merge'


### PR DESCRIPTION
This adds the `x25519` gem dependency to bolt packaging, except on
Windows platforms, 32-bit platforms, and el6.