### PR TITLE
(maint) patch sys-filesystem gem

### DIFF
--- a/configs/components/rubygem-sys-filesystem.rb
+++ b/configs/components/rubygem-sys-filesystem.rb
@@ -3,4 +3,6 @@ component 'rubygem-sys-filesystem' do |pkg, settings, platform|
   pkg.sha256sum '4e907d2a18b0d1a5785896c39e9742ad1dc1e1f772f8154c20e7a1b5a41a9154'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
+
+  pkg.apply_patch "resources/patches/rubygem-sys-filesystem/linux-statvfs.patch", destination: "#{settings[:gem_home]}/gems/sys-filesystem-#{pkg.get_version}", after: "install"
 end

--- a/resources/patches/rubygem-sys-filesystem/linux-statvfs.patch
+++ b/resources/patches/rubygem-sys-filesystem/linux-statvfs.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/sys/unix/sys/filesystem/functions.rb b/lib/sys/unix/sys/filesystem/functions.rb
+index a821b15..a51b96f 100644
+--- a/lib/sys/unix/sys/filesystem/functions.rb
++++ b/lib/sys/unix/sys/filesystem/functions.rb
+@@ -7,7 +7,7 @@
+ 
+       ffi_lib FFI::Library::LIBC
+ 
+-      if RbConfig::CONFIG['host_os'] =~ /sunos|solaris|linux/i
++      if RbConfig::CONFIG['host_os'] =~ /sunos|solaris|x86_64.*linux/i
+         attach_function(:statvfs, :statvfs64, [:string, :pointer], :int)
+       else
+         attach_function(:statvfs, [:string, :pointer], :int)


### PR DESCRIPTION
The commit https://github.com/djberg96/sys-filesystem/commit/4024d9569cc11841f605bb9f5e74e42c32f2082e causes crash on 32 bits Linux, we should use statvfs64 only on 64 bits Linux

Change also proposed upstream: https://github.com/djberg96/sys-filesystem/pull/56