### PR TITLE
(PA-3744) Fix siteruby removal on el-7-aarch64

### DIFF
--- a/configs/components/ruby-2.7.3.rb
+++ b/configs/components/ruby-2.7.3.rb
@@ -145,6 +145,17 @@ component 'ruby-2.7.3' do |pkg, settings, platform|
     ]
   end
 
+  # Handle missing sitedir on cross-compiled el-7. This is ugly and at some
+  # point we might need to update our base ruby version on cross-compiled
+  # platforms. The following trick is for for ruby/rubygems 2.0.
+  if platform.name =~ /el-7-aarch64/
+    pkg.build do
+      [
+        %(#{platform[:sed]} -i 's/sitedir/vendordir/' /usr/share/rubygems/rubygems/defaults/operating_system.rb),
+      ]
+    end
+  end
+
   #########
   # INSTALL
   #########


### PR DESCRIPTION
When installing our compiled ruby we still use some of the code from the local ruby installation on cross-compiled platforms. On el-7-aarch64 ruby 2.0 expects sitedir to point to a valid path. It's not used for anything so just make it point to vendordir as well.

We might get hit with this again if we backport the sitedir removal on 6.x, as we have more cross-compiled platforms there... but until then this workaround should do.

Related to https://github.com/puppetlabs/puppet-runtime/pull/448