### PR TITLE
(PA-3744) Build without site_ruby

### DIFF
--- a/configs/components/ruby-2.7.3.rb
+++ b/configs/components/ruby-2.7.3.rb
@@ -139,6 +139,7 @@ component 'ruby-2.7.3' do |pkg, settings, platform|
         --enable-bundled-libyaml \
         --disable-install-doc \
         --disable-install-rdoc \
+        --with-sitedir=no \
         #{settings[:host]} \
         #{special_flags}"
     ]


### PR DESCRIPTION
I don't believe `site_ruby` is ever used, such as when installing a gem using the `puppet_gem` provider. So this eliminates 3 of the 8 directories from our agent ruby's $LOAD_PATH when running from puppet-agent packages:

```
"/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
"/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0/x86_64-linux",
"/opt/puppetlabs/puppet/lib/ruby/site_ruby",
```

On Windows, we're left with:

```
C:\>ruby -e "require 'pp'; pp $:"
["C:/Program Files/Puppet Labs/Puppet/puppet/lib",
 "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/vendor_ruby/2.7.0",
 "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/vendor_ruby/2.7.0/x64-msvcrt",
 "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/vendor_ruby",
 "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/2.7.0",
 "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/2.7.0/x64-mingw32"]
```

And on *nix:
```
# /opt/puppetlabs/puppet/bin/ruby -e 'require "pp"; pp $:'
["/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/2.7.0",
 "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/2.7.0/x86_64-linux",
 "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby",
 "/opt/puppetlabs/puppet/lib/ruby/2.7.0",
 "/opt/puppetlabs/puppet/lib/ruby/2.7.0/x86_64-linux"]
```

On Redhat 7, the number of file syscalls is reduced from 14220 to 11808 to run `puppet --version`, while the time drops from 0.922 to 0.883 seconds.

On Windows, the number of file events is reduced from 37,266 to 33,201 to run `puppet --version`, while the time drops from 1.950 to 1.319 seconds.

The before and after numbers include the ruby 2.7 perf patch: https://github.com/puppetlabs/puppet-runtime/commit/c56420a650cfd5c3188fdbbdc6781ce886a193b0