### PR TITLE
(PA-3541) Compile curl with CA path

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -47,6 +47,7 @@ component 'curl' do |pkg, settings, platform|
         --disable-ldap \
         --disable-ldaps \
         --with-ca-bundle=#{settings[:prefix]}/ssl/cert.pem \
+        --with-ca-path=#{settings[:prefix]}/ssl/certs \
         CFLAGS='#{settings[:cflags]}' \
         #{settings[:host]}"]
   end


### PR DESCRIPTION
The curl command is currently compiled without the `--with-ca-path` flag.

This breaks the ability to configure SSL trust for downloading files using curl separately from SSL trust for the Puppet server/agent
applications.

When we configure and build curl, we should pass the `--with-ca-path /opt/puppetlabs/puppet/ssl/certs` flag.

Curl does not provide a way to see the CApath, but overriding the CAfile should print both flags.

Prior to this commit:
```sh-session
> /opt/puppetlabs/puppet/bin/curl --cacert a https://google.com
curl: (77) error setting certificate verify locations:
  CAfile: a
  CApath: none
```

With this commit:
```sh-session
> /opt/puppetlabs/puppet/bin/curl --cacert a https://google.com
curl: (77) error setting certificate verify locations:
  CAfile: a
  CApath: /opt/puppetlabs/puppet/ssl/certs
```