### PR TITLE
(PUP-7446) Remove win32-service gem next agent dependency

### DIFF
--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -61,7 +61,6 @@ if platform.is_windows?
   proj.component 'rubygem-win32-dir'
   proj.component 'rubygem-win32-process'
   proj.component 'rubygem-win32-security'
-  proj.component 'rubygem-win32-service'
 end
 
 if platform.is_macos?

--- a/configs/projects/agent-runtime-5.5.x.rb
+++ b/configs/projects/agent-runtime-5.5.x.rb
@@ -46,4 +46,6 @@ project 'agent-runtime-5.5.x' do |proj|
   proj.component 'yaml-cpp'
 
   proj.component 'openssl-lib' if platform.is_linux?
+
+  proj.component 'rubygem-win32-service' if platform.is_windows?
 end

--- a/configs/projects/agent-runtime-master.rb
+++ b/configs/projects/agent-runtime-master.rb
@@ -42,4 +42,6 @@ project 'agent-runtime-master' do |proj|
 
   proj.component 'boost'
   proj.component 'yaml-cpp'
+
+  proj.component 'rubygem-win32-service' if platform.is_windows?
 end


### PR DESCRIPTION
Since the `win32-service` gem will no longer be used in Puppet 7, this
commit moves it from the puppet runtime shared agent components to the
specific branches that will continue using (5.5.x and master) to avoid
unnecessary packaging.

Depends on [PUP-5758](https://github.com/puppetlabs/puppet/pull/8194)