### PR TITLE
(PA-3006) Vendor boost and yaml-cpp on SLES 15

### DIFF
--- a/configs/platforms/sles-15-x86_64.rb
+++ b/configs/platforms/sles-15-x86_64.rb
@@ -9,7 +9,7 @@ platform "sles-15-x86_64" do |plat|
     "aaa_base",
     "autoconf",
     "automake",
-    "gcc",
+    "gcc-c++",
     "java-1_8_0-openjdk-devel",
     "libbz2-devel",
     "make",

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -42,9 +42,8 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'rubygem-highline'
   proj.component 'rubygem-hiera-eyaml'
   proj.component 'ruby-stomp'
-  # SLES 15 uses the OS distro versions of boost and yaml-cpp:
-  proj.component 'boost' unless platform.name =~ /sles-15/
-  proj.component 'yaml-cpp' unless platform.name =~ /sles-15/
+  proj.component 'boost'
+  proj.component 'yaml-cpp'
 
   proj.component 'openssl-lib' if platform.is_linux?
 end

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -40,7 +40,6 @@ project 'agent-runtime-master' do |proj|
     proj.component 'rubygem-sys-filesystem'
   end
 
-  # SLES 15 uses the OS distro versions of boost and yaml-cpp:
-  proj.component 'boost' unless platform.name =~ /sles-15/
-  proj.component 'yaml-cpp' unless platform.name =~ /sles-15/
+  proj.component 'boost'
+  proj.component 'yaml-cpp'
 end


### PR DESCRIPTION
Successfully built both 5.5.x and master runtimes on SLES 15.