### PR TITLE
(maint) install `libarchive` on el-8

### DIFF
--- a/configs/platforms/el-8-aarch64.rb
+++ b/configs/platforms/el-8-aarch64.rb
@@ -3,7 +3,7 @@ platform 'el-8-aarch64' do |plat|
   plat.defaultdir '/etc/sysconfig'
   plat.servicetype 'systemd'
 
-  packages = %w[make cmake-3.11.4 perl-Getopt-Long gcc-c++ java-1.8.0-openjdk-devel
+  packages = %w[make cmake libarchive perl-Getopt-Long gcc-c++ java-1.8.0-openjdk-devel
     patch swig libselinux-devel readline-devel zlib-devel systemtap-sdt-devel]
   plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
   plat.install_build_dependencies_with 'dnf install -y --allowerasing'

--- a/configs/platforms/el-8-ppc64le.rb
+++ b/configs/platforms/el-8-ppc64le.rb
@@ -3,7 +3,7 @@ platform 'el-8-ppc64le' do |plat|
   plat.defaultdir '/etc/sysconfig'
   plat.servicetype 'systemd'
 
-  packages = %w[make cmake-3.11.4 perl-Getopt-Long gcc-c++ java-1.8.0-openjdk-devel
+  packages = %w[make cmake libarchive perl-Getopt-Long gcc-c++ java-1.8.0-openjdk-devel
     patch swig libselinux-devel readline-devel zlib-devel systemtap-sdt-devel]
   plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
   plat.install_build_dependencies_with 'dnf install -y --allowerasing'

--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -5,9 +5,9 @@ platform 'el-8-x86_64' do |plat|
 
   packages = %w[
     autoconf automake createrepo gcc gcc-c++ java-1.8.0-openjdk-devel
-    libsepol libsepol-devel libselinux-devel make pkgconfig cmake-3.11.4 readline-devel
+    libsepol libsepol-devel libselinux-devel make pkgconfig cmake readline-devel
     rsync rpm-build rpm-libs rpm-sign rpmdevtools swig yum-utils zlib-devel
-    systemtap-sdt-devel
+    systemtap-sdt-devel libarchive
   ]
   plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
   plat.install_build_dependencies_with 'dnf install -y --allowerasing'


### PR DESCRIPTION
https://github.com/puppetlabs/puppet-runtime/pull/455 locked `cmake` to 3.11.4 to overcome an issue with `libarchive 3.3.2`. 
The issue was fixed in `libarchive 3.3.1` https://bugs.centos.org/view.php?id=18212