### PR TITLE
(PA-3352) remove httpclient gem from runtime main

### DIFF
--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -47,7 +47,6 @@ project 'agent-runtime-main' do |proj|
   proj.component 'rubygem-optimist'
   proj.component 'rubygem-highline'
   proj.component 'rubygem-hiera-eyaml'
-  proj.component 'rubygem-httpclient'
   proj.component 'rubygem-thor'
   proj.component 'rubygem-scanf'
 


### PR DESCRIPTION
Starting from Puppet 7, the httpclient gem is no longer used.
This removes the gem from the Puppet Agent main AIO