### PR TITLE
(PE-30632) Update puppet gem version

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
-  pkg.version "6.18.0"
-  pkg.md5sum 'bb3455dc67f65785192e0765527177e8'
+  pkg.version "6.19.1"
+  pkg.md5sum '8d68e677e6ba88e46eb00699dcd4930b'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This commit updates the puppet gem shipped in various runtimes to version
6.19.1.