### PR TITLE
(PA-3433) Patch augeas to allow AD groups in sudoers

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -18,6 +18,8 @@ component 'augeas' do |pkg, settings, platform|
     pkg.md5sum 'abf51f4c0cf3901d167f23687f60434a'
   when '1.12.0'
     pkg.md5sum '74f1c7b8550f4e728486091f6b907175'
+
+    pkg.apply_patch 'resources/patches/augeas/augeas-1.12.0-allow-ad-groups-in-sudoers.patch'
   else
     raise "augeas version #{version} has not been configured; Cannot continue."
   end

--- a/resources/patches/augeas/augeas-1.12.0-allow-ad-groups-in-sudoers.patch
+++ b/resources/patches/augeas/augeas-1.12.0-allow-ad-groups-in-sudoers.patch
@@ -1,0 +1,26 @@
+From 3afe12b2a95f248862312ca56cbd7ce3df4af2ac Mon Sep 17 00:00:00 2001
+From: Luchian Nemes <luchian.nemes@puppet.com>
+Date: Mon, 12 Oct 2020 14:58:40 +0300
+Subject: [PATCH] Allow AD groups in '/etc/sudoers'
+
+Before this commit, `/etc/sudoers` files containing AD users or groups
+could not be parsed with the sudoers lens because it was containing `\\`
+in said users/groups name. Running `visudo -c` shows that a sudoers file
+containing these is valid so this case was added in the affected regex.
+---
+ lenses/sudoers.aug            |  2 +-
+ 1 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lenses/sudoers.aug a/lenses/sudoers.aug
+index 043c563..59d8417 100644
+--- a/lenses/sudoers.aug
++++ a/lenses/sudoers.aug
+@@ -127,7 +127,7 @@ let sto_to_com_host = store /[^,=:#() \t\n\\]+/
+ Escaped spaces and NIS domains and allowed*)
+ let sto_to_com_user =
+       let nis_re = /([A-Z]([-A-Z0-9]|(\\\\[ \t]))*+\\\\\\\\)/
+-   in let user_re = /[%+@a-z]([-A-Za-z0-9._+]|(\\\\[ \t]))*/
++   in let user_re = /[%+@a-z]([-A-Za-z0-9._+]|(\\\\[ \t])|\\\\\\\\[A-Za-z0-9])*/
+    in let alias_re = /[A-Z_]+/
+    in store ((nis_re? . user_re) | alias_re)
+


### PR DESCRIPTION
Original commit description:

Before this commit, `/etc/sudoers` files containing AD users or groups
could not be parsed with the sudoers lens because it was containing `\\`
in said users/groups name. Running `visudo -c` shows that a sudoers file
containing these is valid so this case was added in the affected regex.

Augeas PR: https://github.com/hercules-team/augeas/pull/696