### PR TITLE
(packaging) Bump Bolt dependencies to latest versions

### DIFF
--- a/configs/components/rubygem-aws-eventstream.rb
+++ b/configs/components/rubygem-aws-eventstream.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-eventstream" do |pkg, settings, platform|
-  pkg.version "1.0.3"
-  pkg.md5sum "cf77589b3608786511a827d402c8a260"
+  pkg.version "1.1.0"
+  pkg.md5sum "50f4916f0e7bdc4527f30fe02ad9197f"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.292.0"
-  pkg.md5sum "e5d1428f47d35c01fe2023a14c189f45"
+  pkg.version "1.334.0"
+  pkg.md5sum "755ec4704e0cba52269ed4b3ff44f695"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.92.0"
-  pkg.md5sum "118c7a146f65f09122c20601b4d12892"
+  pkg.version "3.102.0"
+  pkg.md5sum "288a93975a8810d7d9d692147cf0de99"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.151.0"
-  pkg.md5sum "1344705f32bb9f1f19f4fb068a10ad61"
+  pkg.version "1.170.0"
+  pkg.md5sum "013e51f41105ea8449efe02ad2afff97"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sigv4.rb
+++ b/configs/components/rubygem-aws-sigv4.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sigv4" do |pkg, settings, platform|
-  pkg.version "1.1.1"
-  pkg.md5sum "516d8371db693d375dcdc57e862aa930"
+  pkg.version "1.2.1"
+  pkg.md5sum "28b179833defb01be1da401694d741f0"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-connection_pool.rb
+++ b/configs/components/rubygem-connection_pool.rb
@@ -1,6 +1,6 @@
 component 'rubygem-connection_pool' do |pkg, settings, platform|
-  pkg.version '2.2.2'
-  pkg.md5sum '08792dcd46b6410cabb8d4ad321b6d43'
+  pkg.version '2.2.3'
+  pkg.md5sum '1ccc96dc7feb55947fe7ec6799ba19b3'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '4.0.21'
-  pkg.md5sum '1122f4cec8a7151c2d8a238ad34acf15'
+  pkg.version '4.0.28'
+  pkg.md5sum '92ff77b556cad16de75e47460dcbd3fd'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-net-http-persistent.rb
+++ b/configs/components/rubygem-net-http-persistent.rb
@@ -1,6 +1,6 @@
 component 'rubygem-net-http-persistent' do |pkg, settings, platform|
-  pkg.version '3.1.0'
-  pkg.md5sum '255209628ccd2fefd3df41bfb1b49660'
+  pkg.version '4.0.0'
+  pkg.md5sum '68018c9b318cf5ead404c4a0c933d4f1'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -4,8 +4,8 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.version version
 
   case version
-  when "6.0.2"
-    pkg.md5sum "20d6098cf1139c66c26d53f0c42456b3"
+  when "6.1.0"
+    pkg.md5sum "383afadb1bd66a458a5d8d2d60736b3d"
   when "5.2.0"
     pkg.md5sum "341114b3bf34257abd3b11bd16b0c99d"
   when "4.2.0"

--- a/configs/components/rubygem-public_suffix.rb
+++ b/configs/components/rubygem-public_suffix.rb
@@ -1,6 +1,6 @@
 component 'rubygem-public_suffix' do |pkg, _settings, _platform|
-  pkg.version '4.0.3'
-  pkg.md5sum '962527905a37e6f128f81978443bd56a'
+  pkg.version '4.0.5'
+  pkg.md5sum 'fe7579f10c7817f06699f6a0b68e8767'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet-resource_api.rb
+++ b/configs/components/rubygem-puppet-resource_api.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet-resource_api' do |pkg, settings, platform|
-  pkg.version '1.8.12'
-  pkg.md5sum '3e4412252e4574bbf86dd9e85a318f22'
+  pkg.version '1.8.13'
+  pkg.md5sum '3f6edad4f7a03713ff20d8ae0378e895'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,6 +1,6 @@
 component 'rubygem-r10k' do |pkg, settings, platform|
-  pkg.version '3.4.1'
-  pkg.md5sum '0dec8b5602673ef8076166d9407bb77e'
+  pkg.version '3.5.1'
+  pkg.md5sum '93b75d1acf4eba4ab46cde553f3df763'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-yard.rb
+++ b/configs/components/rubygem-yard.rb
@@ -1,6 +1,6 @@
 component 'rubygem-yard' do |pkg, settings, platform|
-  pkg.version '0.9.24'
-  pkg.md5sum '413197ed3b0a0d8c791d2111ea3a1bd0'
+  pkg.version '0.9.25'
+  pkg.md5sum 'b987bbe40d5424ab115e132312d04e1c'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -42,7 +42,7 @@ proj.setting(:runtime_project, 'pe-bolt-server')
 # TODO: Can runtime projects use these updated versions?
 proj.setting(:rubygem_gettext_version, '3.2.9')
 proj.setting(:rubygem_deep_merge_version, '1.2.1')
-proj.setting(:rubygem_net_ssh_version, '6.0.2')
+proj.setting(:rubygem_net_ssh_version, '6.1.0')
 
 # (pe-bolt-server does not run on Windows, so only the *nix path is here)
 proj.setting(:prefix, '/opt/puppetlabs/server/apps/bolt-server')

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -3,7 +3,7 @@ project 'bolt-runtime' do |proj|
   proj.setting(:runtime_project, 'bolt')
   proj.setting(:ruby_version, '2.5.8')
   proj.setting(:openssl_version, '1.1.1')
-  proj.setting(:rubygem_net_ssh_version, '6.0.2')
+  proj.setting(:rubygem_net_ssh_version, '6.1.0')
   proj.setting(:augeas_version, '1.11.0')
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_gettext_version, '3.2.9')


### PR DESCRIPTION
This updates gems used only by Bolt and PE Bolt Server packages to their
latest versions.