### PR TITLE
Add debian-10-armhf build

### DIFF
--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -78,6 +78,8 @@ component 'openssl' do |pkg, settings, platform|
       target = 'linux-ppc64le'
     elsif platform.architecture =~ /64$/
       target = 'linux-x86_64'
+    elsif platform.architecture == 'armhf'
+      target = 'linux-armv4'
     end
   end
 

--- a/configs/platforms/debian-10-armhf.rb
+++ b/configs/platforms/debian-10-armhf.rb
@@ -1,0 +1,34 @@
+platform "debian-10-armhf" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "buster"
+
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+
+  packages = [
+    "build-essential",
+    "make",
+    "quilt",
+    "pkg-config",
+    "debhelper",
+    "rsync",
+    "fakeroot",
+    "libbz2-dev",
+    "libreadline-dev",
+    "libselinux1-dev",
+    "make",
+    "openjdk-11-jre-headless",
+    "pkg-config",
+    "cmake",
+    "gcc",
+    "swig",
+    "systemtap-sdt-dev",
+    "zlib1g-dev"
+  ]
+
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq && apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+
+  plat.vmpooler_template "debian-10-armhf"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
+end

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -99,7 +99,7 @@ platform_triple = "ppc64-redhat-linux" if platform.architecture == "ppc64"
 platform_triple = "ppc64le-redhat-linux" if platform.architecture == "ppc64le"
 platform_triple = "powerpc64le-suse-linux" if platform.architecture == "ppc64le" && platform.name =~ /^sles-/
 platform_triple = "powerpc64le-linux-gnu" if platform.architecture == "ppc64el"
-platform_triple = "arm-linux-gnueabihf" if platform.name == 'debian-8-armhf'
+platform_triple = "arm-linux-gnueabihf" if platform.architecture == "armhf"
 platform_triple = "arm-linux-gnueabi" if platform.name == 'debian-8-armel'
 platform_triple = "aarch64-redhat-linux" if platform.name == 'el-7-aarch64'
 

--- a/resources/files/runtime/runtime.sh
+++ b/resources/files/runtime/runtime.sh
@@ -16,7 +16,7 @@ else
     LIBDIR="$1"
   else
     echo "$1 does not exist" >2
-    exit 1
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
I wanted Raspberry Pi agents to be modern. This change allows the
puppet-runtime to build on debian-10-armhf on a direct compile (not cross)
because modern arm systems aren't totally terrible in terms of speed.