### PR TITLE
(maint) Use correct pe_version for pe-bolt-server

### DIFF
--- a/configs/projects/pe-bolt-server-runtime-2019.8.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2019.8.x.rb
@@ -1,5 +1,5 @@
 project 'pe-bolt-server-runtime-2019.8.x' do |proj|
-  proj.setting(:pe_version, 'master')
+  proj.setting(:pe_version, '2019.8')
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.5 we need to use a --no-ri --no-rdoc flag
   # for gem installs instead of --no-document. This setting allows us to use this while we support both ruby 2.5 and 2.7
   # Once we are no longer using ruby 2.5 we can update.


### PR DESCRIPTION
This commit updates the pe-bolt-server runtime defition to use '2019.8'
instead of 'master' for the 2019.8 builds so that builds pull from the correct
repo locations instead of the deprecated 'master' locations