### PR TITLE
(maint) pin cmake-3.11.4 on el-8-x86_64

### DIFF
--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -5,7 +5,7 @@ platform 'el-8-x86_64' do |plat|
 
   packages = %w[
     autoconf automake createrepo gcc gcc-c++ java-1.8.0-openjdk-devel
-    libsepol libsepol-devel libselinux-devel make pkgconfig cmake readline-devel
+    libsepol libsepol-devel libselinux-devel make pkgconfig cmake-3.11.4 readline-devel
     rsync rpm-build rpm-libs rpm-sign rpmdevtools swig yum-utils zlib-devel
     systemtap-sdt-devel
   ]


### PR DESCRIPTION
RedHat recently updated their repos and the cmake version pulled is
newer (3.18.2). This uses a libarchive method that is not available on
3.3.2 which is the one that comes with the box.

   cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd

This can either be fixed by updating the libarchive package to 3.3.3, or
by pinning cmake to the previous working version (3.11.4). Pin cmake for
now.