### PR TITLE
(PA-3603) Add Fedora 34 x86_64 to puppet-runtime

### DIFF
--- a/configs/platforms/fedora-34-x86_64.rb
+++ b/configs/platforms/fedora-34-x86_64.rb
@@ -1,0 +1,17 @@
+platform 'fedora-34-x86_64' do |plat|
+    plat.servicedir '/usr/lib/systemd/system'
+    plat.defaultdir '/etc/sysconfig'
+    plat.servicetype 'systemd'
+    plat.dist 'fc34'
+
+    packages = %w[
+      autoconf automake bzip2-devel gcc gcc-c++ libselinux-devel
+      libsepol libsepol-devel make cmake pkgconfig readline-devel
+      rpmdevtools rsync swig zlib-devel systemtap-sdt-devel
+      perl-lib perl-FindBin
+    ]
+    plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+
+    plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
+    plat.vmpooler_template 'fedora-34-x86_64'
+  end


### PR DESCRIPTION
Link to passing run for Fedora 34 :
https://jenkins-master-prod-1.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=fedora-34-x86_64,SLAVE_LABEL=worker/1108/