### PR TITLE
(maint) Enable Docker buildkit linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
         - DOCKER_COMPOSE_VERSION=1.25.5
         # necessary to prevent overwhelming TravisCI build output limits
         - DOCKER_BUILD_FLAGS="--progress plain"
-      script:
+      before_install:
         - |
           if [ -n "$TRAVIS_COMMIT_RANGE" ]; then
             git diff --name-only $TRAVIS_COMMIT_RANGE | grep docker || {
@@ -43,13 +43,15 @@ matrix:
               exit
             }
           fi
-          set -ex
-          sudo rm /usr/local/bin/docker-compose
-          curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
-          cd docker
-          make lint build test
-          set +x
+        - sudo rm /usr/local/bin/docker-compose
+        - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
+        - chmod +x docker-compose
+        - sudo mv docker-compose /usr/local/bin
+      script:
+        - set -e
+        - cd docker
+        - make lint
+        - make build
+        - make test
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
         - docker
       env:
         - DOCKER_COMPOSE_VERSION=1.25.5
+        # necessary to prevent overwhelming TravisCI build output limits
+        - DOCKER_BUILD_FLAGS="--progress plain"
       script:
         - |
           if [ -n "$TRAVIS_COMMIT_RANGE" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
           fi
     - stage: runtime container tests
       rvm: 2.6.6
+      services:
+        - docker
       env:
         - DOCKER_COMPOSE_VERSION=1.25.5
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 sudo: false
 language: ruby
 matrix:
@@ -27,7 +28,7 @@ matrix:
             false
           fi
     - stage: runtime container tests
-      rvm: 2.5.5
+      rvm: 2.6.6
       env:
         - DOCKER_COMPOSE_VERSION=1.25.5
       script:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ variables:
   CONTAINER_NAME: puppet-runtime
   LINT_IGNORES:
   DOCKER_BUILDKIT: 1
+  BUILD_OPTIONS: --build-arg centos_version=7
 
 workspace:
   clean: resources
@@ -51,7 +52,7 @@ steps:
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
-    Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE
+    Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -AdditionalOptions ($ENV:BUILD_OPTIONS -split ' ')
   displayName: Build $(CONTAINER_NAME) Container
   timeoutInMinutes: 5
   name: build_container

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,6 +9,7 @@ pwd := $(shell pwd)
 export BUNDLE_PATH = $(pwd)/.bundle/gems
 export BUNDLE_BIN = $(pwd)/.bundle/bin
 export GEMFILE = $(pwd)/Gemfile
+export CENTOS_VERSION = 7
 export DOCKER_BUILDKIT = 1
 
 version = $(shell echo $(git_describe) | sed 's/-.*//')
@@ -17,6 +18,7 @@ agent_branches := 1.10.x 5.5.x master
 prep:
 	@git fetch --unshallow 2> /dev/null ||:
 	@git fetch origin 'refs/tags/*:refs/tags/*'
+	docker pull centos:$$CENTOS_VERSION
 
 lint:
 ifeq ($(hadolint_available),0)
@@ -33,7 +35,7 @@ build-agent-runtimes: prep
 	@for branch in $(agent_branches); do \
 		docker build \
 			${DOCKER_BUILD_FLAGS} \
-			--pull \
+			--build-arg centos_version=$$CENTOS_VERSION \
 			--build-arg vcs_ref=$(vcs_ref) \
 			--build-arg build_date=$(build_date) \
 			--build-arg version=$(version) \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,6 +9,7 @@ pwd := $(shell pwd)
 export BUNDLE_PATH = $(pwd)/.bundle/gems
 export BUNDLE_BIN = $(pwd)/.bundle/bin
 export GEMFILE = $(pwd)/Gemfile
+export DOCKER_BUILDKIT = 1
 
 version = $(shell echo $(git_describe) | sed 's/-.*//')
 agent_branches := 1.10.x 5.5.x master
@@ -31,6 +32,7 @@ build: prep build-agent-runtimes
 build-agent-runtimes: prep
 	@for branch in $(agent_branches); do \
 		docker build \
+			${DOCKER_BUILD_FLAGS} \
 			--pull \
 			--build-arg vcs_ref=$(vcs_ref) \
 			--build-arg build_date=$(build_date) \

--- a/docker/puppet-runtime/Dockerfile
+++ b/docker/puppet-runtime/Dockerfile
@@ -1,4 +1,6 @@
-FROM centos:7
+ARG centos_version=7
+
+FROM centos:${centos_version}
 
 ARG vcs_ref
 ARG build_date


### PR DESCRIPTION
- Switches Travis to Ubuntu 20.04 builder that has Docker 19.03 pre-installed, so that removes ~30s of setup time from builds
- Enable Docker buildkit (for this project it's mostly an improvement for local caching)
- Buildkit in Travis doesn't seem to work right pulling CentOS with the `--pull` switch for `docker build`, so manually download the image prior to building (based on https://github.com/puppetlabs/puppet-agent/pull/1906 / https://github.com/puppetlabs/puppet-agent/pull/1907)
- Separate out Travis operations so that logs have timings for lint, build and test