### PR TITLE
(PA-3702) Short-circuit search if .so already loaded

### DIFF
--- a/configs/components/ruby-2.7.3.rb
+++ b/configs/components/ruby-2.7.3.rb
@@ -39,6 +39,7 @@ component 'ruby-2.7.3' do |pkg, settings, platform|
   # Patch for https://bugs.ruby-lang.org/issues/14972
   pkg.apply_patch "#{base}/net_http_eof_14972_r2.5.patch"
 
+  pkg.apply_patch "#{base}/ruby-fast-load_27.patch"
   pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
 
   if platform.is_cross_compiled?

--- a/resources/patches/ruby_27/ruby-fast-load_27.patch
+++ b/resources/patches/ruby_27/ruby-fast-load_27.patch
@@ -1,0 +1,15 @@
+diff --git a/load.c b/load.c
+index 07acc9ac79..961323d5f3 100644
+--- a/load.c
++++ b/load.c
+@@ -898,6 +898,10 @@ search_required(VALUE fname, volatile VALUE *path, feature_func rb_feature_p)
+ 	if (loading) *path = rb_filesystem_str_new_cstr(loading);
+ 	return 'r';
+     }
++    else if ((ft = rb_feature_p(ftptr, 0, FALSE, FALSE, &loading)) == 's') {
++	if (loading) *path = rb_filesystem_str_new_cstr(loading);
++	return 's';
++    }
+     tmp = fname;
+     type = rb_find_file_ext(&tmp, loadable_ext);
+     switch (type) {


### PR DESCRIPTION
Requiring a ruby library with a short name, like require 'openssl', will scan
all activated gems even if the native library providing that feature has already
been loaded. This patch is based on the ruby ticket[1] and causes ruby to short
circuit the search.

In theory, this patch could break someone if both `lib.rb` and `lib.so` exist,
and they require `lib.so` explicitly, but then expect `require 'lib'` to load
`lib.rb`. That seems highly unlikely though.

[1] https://bugs.ruby-lang.org/issues/15856