### PR TITLE
(maint) Add bundle path to bolt-runtime

### DIFF
--- a/configs/components/rubygem-bundler.rb
+++ b/configs/components/rubygem-bundler.rb
@@ -1,0 +1,6 @@
+component 'rubygem-bundler' do |pkg, settings, platform|
+  pkg.version '1.16.1'
+  pkg.md5sum '250ac082e64245f439c76b2c641e85b5'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -47,6 +47,7 @@ project 'bolt-runtime' do |proj|
   if platform.is_windows?
     proj.setting(:host_ruby, File.join(proj.ruby_bindir, "ruby.exe"))
     proj.setting(:host_gem, File.join(proj.ruby_bindir, "gem.bat"))
+    proj.setting(:host_bundle, File.join(proj.ruby_bindir, "bundle.bat"))
 
     # For windows, we need to ensure we are building for mingw not cygwin
     platform_triple = platform.platform_triple
@@ -54,6 +55,7 @@ project 'bolt-runtime' do |proj|
   else
     proj.setting(:host_ruby, File.join(proj.ruby_bindir, "ruby"))
     proj.setting(:host_gem, File.join(proj.ruby_bindir, "gem"))
+    proj.setting(:host_bundle, File.join(proj.ruby_bindir, "bundle"))
   end
 
   ruby_base_version = proj.ruby_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2.0')
@@ -114,6 +116,7 @@ project 'bolt-runtime' do |proj|
   proj.component "runtime-bolt"
   proj.component "puppet-ca-bundle"
   proj.component "ruby-#{proj.ruby_version}"
+  proj.component "rubygem-bundler"
 
   # Building native gems on Windows has some issues right now.
   # Include for non-Windows platforms only.


### PR DESCRIPTION
In order to run a rake task to generate the Bolt cmdlets Powershell
module in bolt-vanagon we need to use bundler to install gems at build time.
This adds the platform-dependent bundle-path setting to bolt-runtime so that we
can easily call bundler from the Bolt component to create a ruby environment
and run the rake task.