### PR TITLE
(maint) Remove public chocolate source

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -14,7 +14,7 @@ platform "windows-2012r2-x64" do |plat|
   plat.provision_with "mkdir -p C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey"
-  # plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   packages = [
     "cmake",


### PR DESCRIPTION
During testing https://github.com/puppetlabs/puppet-runtime/pull/384 the public chocolate repo source was added, but I did not remove it before merging. This removes the public repo to ensure the correct sources are used.
