### PR TITLE
(maint) Bump Bolt shared dependencies

### DIFF
--- a/configs/components/rubygem-concurrent-ruby.rb
+++ b/configs/components/rubygem-concurrent-ruby.rb
@@ -1,6 +1,6 @@
 component 'rubygem-concurrent-ruby' do |pkg, settings, platform|
-  pkg.version '1.1.5'
-  pkg.md5sum '4409c2d6925d8448cb34a947eacaa29b'
+  pkg.version '1.1.8'
+  pkg.md5sum '68c226f3ee1bf39313dd4ebc0cf52d43'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-hiera-eyaml.rb
+++ b/configs/components/rubygem-hiera-eyaml.rb
@@ -1,6 +1,6 @@
 component 'rubygem-hiera-eyaml' do |pkg, settings, platform|
-  pkg.version '3.2.0'
-  pkg.md5sum '33b3794e2e580de8baf037ef0b624879'
+  pkg.version '3.2.1'
+  pkg.md5sum 'c812e9e75bdf69f2079f16fed61e1109'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 

--- a/configs/components/rubygem-highline.rb
+++ b/configs/components/rubygem-highline.rb
@@ -1,6 +1,6 @@
 component 'rubygem-highline' do |pkg, settings, _platform|
-  pkg.version '1.6.21'
-  pkg.md5sum 'fc79952fb9d12957d828da76b94e4ecb'
+  pkg.version '2.0.3'
+  pkg.md5sum 'be63a46ed7eabcae9a4cf53032dba5bc'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 

--- a/configs/components/rubygem-thor.rb
+++ b/configs/components/rubygem-thor.rb
@@ -1,6 +1,6 @@
 component 'rubygem-thor' do |pkg, settings, platform|
-  pkg.version '1.0.1'
-  pkg.md5sum '052eb36fd3e522331af98449556991dc'
+  pkg.version '1.1.0'
+  pkg.md5sum '0d39b5be66778612f3233253e5b78ae6'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This pulls in the latest versions of dependencies Bolt shares with the
Puppet Agent projects.

CC @puppetlabs/night-s-watch for approval