### PR TITLE
(maint) update yum install script to use ftp passive mode

### DIFF
--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -40,7 +40,20 @@ curl -O https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildso
 uncompress openssl-1.0.2.1800.tar.Z;
 tar xvf openssl-1.0.2.1800.tar;
 cd openssl-1.0.2.1800 && /usr/sbin/installp -acgwXY -d $PWD openssl.base;
-curl -O http://ftp.software.ibm.com/aix/freeSoftware/aixtoolbox/ezinstall/ppc/yum.sh && sh yum.sh;
+cat >yum.patch <<EOF
+--- yum.sh.orig	2020-12-04 14:51:35.103032555 +0200
++++ yum.sh	2020-12-04 14:52:06.511040198 +0200
+@@ -70,6 +70,8 @@
+     expect "ftp>"
+     send "bin\\r"
+     expect "ftp>"
++    send "passive\\r"
++    expect "ftp>"
+     send "cd aix/freeSoftware/aixtoolbox/INSTALLP/ppc\\r"
+     expect "ftp>"
+     if {"\\$oslvl" == "6.1.0.0"} {
+EOF
+curl -O http://ftp.software.ibm.com/aix/freeSoftware/aixtoolbox/ezinstall/ppc/yum.sh && /opt/freeware/bin/patch yum.sh yum.patch && sh yum.sh;
 yum install -y gcc-c++]
 
   # We use --force with rpm because the pl-gettext and pl-autoconf


### PR DESCRIPTION
The yum install script we download from ftp.software.ibm.com is using
command line FTP client with expect. The ftp client is in FTP active
mode by default and started to fail(timeout) in our environment.

After this commit we will patch the yum install shell script to
use FTP passive mode.