### PR TITLE
Revert "(maint) Add x25519 gem dependency to bolt-runtime"

### DIFF
--- a/configs/components/rubygem-x25519.rb
+++ b/configs/components/rubygem-x25519.rb
@@ -1,6 +1,0 @@
-component 'rubygem-x25519' do |pkg, settings, platform|
-  pkg.version '1.0.8'
-  pkg.md5sum '6d6fd1c422a6d1e370ea6aa2ee356982'
-
-  instance_eval File.read('configs/components/_base-rubygem.rb')
-end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -122,12 +122,6 @@ project 'bolt-runtime' do |proj|
     proj.component 'rubygem-ed25519'
   end
 
-  # Building native extensions for the x25519 gem is only supported
-  # on 64-bit, non-Windows systems.
-  unless platform.is_windows? || platform.dist == 'el6' || platform.architecture == 'i386'
-    proj.component 'rubygem-x25519'
-  end
-
   # Puppet dependencies
   proj.component 'rubygem-hocon'
   proj.component 'rubygem-deep_merge'


### PR DESCRIPTION
Reverts puppetlabs/puppet-runtime#333

This gem has fundamental issues that cause it to crash on unsupported architectures / CPUs. Because of it's unreliability, we should not ship this with Bolt.