### PR TITLE
(GH-2548) Update Bolt's ruby to 2.7

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -1,7 +1,7 @@
 project 'bolt-runtime' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'bolt')
-  proj.setting(:ruby_version, '2.5.8')
+  proj.setting(:ruby_version, '2.7.2')
   proj.setting(:openssl_version, '1.1.1')
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
   proj.setting(:augeas_version, '1.11.0')


### PR DESCRIPTION
This updates the version of Ruby packaged with Bolt from 2.5 to 2.7 as
part of the Bolt 3.0 release.