### PR TITLE
(PUP-10590) Remove win32 gems from puppet-agent dependency

### DIFF
--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -59,7 +59,6 @@ end
 
 if platform.is_windows?
   proj.component 'rubygem-win32-dir'
-  proj.component 'rubygem-win32-process'
   proj.component 'rubygem-win32-security'
   proj.component 'rubygem-win32-service'
 end

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -58,7 +58,6 @@ if platform.is_windows? || platform.is_solaris?
 end
 
 if platform.is_windows?
-  proj.component 'rubygem-win32-dir'
   proj.component 'rubygem-win32-security'
 end
 

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -57,10 +57,6 @@ if platform.is_windows? || platform.is_solaris?
   proj.component 'rubygem-ffi'
 end
 
-if platform.is_windows?
-  proj.component 'rubygem-win32-security'
-end
-
 if platform.is_macos?
   proj.component 'rubygem-CFPropertyList'
 end

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -60,7 +60,6 @@ end
 if platform.is_windows?
   proj.component 'rubygem-win32-dir'
   proj.component 'rubygem-win32-security'
-  proj.component 'rubygem-win32-service'
 end
 
 if platform.is_macos?

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -49,5 +49,6 @@ project 'agent-runtime-5.5.x' do |proj|
 
   if platform.is_windows?
     proj.component 'rubygem-win32-process'
+    proj.component 'rubygem-win32-service'
   end
 end

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -46,4 +46,8 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'yaml-cpp'
 
   proj.component 'openssl-lib' if platform.is_linux?
+
+  if platform.is_windows?
+    proj.component 'rubygem-win32-process'
+  end
 end

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -50,6 +50,7 @@ project 'agent-runtime-5.5.x' do |proj|
   if platform.is_windows?
     proj.component 'rubygem-win32-dir'
     proj.component 'rubygem-win32-process'
+    proj.component 'rubygem-win32-security'
     proj.component 'rubygem-win32-service'
   end
 end

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -48,6 +48,7 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'openssl-lib' if platform.is_linux?
 
   if platform.is_windows?
+    proj.component 'rubygem-win32-dir'
     proj.component 'rubygem-win32-process'
     proj.component 'rubygem-win32-service'
   end

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -46,6 +46,7 @@ project 'agent-runtime-master' do |proj|
   if platform.is_windows?
     proj.component 'rubygem-win32-dir'
     proj.component 'rubygem-win32-process'
+    proj.component 'rubygem-win32-security'
     proj.component 'rubygem-win32-service'
   end
 end

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -45,5 +45,6 @@ project 'agent-runtime-master' do |proj|
 
   if platform.is_windows?
     proj.component 'rubygem-win32-process'
+    proj.component 'rubygem-win32-service'
   end
 end

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -44,6 +44,7 @@ project 'agent-runtime-master' do |proj|
   proj.component 'yaml-cpp'
 
   if platform.is_windows?
+    proj.component 'rubygem-win32-dir'
     proj.component 'rubygem-win32-process'
     proj.component 'rubygem-win32-service'
   end

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -42,4 +42,8 @@ project 'agent-runtime-master' do |proj|
 
   proj.component 'boost'
   proj.component 'yaml-cpp'
+
+  if platform.is_windows?
+    proj.component 'rubygem-win32-process'
+  end
 end


### PR DESCRIPTION
Since the `win32-dir`,`win32-process`,`win32-security`,`win32-service` gems will no longer be used in Puppet 7, this commit moves them from the puppet runtime shared agent components to the specific branches that will continue using (5.5.x and 6.x) to avoid unnecessary packaging.

Depends on [PUP-7445](https://github.com/puppetlabs/puppet/pull/8204), [PUP-5758](https://github.com/puppetlabs/puppet/pull/8194) and [PUP-6184](https://github.com/puppetlabs/puppet/pull/8258).