### PR TITLE
(maint) Pull in Puppet 6.20.0 for Bolt

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
-  pkg.version "6.19.1"
-  pkg.md5sum '8d68e677e6ba88e46eb00699dcd4930b'
+  pkg.version "6.20.0"
+  pkg.md5sum 'b1a6f244663f04075bafb1d36eede31c'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Update the Puppet gem to 6.20.0 for Bolt and PE Bolt usage.