### PR TITLE
(maint) Bump puppet rubygem to 6.18.0

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
-  pkg.version '6.16.0'
-  pkg.md5sum 'ed0c92a2bbeb5247bff7e33fb85af873'
+  pkg.version "6.18.0"
+  pkg.md5sum 'bb3455dc67f65785192e0765527177e8'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Bumps the puppet rubygem to latest 6.18.0