### PR TITLE
(maint) Bump puppet to 6.19

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
-  pkg.version "6.18.0"
-  pkg.md5sum 'bb3455dc67f65785192e0765527177e8'
+  pkg.version '6.19.0'
+  pkg.md5sum 'f2b4f1c523bbfdf5632a741d5657af11'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Bumps the puppet gem to the newly released 6.19 version.

CC @puppetlabs/skeletor for approval