### PR TITLE
(SEC-191) Patch OpenSSL 1.0.2 for CVE-2020-1968

### DIFF
--- a/configs/components/openssl-1.0.2.rb
+++ b/configs/components/openssl-1.0.2.rb
@@ -98,6 +98,7 @@ component 'openssl' do |pkg, settings, platform|
       pkg.apply_patch 'resources/patches/openssl/openssl-1.0.0l-use-gcc-instead-of-makedepend.patch'
     end
   end
+  pkg.apply_patch 'resources/patches/openssl/CVE-2020-1968.patch'
 
   ###########
   # CONFIGURE

--- a/resources/patches/openssl/CVE-2020-1968.patch
+++ b/resources/patches/openssl/CVE-2020-1968.patch
@@ -1,0 +1,259 @@
+From 84416500cf0faf134a918acc778ef0990c0fcbc5 Mon Sep 17 00:00:00 2001
+From: Morgan Rhodes <morgan@puppet.com>
+Date: Tue, 8 Dec 2020 22:38:43 +0000
+Subject: [PATCH] Add more ciphers to the 'weak' cipher list to address
+ CVE-2020-1968
+
+---
+ ssl/s3_lib.c | 36 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
+
+diff --git a/ssl/s3_lib.c b/ssl/s3_lib.c
+index 10c6db6..64e1b0a 100644
+--- a/ssl/s3_lib.c
++++ b/ssl/s3_lib.c
+@@ -942,6 +942,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      },
+ /* Cipher 30 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_128_SHA,
+@@ -956,7 +957,9 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      128,
+      },
++#endif
+ /* Cipher 31 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_128_SHA,
+@@ -971,6 +974,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      128,
+      },
++#endif
+ /* Cipher 32 */
+     {
+      1,
+@@ -1033,6 +1037,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      256,
+      },
+ /* Cipher 36 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_256_SHA,
+@@ -1047,8 +1052,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      256,
+      256,
+      },
++#endif
+ 
+ /* Cipher 37 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_256_SHA,
+@@ -1063,6 +1070,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      256,
+      256,
+      },
++#endif
+ 
+ /* Cipher 38 */
+     {
+@@ -1162,6 +1170,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      },
+ 
+     /* Cipher 3E */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_128_SHA256,
+@@ -1176,8 +1185,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 3F */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_128_SHA256,
+@@ -1192,6 +1203,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 40 */
+     {
+@@ -1229,6 +1241,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      },
+ 
+     /* Cipher 42 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_CAMELLIA_128_CBC_SHA,
+@@ -1243,8 +1256,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 43 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_CAMELLIA_128_CBC_SHA,
+@@ -1259,6 +1274,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 44 */
+     {
+@@ -1452,6 +1468,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      },
+ 
+     /* Cipher 68 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_256_SHA256,
+@@ -1466,8 +1483,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher 69 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_256_SHA256,
+@@ -1482,6 +1501,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher 6A */
+     {
+@@ -1621,6 +1641,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      256,
+      },
+     /* Cipher 85 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_CAMELLIA_256_CBC_SHA,
+@@ -1635,8 +1656,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher 86 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_CAMELLIA_256_CBC_SHA,
+@@ -1651,6 +1674,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher 87 */
+     {
+@@ -1787,6 +1811,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      },
+ 
+     /* Cipher 97 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_SEED_SHA,
+@@ -1801,8 +1826,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 98 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_SEED_SHA,
+@@ -1817,6 +1844,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 99 */
+     {
+@@ -1935,6 +1963,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      },
+ 
+     /* Cipher A0 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_128_GCM_SHA256,
+@@ -1949,8 +1978,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher A1 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_256_GCM_SHA384,
+@@ -1965,6 +1996,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher A2 */
+     {
+@@ -1999,6 +2031,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      },
+ 
+     /* Cipher A4 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_128_GCM_SHA256,
+@@ -2013,8 +2046,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher A5 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_256_GCM_SHA384,
+@@ -2029,6 +2064,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher A6 */
+     {
+-- 
+1.8.3.1
+


### PR DESCRIPTION
Patch compiled from http://launchpadlibrarian.net/497794798/openssl1.0_1.0.2n-1ubuntu5.3_1.0.2n-1ubuntu5.4.diff.gz