### PR TITLE
(FIXUP) Change `fstack-protector` rbconfig for Ruby 2.7.1 on RHEL7

### DIFF
--- a/configs/components/ruby-2.7.1.rb
+++ b/configs/components/ruby-2.7.1.rb
@@ -198,6 +198,9 @@ component 'ruby-2.7.1' do |pkg, settings, platform|
     end
   elsif platform.is_windows?
     rbconfig_changes["CC"] = "x86_64-w64-mingw32-gcc"
+  elsif platform.name =~ /el-7-x86_64/
+    # EL 7 GCC (4.8.x) does not support -fstack-protector-strong
+    rbconfig_changes["LDFLAGS"] = "-L. -Wl,-rpath=/opt/puppetlabs/puppet/lib -fstack-protector -rdynamic -Wl,-export-dynamic -L/opt/puppetlabs/puppet/lib"
   end
 
   pkg.add_source("file://resources/files/ruby_vendor_gems/operating_system.rb")


### PR DESCRIPTION
For whatever reason, the flag support detection in Ruby >2.6.0 is improperly including `-fstack-protector-strong` in `LDFLAGS` even on GCC versions that don't support it.

Not 100% sure this is the right/best way to fix this (just copied what was being done above for `sles-12-ppc64le`) but this does seem to fix the issues I was having compiling native gems with `pdk-runtime` on RHEL7.