### PR TITLE
(PA-3744) Revert "build without site_ruby"

### DIFF
--- a/configs/components/ruby-2.7.3.rb
+++ b/configs/components/ruby-2.7.3.rb
@@ -139,7 +139,6 @@ component 'ruby-2.7.3' do |pkg, settings, platform|
         --enable-bundled-libyaml \
         --disable-install-doc \
         --disable-install-rdoc \
-        --with-sitedir=no \
         #{settings[:host]} \
         #{special_flags}"
     ]

--- a/configs/components/ruby-2.7.3.rb
+++ b/configs/components/ruby-2.7.3.rb
@@ -145,17 +145,6 @@ component 'ruby-2.7.3' do |pkg, settings, platform|
     ]
   end
 
-  # Handle missing sitedir on cross-compiled el-7. This is ugly and at some
-  # point we might need to update our base ruby version on cross-compiled
-  # platforms. The following trick is for for ruby/rubygems 2.0.
-  if platform.name =~ /el-7-aarch64/
-    pkg.build do
-      [
-        %(#{platform[:sed]} -i 's/sitedir/vendordir/' /usr/share/rubygems/rubygems/defaults/operating_system.rb),
-      ]
-    end
-  end
-
   #########
   # INSTALL
   #########


### PR DESCRIPTION
We are temporary reverting site_ruby change since it might create a regression (e. g. if people are using `site_ruby` directory for ruby script or libraries) and there is no easy work-around.