### PR TITLE
(packaging) bump resource-api to latest version

### DIFF
--- a/configs/components/rubygem-puppet-resource_api.rb
+++ b/configs/components/rubygem-puppet-resource_api.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet-resource_api' do |pkg, settings, platform|
-  pkg.version '1.8.13'
-  pkg.md5sum '3f6edad4f7a03713ff20d8ae0378e895'
+  pkg.version '1.8.14'
+  pkg.md5sum 'aee660a8398fc1c4dff2154eeb8b5975'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This version adds the custom `in_sync?` functionality, which allows
modern DSC resource types to work idempotently even when the underlying
DSC resource is flawed. Other types will likely start to use this soon
too.