### PR TITLE
(maint) Pin back ffi on Windows

### DIFF
--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -7,6 +7,9 @@ component "rubygem-ffi" do |pkg, settings, platform|
   # Windows versions of the FFI gem have custom filenames, so we overwite the
   # defaults that _base-rubygem provides here, just for Windows.
   if platform.is_windows?
+    # Pin this if lower than Ruby 2.7
+    rb_minor_version = settings[:ruby_version].split('.')[1].to_i
+    pkg.version '1.9.25' if rb_minor_version < 7
     # Vanagon's `pkg.mirror` is additive, and the _base_rubygem sets the
     # non-Windows gem as the first mirror, which is incorrect. We need to unset
     # the list of mirrors before adding the Windows-appropriate ones here:
@@ -15,11 +18,23 @@ component "rubygem-ffi" do |pkg, settings, platform|
     @component.install = []
 
     if platform.architecture == "x64"
-      pkg.sha256sum "029c5c65c4b862a901d8751b8265f46cdcedf6f9186f59121e7511cbeb6e36be"
+      case pkg.get_version
+      when '1.9.25'
+        pkg.md5sum "e263997763271fba35562245b450576f"
+      when '1.13.1'
+        pkg.sha256sum "029c5c65c4b862a901d8751b8265f46cdcedf6f9186f59121e7511cbeb6e36be"
+      end
+
       pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x64-mingw32.gem"
       pkg.mirror "#{settings[:buildsources_url]}/ffi-#{pkg.get_version}-x64-mingw32.gem"
     else
-      pkg.sha256sum "10d30fca1ddeac3ca27b39c60ef408248a4714692bb22b4789da7598a9ded69e"
+      case pkg.get_version
+      when '1.9.25'
+        pkg.md5sum "3303124f1ca0ee3e59829301ffcad886"
+      when '1.13.1'
+        pkg.sha256sum "10d30fca1ddeac3ca27b39c60ef408248a4714692bb22b4789da7598a9ded69e"
+      end
+
       pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x86-mingw32.gem"
       pkg.mirror "#{settings[:buildsources_url]}/ffi-#{pkg.get_version}-x86-mingw32.gem"
     end


### PR DESCRIPTION
We accidentally bumped ffi for Windows when merging https://github.com/puppetlabs/puppet-runtime/pull/362.

I think we only want this for the `agent-runtime-main` project, where we ship Ruby 2.7, which does not work with older versions of FFI.