### PR TITLE
(maint) Bump Bolt and PE Bolt server dependencies

### DIFF
--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.431.0"
-  pkg.md5sum "cf93d88a599ea7ab48eeb5fb4dcb9f62"
+  pkg.version "1.447.0"
+  pkg.md5sum "5f79bd97f319761f41ff0c15ba566f55"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.112.1"
-  pkg.md5sum "ab921dc50a05ed758335554aed9c6593"
+  pkg.version "3.114.0"
+  pkg.md5sum "a53e675090a4d274fd7f7db922e66db6"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.225.0"
-  pkg.md5sum "d8f4d0dffd229a5cc9b2af127d8a6039"
+  pkg.version "1.235.0"
+  pkg.md5sum "d8e184a04c93ae7c49fed74ad36e2fd1"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-bindata.rb
+++ b/configs/components/rubygem-bindata.rb
@@ -1,6 +1,6 @@
 component 'rubygem-bindata' do |pkg, settings, platform|
-  pkg.version '2.4.8'
-  pkg.md5sum '80a3ba1ffdbf020da0efb8c492c67a3a'
+  pkg.version '2.4.9'
+  pkg.md5sum 'a7b78a4d3a97cd97db5e24bd1e9345a2'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-connection_pool.rb
+++ b/configs/components/rubygem-connection_pool.rb
@@ -1,6 +1,6 @@
 component 'rubygem-connection_pool' do |pkg, settings, platform|
-  pkg.version '2.2.3'
-  pkg.md5sum '1ccc96dc7feb55947fe7ec6799ba19b3'
+  pkg.version '2.2.5'
+  pkg.md5sum '498bdfe245ece1c2025fd3727a3dc7e3'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-hiera.rb
+++ b/configs/components/rubygem-hiera.rb
@@ -1,6 +1,6 @@
 component 'rubygem-hiera' do |pkg, settings, platform|
-  pkg.version '3.6.0'
-  pkg.md5sum 'c1975a0cad3df4ba6cf64d07be219f75'
+  pkg.version '3.7.0'
+  pkg.md5sum '24fd0b1e4f449d09a81bf7688e0dcbde'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-jwt.rb
+++ b/configs/components/rubygem-jwt.rb
@@ -1,6 +1,6 @@
 component "rubygem-jwt" do |pkg, settings, platform|
-  pkg.version "2.2.2"
-  pkg.md5sum "33d01d792216c68b0f964aed0858635c"
+  pkg.version "2.2.3"
+  pkg.md5sum "a25cbd9b40f8da7a40faad7a26b8153c"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -4,8 +4,8 @@ component 'rubygem-puppet' do |pkg, settings, platform|
   pkg.version version
 
   case version
-  when '7.4.1'
-    pkg.md5sum 'eb18488e61f43bf3cf7ee94128c469e6'
+  when '7.6.1'
+    pkg.md5sum 'f0b9a3f44dd7d1fce1e147693e971908'
   when '6.20.0'
     pkg.md5sum 'b1a6f244663f04075bafb1d36eede31c'
   else

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -8,7 +8,7 @@ project 'bolt-runtime' do |proj|
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_gettext_version, '3.2.9')
   proj.setting(:rubygem_deep_merge_version, '1.2.1')
-  proj.setting(:rubygem_puppet_version, '7.4.1')
+  proj.setting(:rubygem_puppet_version, '7.6.1')
 
   platform = proj.get_platform
 


### PR DESCRIPTION
This adds a new clause to allow projects to pull in Puppet 7.6.1 if they
have the version specified in the project file, and bumps dependencies
that are unique to Bolt and PE Bolt server. Shared dependency bumps are
in a separate PR for review by teams that need them.

Built and installed for ubuntu-20.04 