### PR TITLE
Revert "(maint) Pin FFI to 1.13.1 for the Bolt runtime"

### DIFF
--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -1,6 +1,5 @@
 component "rubygem-ffi" do |pkg, settings, platform|
-  if (platform.is_cross_compiled? && (platform.is_linux? || platform.is_solaris?)) ||
-      settings[:rubygem_ffi_version] == '1.13.1'
+  if platform.is_cross_compiled? && (platform.is_linux? || platform.is_solaris?)
     # Installing ffi >= 1.14.0 blows up horribly if we're cross compiling on Linux and Solaris.
     # This is because we're using old rubies (2.1 and 2.0) to install gems which do not have
     # methods like `append_ldflags`.
@@ -35,8 +34,6 @@ component "rubygem-ffi" do |pkg, settings, platform|
       case pkg.get_version
       when '1.9.25'
         pkg.sha256sum '5473ac958b78f271f53e9a88197c35cd3e990fbe625d21e525c56d62ae3750da'
-      when '1.13.1'
-        pkg.sha256sum '029c5c65c4b862a901d8751b8265f46cdcedf6f9186f59121e7511cbeb6e36be'
       when '1.15.3'
         pkg.sha256sum '606486bf10f4dcaedcf630be04d0470ff16923da9d7a44efd544484d50e9b9f0'
       end
@@ -47,8 +44,6 @@ component "rubygem-ffi" do |pkg, settings, platform|
       case pkg.get_version
       when '1.9.25'
         pkg.sha256sum '43d357732a6a0e3e41dc7e28a9c9c5112ac66f4a6ed9e1de40afba9ffcb836c1'
-      when '1.13.1'
-        pkg.sha256sum '10d30fca1ddeac3ca27b39c60ef408248a4714692bb22b4789da7598a9ded69e'
       when '1.15.3'
         pkg.sha256sum '9ae5b0d5e15fb638b177bc697e7510e29df68a021504f0be57ef9f2ffb4fafe1'
       end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -40,9 +40,8 @@ proj.setting(:runtime_project, 'pe-bolt-server')
 
 # Set desired versions for gem components that offer multiple versions:
 # TODO: Can runtime projects use these updated versions?
-proj.setting(:rubygem_deep_merge_version, '1.2.1')
-proj.setting(:rubygem_ffi_version, '1.13.1')
 proj.setting(:rubygem_gettext_version, '3.2.9')
+proj.setting(:rubygem_deep_merge_version, '1.2.1')
 proj.setting(:rubygem_net_ssh_version, '6.1.0')
 
 # (pe-bolt-server does not run on Windows, so only the *nix path is here)

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -6,9 +6,8 @@ project 'bolt-runtime' do |proj|
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
   proj.setting(:augeas_version, '1.11.0')
   # TODO: Can runtime projects use these updated versions?
-  proj.setting(:rubygem_deep_merge_version, '1.2.1')
-  proj.setting(:rubygem_ffi_version, '1.13.1')
   proj.setting(:rubygem_gettext_version, '3.2.9')
+  proj.setting(:rubygem_deep_merge_version, '1.2.1')
   proj.setting(:rubygem_puppet_version, '7.7.0')
 
   platform = proj.get_platform


### PR DESCRIPTION
Reverts puppetlabs/puppet-runtime#473