### PR TITLE
(maint) Update puppet to 7.3.0 for bolt-runtime

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,6 +1,16 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
-  pkg.version "6.20.0"
-  pkg.md5sum 'b1a6f244663f04075bafb1d36eede31c'
+  # Projects may define a :rubygem_puppet_version setting, or we use 6.20.0 by default:
+  version = settings[:rubygem_puppet_version] || '6.20.0'
+  pkg.version version
+
+  case version
+  when '7.3.0'
+    pkg.md5sum '82857bbc5a75c3b6e49ce15c18959504'
+  when '6.20.0'
+    pkg.md5sum 'b1a6f244663f04075bafb1d36eede31c'
+  else
+    raise "Invalid version #{version} for rubygem-puppet; Cannot continue."
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -8,6 +8,7 @@ project 'bolt-runtime' do |proj|
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_gettext_version, '3.2.9')
   proj.setting(:rubygem_deep_merge_version, '1.2.1')
+  proj.setting(:rubygem_puppet_version, '7.3.0')
 
   platform = proj.get_platform
 


### PR DESCRIPTION
This updates the bolt-runtime project to include Puppet 7.3.0.

Part of puppetlabs/bolt#2547