### PR TITLE
(packaging) Bump facter to 4.0.21 for bolt, pe-bolt-server

### DIFF
--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '4.0.14'
-  pkg.md5sum '98ab3184789da98bd5e053555f7807ba'
+  pkg.version '4.0.21'
+  pkg.md5sum '1122f4cec8a7151c2d8a238ad34acf15'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Closes puppetlabs/bolt#1813