### PR TITLE
(packaging) Update puppet to 6.16.0 for bolt/bolt-server

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
-  pkg.version '6.15.0'
-  pkg.md5sum '4fc59e4be69e9526921899b5e0e7c1ff'
+  pkg.version '6.16.0'
+  pkg.md5sum 'ed0c92a2bbeb5247bff7e33fb85af873'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This commit pulls in 6.16.0 to accomidate improvements to PAL api used by bolt for apply.