### PR TITLE
(maint) Fix Travis docker build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,14 @@ matrix:
         - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
+        - docker buildx create --name travis_builder --use
       script:
         - set -e
         - cd docker
         - make lint
         - make build
         - make test
+      after_script:
+        - docker buildx rm travis_builder
 notifications:
   email: false

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -33,7 +33,8 @@ build: prep build-agent-runtimes
 
 build-agent-runtimes: prep
 	@for branch in $(agent_branches); do \
-		docker build \
+		docker buildx build \
+			--load \
 			${DOCKER_BUILD_FLAGS} \
 			--build-arg centos_version=$$CENTOS_VERSION \
 			--build-arg vcs_ref=$(vcs_ref) \


### PR DESCRIPTION
 - Upgrading to Travis 20.10 from 19.03 doesn't seem to have fully
   resolved the docker buildkit precondition issues. Implement the
   workaround suggestion from https://github.com/moby/moby/issues/41864

   This switches to the docker buildx build cli from docker build cli