### PR TITLE
Pull in orchestrator_client-ruby 0.5.1

### DIFF
--- a/configs/components/rubygem-orchestrator_client.rb
+++ b/configs/components/rubygem-orchestrator_client.rb
@@ -1,6 +1,6 @@
 component 'rubygem-orchestrator_client' do |pkg, settings, platform|
-  pkg.version '0.4.3'
-  pkg.md5sum '603e715895fcf25d80fdccd0b3a4b22f'
+  pkg.version '0.5.1'
+  pkg.md5sum 'c1cf6fb6d4613c2ec1a3267b90e254b6'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This updates the orchestrator_client-ruby gem to 0.5.1 to include the
new read-timeout configuration option.

Opening this as we need to get this updated before releasing Bolt, and I don't want that to be gated on #411 .