### PR TITLE
(PA-3265) add ffi component on Solaris 10

### DIFF
--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -54,10 +54,10 @@ proj.component 'rubygem-fast_gettext'
 
 if platform.is_windows? || platform.is_solaris?
   proj.component 'rubygem-minitar'
+  proj.component 'rubygem-ffi'
 end
 
 if platform.is_windows?
-  proj.component 'rubygem-ffi'
   proj.component 'rubygem-win32-dir'
   proj.component 'rubygem-win32-process'
   proj.component 'rubygem-win32-security'


### PR DESCRIPTION
This commit should fix the following error on Puppet 5.5.x/Solaris 10:
```
10:14:48       Error: Failed to load Solaris implementation of the Puppet::Util::AtFork handler. Child process contract management will be unavailable, which means that agent runs executed by the puppet agent service will be killed when they attempt to restart the service.
```