### PR TITLE
(maint) Reset puppetfile-resolver to 0.1.0

### DIFF
--- a/configs/components/rubygem-puppetfile-resolver.rb
+++ b/configs/components/rubygem-puppetfile-resolver.rb
@@ -1,6 +1,6 @@
 component "rubygem-puppetfile-resolver" do |pkg, settings, platform|
-  pkg.version "0.4.0"
-  pkg.md5sum "6e0e4152b1b3012a075fbd5ccc81c5fa"
+  pkg.version "0.1.0"
+  pkg.md5sum "5fcb2ee3525feae3863f854795a64079"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This needs to wait for the Bolt gemspec to bump the version as well,
since the `~> 0.1.0` dependency won't pick up version 0.4.0