### PR TITLE
Revert "(maint) Bump shared rubygems for bolt, pe-bolt-server"

### DIFF
--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.407.0"
-  pkg.md5sum "399af7454f62196c4cedb56871aaa9bf"
+  pkg.version "1.371.0"
+  pkg.md5sum "6b70b220604890f584a7b3be2bd6a971"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.110.0"
-  pkg.md5sum "2bc5a7da71c3aec59fca906eb9bbd524"
+  pkg.version "3.107.0"
+  pkg.md5sum "411b8299481c0ee2a2c7c72c21964405"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.217.0"
-  pkg.md5sum "77ddef9c41d754a2887e26df096dea67"
+  pkg.version "1.195.0"
+  pkg.md5sum "fa2ccc15cb5d1ccb615ea4631b9c19b6"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-erubi.rb
+++ b/configs/components/rubygem-erubi.rb
@@ -1,6 +1,6 @@
 component 'rubygem-erubi' do |pkg, settings, platform|
-  pkg.version '1.10.0'
-  pkg.md5sum 'e8111998389faf7fb877012fba4485ff'
+  pkg.version '1.9.0'
+  pkg.md5sum '9a1e6439fae69dd1133fbb76c96797db'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '4.0.47'
-  pkg.md5sum '30577ad8e59fb7d6c09dd53115b2a15d'
+  pkg.version '4.0.38'
+  pkg.md5sum '3c518707beab8810cfcbe5129d77447f'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-molinillo.rb
+++ b/configs/components/rubygem-molinillo.rb
@@ -1,6 +1,6 @@
 component "rubygem-molinillo" do |pkg, settings, platform|
-  pkg.version "0.7.0"
-  pkg.md5sum "3da77c3c3b5d604aa654b29390f25cb0"
+  pkg.version "0.6.6"
+  pkg.md5sum "f0f9d1fbb7277e3e4ae6c4be81fc0a92"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-paint.rb
+++ b/configs/components/rubygem-paint.rb
@@ -1,6 +1,6 @@
 component 'rubygem-paint' do |pkg, settings, platform|
-  pkg.version '2.2.1'
-  pkg.md5sum 'c9f60207d67262cbb55ce12d100cf3f2'
+  pkg.version '2.2.0'
+  pkg.md5sum 'ddd76c92404e3af9abcbae2d26a47a3d'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppetfile-resolver.rb
+++ b/configs/components/rubygem-puppetfile-resolver.rb
@@ -1,6 +1,6 @@
 component "rubygem-puppetfile-resolver" do |pkg, settings, platform|
-  pkg.version "0.5.0"
-  pkg.md5sum "bcfc87be63178498b6c3a9b706d0caa7"
+  pkg.version "0.4.0"
+  pkg.md5sum "6e0e4152b1b3012a075fbd5ccc81c5fa"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Reverts puppetlabs/puppet-runtime#405

Puppetfile Resolver has a minimum ruby version of 2.5.3, which requires us to use an updated CI environment in Jenkins that uses Bundler 2.2.1, which may be incompatible for downstream projects (see #2460). We're reverting this change for now to get a bug fix out, and will update after the holiday break.