### PR TITLE
(maint) Update Bolt-specific gem dependencies

### DIFF
--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.465.0"
-  pkg.md5sum "09f616bb878976ebe5333c4899a4edf0"
+  pkg.version "1.470.0"
+  pkg.md5sum "364c2925fbaa664be7db168f0e935eb4"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.114.1"
-  pkg.md5sum "6769e3bd1749592b9ce817ef13c0b8c9"
+  pkg.version "3.115.0"
+  pkg.md5sum "7a95ddd58115f245452dd2b11e5aea2f"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.240.0"
-  pkg.md5sum "9e2797eb4cac551c5c15fab8038a53d5"
+  pkg.version "1.245.0"
+  pkg.md5sum "55d03fecb2bbd058f40b931828227f43"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '4.2.0'
-  pkg.md5sum '28fa3ba73d0707377370b08733e7d016'
+  pkg.version '4.2.1'
+  pkg.md5sum '404fda5456d8806611eac9778b001536'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-orchestrator_client.rb
+++ b/configs/components/rubygem-orchestrator_client.rb
@@ -1,6 +1,6 @@
 component 'rubygem-orchestrator_client' do |pkg, settings, platform|
-  pkg.version '0.5.1'
-  pkg.md5sum 'c1cf6fb6d4613c2ec1a3267b90e254b6'
+  pkg.version '0.5.2'
+  pkg.md5sum '97b3f0597a4fddf0ce88783c919748fc'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet-resource_api.rb
+++ b/configs/components/rubygem-puppet-resource_api.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet-resource_api' do |pkg, settings, platform|
-  pkg.version '1.8.13'
-  pkg.md5sum '3f6edad4f7a03713ff20d8ae0378e895'
+  pkg.version '1.8.14'
+  pkg.md5sum 'aee660a8398fc1c4dff2154eeb8b5975'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,6 +1,6 @@
 component 'rubygem-r10k' do |pkg, settings, platform|
-  pkg.version '3.9.0'
-  pkg.md5sum '8b358a582b028322a5a6c37eb4c8b0e6'
+  pkg.version '3.9.2'
+  pkg.md5sum 'a5a29f904dbbf2802a06304614e16bf2'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This updates gem dependency versions that are only used in Bolt
projects. Specifically this is to pull in orchestrator_client-ruby to
pick up a fix for the `URI.escape` warning.