### PR TITLE
(PA-3250) remove env check for OPENSSL_FIPS

### DIFF
--- a/configs/components/openssl-1.1.1-fips.rb
+++ b/configs/components/openssl-1.1.1-fips.rb
@@ -28,6 +28,7 @@ component 'openssl-1.1.1-fips' do |pkg, settings, _platform|
   pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-force-fips-mode.patch'
   pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-post-rand.patch'
   pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch'
+  pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-remove-env-check.patch'
 
   topdir = "--define \"_topdir `pwd`/openssl-#{pkg.get_version}\""
   libdir = "--define '%_libdir %{_prefix}/lib'"
@@ -39,7 +40,8 @@ component 'openssl-1.1.1-fips' do |pkg, settings, _platform|
       "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-patch-openssl-cnf.patch && cd -",
       "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-force-fips-mode.patch && cd -",
       "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-post-rand.patch && cd -",
-      "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-spec-file.patch && cd -"
+      "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-spec-file.patch && cd -",
+      "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-remove-env-check.patch && cd -"
     ]
   end
 

--- a/resources/patches/openssl/openssl-1.1.1-fips-remove-env-check.patch
+++ b/resources/patches/openssl/openssl-1.1.1-fips-remove-env-check.patch
@@ -1,0 +1,17 @@
+--- a/SOURCES/openssl-1.1.1-remove-env-check.patch	1970-01-01 00:00:00.000000000 +0000
++++ a/SOURCES/openssl-1.1.1-remove-env-check.patch	2020-06-02 08:11:15.751135001 +0000
+@@ -0,0 +1,14 @@
++--- openssl-1.1.1/apps/openssl.c.orig	2020-06-02 08:02:26.670078073 +0000
+++++ openssl-1.1.1/apps/openssl.c	2020-06-02 08:02:49.915080574 +0000
++@@ -151,11 +151,6 @@
++         CRYPTO_set_mem_debug(1);
++     CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
++ 
++-    if (getenv("OPENSSL_FIPS")) {
++-        BIO_printf(bio_err, "FIPS mode not supported.\n");
++-        return 1;
++-    }
++-
++     if (!apps_startup()) {
++         BIO_printf(bio_err,
++                    "FATAL: Startup failure (dev note: apps_startup() failed)\n");

--- a/resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch
+++ b/resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch
@@ -1,11 +1,12 @@
 --- a/SPECS/openssl.spec	2019-05-11 00:45:45.000000000 +0000
 +++ b/SPECS/openssl.spec	2020-01-13 15:16:29.224852120 +0000
-@@ -67,17 +67,19 @@
+@@ -67,17 +67,20 @@
  Patch52: openssl-1.1.1-s390x-update.patch
  Patch53: openssl-1.1.1-fips-crng-test.patch
  Patch54: openssl-1.1.1-regression-fixes.patch
 +Patch55: openssl-1.1.1-force-fips-on-init.patch
 +Patch56: openssl-1.1.1-openssl-cnf-fips-mode.patch
++Patch57: openssl-1.1.1-remove-env-check.patch
  
  License: OpenSSL
  Group: System Environment/Libraries
@@ -39,12 +40,13 @@
  Requires: %{name}%{?_isa} = %{epoch}:%{version}-%{release}
  
  %description perl
-@@ -177,6 +177,8 @@
+@@ -177,6 +177,9 @@
  %patch52 -p1 -b .s390x-update
  %patch53 -p1 -b .crng-test
  %patch54 -p1 -b .regression
 +%patch55 -p1 -b .force-fips-on-init
 +%patch56 -p1 -b .openssl-cnf-fips-mode
++%patch57 -p1 -b .remove-env-check
  
  
  %build


### PR DESCRIPTION
OPENSSL_FIPS env variable was used inside openssl 1.0.2 application
to throw error if openssl was not compiled in fips mode.

After move to openssl 1.1.0/1.1.1 branch (that is not supporting FIPS mode)
the check was change to dirrectly throw error if OPENSSL_FIPS is set.

After this commit, the check is removed for redhat7 vendored openssl fips