### PR TITLE
(maint) Add paint gem for rainbow output format

### DIFF
--- a/configs/components/rubygem-paint.rb
+++ b/configs/components/rubygem-paint.rb
@@ -1,0 +1,6 @@
+component 'rubygem-paint' do |pkg, settings, platform|
+  pkg.version '2.2.0'
+  pkg.md5sum 'ddd76c92404e3af9abcbae2d26a47a3d'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -177,6 +177,7 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-net-ssh-krb'
   proj.component 'rubygem-nori'
   proj.component 'rubygem-orchestrator_client'
+  proj.component 'rubygem-paint'
   proj.component 'rubygem-public_suffix'
   proj.component 'rubygem-puppet'
   proj.component 'rubygem-puppet_forge'


### PR DESCRIPTION
This adds the paint rubygem that's a new dependency for Bolt to support
rainbow formatted output - see puppetlabs/bolt#1911.