### PR TITLE
(PA-3223) OpenSSL 1.1.1-fips config update

### DIFF
--- a/configs/components/openssl-1.1.1-fips.rb
+++ b/configs/components/openssl-1.1.1-fips.rb
@@ -24,6 +24,7 @@ component 'openssl-1.1.1-fips' do |pkg, settings, _platform|
   # FIXME: pkg.apply_patch is not usefull here as vanagon component does
   # not know how to extract rpm and patch happend before configure step
   # proper fix would be extension in vanagon for source rpm handling
+  pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-patch-openssl-cnf.patch'
   pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-force-fips-mode.patch'
   pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-post-rand.patch'
   pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch'
@@ -35,6 +36,7 @@ component 'openssl-1.1.1-fips' do |pkg, settings, _platform|
   pkg.configure do
     [
       "rpm -i #{topdir} openssl-#{pkg.get_version}.el8.src.rpm",
+      "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-patch-openssl-cnf.patch && cd -",
       "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-force-fips-mode.patch && cd -",
       "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-post-rand.patch && cd -",
       "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-spec-file.patch && cd -"

--- a/resources/patches/openssl/openssl-1.1.1-fips-patch-openssl-cnf.patch
+++ b/resources/patches/openssl/openssl-1.1.1-fips-patch-openssl-cnf.patch
@@ -1,0 +1,20 @@
+-- a/SOURCES/openssl-1.1.1-openssl-cnf-fips-mode.patch     1970-01-01 00:00:00.000000000 +0000
++++ a/SOURCES/openssl-1.1.1-openssl-cnf-fips-mode.patch    2020-01-13 15:17:06.850638770 +0000
+@@ -0,0 +1,17 @@
++--- openssl-1.1.1c/apps/openssl.cnf.orig	2020-05-07 18:41:48.140115738 +0000
+++++ openssl-1.1.1c/apps/openssl.cnf	2020-05-07 18:42:35.721120857 +0000
++@@ -32,11 +32,11 @@
++ 
++ [ ssl_module ]
++ 
++-system_default = crypto_policy
+++alg_section = evp_settings
++ 
++-[ crypto_policy ]
+++[ evp_settings ]
++ 
++-.include /etc/crypto-policies/back-ends/opensslcnf.config
+++fips_mode = true
++ 
++ [ new_oids ]
++ 

--- a/resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch
+++ b/resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch
@@ -1,10 +1,11 @@
 --- a/SPECS/openssl.spec	2019-05-11 00:45:45.000000000 +0000
 +++ b/SPECS/openssl.spec	2020-01-13 15:16:29.224852120 +0000
-@@ -67,17 +67,18 @@
+@@ -67,17 +67,19 @@
  Patch52: openssl-1.1.1-s390x-update.patch
  Patch53: openssl-1.1.1-fips-crng-test.patch
  Patch54: openssl-1.1.1-regression-fixes.patch
 +Patch55: openssl-1.1.1-force-fips-on-init.patch
++Patch56: openssl-1.1.1-openssl-cnf-fips-mode.patch
  
  License: OpenSSL
  Group: System Environment/Libraries
@@ -38,11 +39,12 @@
  Requires: %{name}%{?_isa} = %{epoch}:%{version}-%{release}
  
  %description perl
-@@ -177,6 +177,7 @@
+@@ -177,6 +177,8 @@
  %patch52 -p1 -b .s390x-update
  %patch53 -p1 -b .crng-test
  %patch54 -p1 -b .regression
 +%patch55 -p1 -b .force-fips-on-init
++%patch56 -p1 -b .openssl-cnf-fips-mode
  
  
  %build


### PR DESCRIPTION
As OpenSSL 1.1.1-fips is backported from RHEL8 to RHEL7-fips, openssl.cnf
also needs to be adapted, since on RHEL8 openssl expects backends configuration
to be generated by `update-crypto-policies`, while this tool is not available on RHEL7

With this change, the openssl algorithms configuration is done by evp_setting fips_mode.