### PR TITLE
(maint) Update bolt-runtime to use --no-document

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -59,7 +59,7 @@ project 'bolt-runtime' do |proj|
 
   ruby_base_version = proj.ruby_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2.0')
   proj.setting(:gem_home, File.join(proj.libdir, 'ruby', 'gems', ruby_base_version))
-  proj.setting(:gem_install, "#{proj.host_gem} install --no-rdoc --no-ri --local --bindir=#{proj.ruby_bindir}")
+  proj.setting(:gem_install, "#{proj.host_gem} install --no-document --local --bindir=#{proj.ruby_bindir}")
 
   proj.setting(:platform_triple, platform_triple)
   proj.setting(:host, host)


### PR DESCRIPTION
This updates the bolt-runtime to use the `--no-document` option
when installing gems instead of the defunct `--no-rdoc` and `--no-ri`
options.