### PR TITLE
(maint) Add rubygem-scanf component to bolt-runtime

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -130,6 +130,7 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-locale'
   proj.component 'rubygem-gettext'
   proj.component 'rubygem-fast_gettext'
+  proj.component 'rubygem-scanf'
   proj.component 'rubygem-semantic_puppet'
 
   # R10k dependencies


### PR DESCRIPTION
This adds the rubygem-scanf component to bolt-runtime.