### PR TITLE
(maint) Try to install libtinfo ubuntu 1804 dep

### DIFF
--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -10,6 +10,7 @@ platform "ubuntu-18.04-amd64" do |plat|
 
   packages = [
     "libbz2-dev",
+    "libtinfo-dev",
     "libreadline-dev",
     "libselinux1-dev",
     "make",


### PR DESCRIPTION
This commit attempts to explicitly install a dependency for libtinfo. However this appears to not be a complete solution.