### PR TITLE
(PE-31686) Ship puppet 6.23.0 with bolt/ace server

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,13 +1,13 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
   # Projects may define a :rubygem_puppet_version setting, or we use 6.20.0 by default:
-  version = settings[:rubygem_puppet_version] || '6.20.0'
+  version = settings[:rubygem_puppet_version] || '6.23.0'
   pkg.version version
 
   case version
   when '7.7.0'
     pkg.md5sum '81cfcab6f6998bf7cfbcf0c91a72a469'
-  when '6.20.0'
-    pkg.md5sum 'b1a6f244663f04075bafb1d36eede31c'
+  when '6.23.0'
+    pkg.md5sum '10dbdce584a286bed95835420e2fba48'
   else
     raise "Invalid version #{version} for rubygem-puppet; Cannot continue."
   end


### PR DESCRIPTION
Take up API changes for ace server to use v4 catalog endpoint more efficently.