### PR TITLE
(CT-131) disable icu usage in client-tools-runtime

### DIFF
--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -37,10 +37,12 @@ component "boost" do |pkg, settings, platform|
   with_toolset = "--with-toolset=#{toolset}"
   boost_dir = ""
   bootstrap_suffix = ".sh"
+  bootstrap_flags = settings[:boost_bootstrap_flags] || ""
   execute = "./"
   addtl_flags = ""
   gpp = "#{settings[:tools_root]}/bin/g++"
-  b2flags = ""
+  b2flags = settings[:boost_b2_flags] || ""
+  b2installflags = settings[:boost_b2_install_flags] || ""
   link_option = settings[:boost_link_option]
   b2location = "#{settings[:prefix]}/bin/b2"
   bjamlocation = "#{settings[:prefix]}/bin/bjam"
@@ -141,7 +143,7 @@ component "boost" do |pkg, settings, platform|
     [
       %Q{echo '#{userconfigjam}' > ~/user-config.jam},
       "cd tools/build",
-      "#{execute}bootstrap#{bootstrap_suffix} #{with_toolset}",
+      "#{execute}bootstrap#{bootstrap_suffix} #{with_toolset} #{bootstrap_flags}",
       "./b2 \
       install \
       variant=release \
@@ -162,6 +164,7 @@ component "boost" do |pkg, settings, platform|
       #{link_option} \
       toolset=#{toolset} \
       #{b2flags} \
+      #{b2installflags} \
       -d+2 \
       --debug-configuration \
       --prefix=#{settings[:prefix]} \

--- a/configs/projects/_shared-client-tools-runtime.rb
+++ b/configs/projects/_shared-client-tools-runtime.rb
@@ -57,6 +57,9 @@ proj.setting(:platform_triple, platform.platform_triple)
 proj.setting(:boost_libs, ["chrono", "date_time", "filesystem", "locale", "log", "program_options",
                            "regex", "system", "thread"])
 proj.setting(:boost_link_option, "")
+proj.setting(:boost_bootstrap_flags, "--without-icu")
+proj.setting(:boost_b2_flags, "--disable-icu")
+proj.setting(:boost_b2_install_flags, "boost.locale.icu=off")
 
 if platform.is_macos?
   # For OS X, we should optimize for an older architecture than Apple


### PR DESCRIPTION
After adding boost component in client-tools-runtime, on el-8 boost
builds with icu backend, leading to changes of libraries to be linked
in all client tools C++ components

With this commit icu backend is disabled in order to keep the components
unchanged