### PR TITLE
(CT-131) add boost to client tools runtime

### DIFF
--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -185,16 +185,16 @@ component "boost" do |pkg, settings, platform|
   # use a script to manually rewrite the finshed dylibs' install_names to use
   # @rpath instead of the build directory.
   if platform.is_macos?
-    pkg.add_source("file://resources/files/boost/macos_rpath_install_names.erb")
+    pkg.add_source("file://resources/files/boost/macos_rpath_install_names.sh")
     pkg.configure do
       [
-        "#{settings[:bindir]}/erb libdir=#{settings[:libdir]} ../macos_rpath_install_names.erb > macos_rpath_install_names.sh",
+        "cp ../macos_rpath_install_names.sh macos_rpath_install_names.sh",
         "chmod +x macos_rpath_install_names.sh",
       ]
     end
     pkg.install do
       [
-        "./macos_rpath_install_names.sh",
+        "LIBDIR=#{settings[:libdir]} ./macos_rpath_install_names.sh",
       ]
     end
   end

--- a/configs/projects/_shared-client-tools-runtime.rb
+++ b/configs/projects/_shared-client-tools-runtime.rb
@@ -53,6 +53,11 @@ proj.setting(:mandir, File.join(proj.datadir, "man"))
 proj.setting(:host, "--host #{platform.platform_triple}") if platform.is_windows?
 proj.setting(:platform_triple, platform.platform_triple)
 
+# These are the boost libraries we care about for leatherman
+proj.setting(:boost_libs, ["chrono", "date_time", "filesystem", "locale", "log", "program_options",
+                           "regex", "system", "thread"])
+proj.setting(:boost_link_option, "")
+
 if platform.is_macos?
   # For OS X, we should optimize for an older architecture than Apple
   # currently ships for; there's a lot of older xeon chips based on
@@ -74,6 +79,7 @@ elsif platform.is_windows?
   proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir} -Wl,--nxcompat -Wl,--dynamicbase")
   proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
 else
+  proj.setting(:tools_root, "/opt/pl-build-tools")
   proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
   proj.setting(:cflags, "#{proj.cppflags}")
   proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
@@ -90,6 +96,7 @@ end
 proj.component "curl"
 proj.component "puppet-ca-bundle"
 proj.component "libicu"
+proj.component "boost"
 
 # What to include in package?
 proj.directory proj.prefix

--- a/resources/files/boost/macos_rpath_install_names.sh
+++ b/resources/files/boost/macos_rpath_install_names.sh
@@ -22,8 +22,6 @@
 #     /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.4.0)
 #     /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
 
-
-LIBDIR=<%= libdir %>
 BOOST_DYLIBS=${LIBDIR}/libboost*.dylib
 
 echo "Updating install_name values for boost dylibs..."


### PR DESCRIPTION
passing build: https://jenkins-master-prod-1.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/947/
can be merged together with: https://github.com/puppetlabs/puppet-runtime/pull/376