### PR TITLE
(MAINT) Update pdk-runtime config for Ubuntu 20.04

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place)
 end
 
 gem 'artifactory'
-gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15.17')
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15.38')
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.8')
 gem 'rake', '~> 12.0'
 

--- a/configs/components/runtime-pdk.rb
+++ b/configs/components/runtime-pdk.rb
@@ -35,7 +35,8 @@ component "runtime-pdk" do |pkg, settings, platform|
   else # Linux and Solaris systems
     if (platform.is_fedora? && platform.os_version.to_i >= 29) ||
         (platform.is_el? && platform.os_version.to_i >= 8) ||
-        (platform.os_name == 'debian' && platform.os_version.to_i >= 10)
+        (platform.is_debian? && platform.os_version.to_i >= 10) ||
+        (platform.is_ubuntu? && platform.os_version.split('.').first.to_i >= 20)
       # On newer linux platforms we are no longer using the pl-build-tools
       # package and instead relying on standard distribution versions of
       # gcc, etc.


### PR DESCRIPTION
Also bumps vanagon to latest