### PR TITLE
(PA-3362) Fix ffi gem compilation on Solaris 11 SPARC

### DIFF
--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -46,7 +46,6 @@ action=nocheck
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
   pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev || exit 1;
   /opt/csw/bin/pkgutil -U && /opt/csw/bin/pkgutil -y -i gcc4g++ bison || exit 1
 
   ntpdate pool.ntp.org]


### PR DESCRIPTION
Previously we've been using the system libffi to build the ffi gem on Solaris 11 SPARC.

This caused all FFI calls to fail with the following message:

`[BUG] Bus Error at 0x033e66d3`

It appears that we can fix this by forcing a static build of the ffi gem native extension. To accomplish this we do the following:

- avoid installing libffi/libffi_dev during the provisioning step
- force compilation to use the GNU ld linker (the simplest way to accomplish this is to temporarily move the Solaris linker somewhere else)
- append a couple of paths to LDFLAGS so ld knows where to find system libraries