### PR TITLE
Bump Bolt dependencies

### DIFF
--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.414.0"
-  pkg.md5sum "22852d399b0ee81533b67dc3ca8c0b9b"
+  pkg.version "1.419.0"
+  pkg.md5sum "6826e9a46b610c0723e4d43a1858fc0d"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.110.0"
-  pkg.md5sum "2bc5a7da71c3aec59fca906eb9bbd524"
+  pkg.version "3.111.2"
+  pkg.md5sum "29f45906de1a73ef703e30aa7e2cc22b"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.220.0"
-  pkg.md5sum "861967dcae85ea521b75e940350e1227"
+  pkg.version "1.221.0"
+  pkg.md5sum "fc4585aadd7a5f712f2948acbfd5be66"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-concurrent-ruby.rb
+++ b/configs/components/rubygem-concurrent-ruby.rb
@@ -1,6 +1,6 @@
 component 'rubygem-concurrent-ruby' do |pkg, settings, platform|
-  pkg.version '1.1.5'
-  pkg.md5sum '4409c2d6925d8448cb34a947eacaa29b'
+  pkg.version '1.1.8'
+  pkg.md5sum '68c226f3ee1bf39313dd4ebc0cf52d43'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '4.0.47'
-  pkg.md5sum '30577ad8e59fb7d6c09dd53115b2a15d'
+  pkg.version '4.0.49'
+  pkg.md5sum '56266dd1b2418bc26a7a0f12fc9774cc'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-faraday.rb
+++ b/configs/components/rubygem-faraday.rb
@@ -1,6 +1,6 @@
 component 'rubygem-faraday' do |pkg, settings, platform|
-  pkg.version '0.14.0'
-  pkg.md5sum '9b11daa6e4a18bddeb7de9a4bc9e0315'
+  pkg.version '0.17.3'
+  pkg.md5sum 'aa0eb149651aa6185ca15b31edafb156'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-multi_json.rb
+++ b/configs/components/rubygem-multi_json.rb
@@ -1,6 +1,6 @@
 component "rubygem-multi_json" do |pkg, settings, platform|
-  pkg.version '1.14.1'
-  pkg.md5sum 'ff088e41a3af364202670f3afdead842'
+  pkg.version '1.15.0'
+  pkg.md5sum '06f0ae43e84ec7b9357f4095f8417cd5'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 

--- a/configs/components/rubygem-net-http-persistent.rb
+++ b/configs/components/rubygem-net-http-persistent.rb
@@ -1,6 +1,6 @@
 component 'rubygem-net-http-persistent' do |pkg, settings, platform|
-  pkg.version '4.0.0'
-  pkg.md5sum '68018c9b318cf5ead404c4a0c933d4f1'
+  pkg.version '4.0.1'
+  pkg.md5sum '42857574ef30faa06e646a7f45292f4b'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet-strings.rb
+++ b/configs/components/rubygem-puppet-strings.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet-strings' do |pkg, settings, platform|
-  pkg.version '2.5.0'
-  pkg.md5sum 'e811763411ce0c36ffcb40aa5ca44212'
+  pkg.version '2.6.0'
+  pkg.md5sum '69557c69e8ed2675b57fc18e24d6e144'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-rubyntlm.rb
+++ b/configs/components/rubygem-rubyntlm.rb
@@ -1,6 +1,6 @@
 component 'rubygem-rubyntlm' do |pkg, settings, platform|
-  pkg.version '0.6.2'
-  pkg.md5sum 'e74146db2e08c5254d15d63f0befcc78'
+  pkg.version '0.6.3'
+  pkg.md5sum 'e1f7477acf8a7d3effb2a3fb931aa84c'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-thor.rb
+++ b/configs/components/rubygem-thor.rb
@@ -1,6 +1,6 @@
 component 'rubygem-thor' do |pkg, settings, platform|
-  pkg.version '1.0.1'
-  pkg.md5sum '052eb36fd3e522331af98449556991dc'
+  pkg.version '1.1.0'
+  pkg.md5sum '0d39b5be66778612f3233253e5b78ae6'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-winrm.rb
+++ b/configs/components/rubygem-winrm.rb
@@ -1,6 +1,6 @@
 component 'rubygem-winrm' do |pkg, settings, platform|
-  pkg.version '2.3.4'
-  pkg.md5sum 'c2e7a4a762929ac78a6c33543be53d90'
+  pkg.version '2.3.6'
+  pkg.md5sum 'a99f8e81343f61caa441eb1397a1c6ae'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This bumps Bolt gem dependencies to their latest versions from the
Gemfile.lock.