### PR TITLE
(PA-3883) Add GitHub Actions workflow that shows component diff

### DIFF
--- a/.github/workflows/comment_on_pr.yaml
+++ b/.github/workflows/comment_on_pr.yaml
@@ -1,0 +1,79 @@
+---
+name: Comment output on PR
+
+on:
+  workflow_run:
+    workflows: ["Vanagon Component Diff"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifacts'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "artifacts"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
+            fs.writeFileSync('./artifactid', matchArtifact.id)
+
+      - name: 'Unzip artifacts'      
+        run: unzip artifacts.zip
+
+      - name: 'Check comment limits'
+        run: |
+          chars=$(cat ./text | wc -m)
+          if ((chars > 65300)); then
+            # Trim output to 65300 characters
+            truncate -s 65300 ./text
+
+            # Close all code blocks
+            nr_code_keyword=$(cat ./text | grep '\`\`\`' | wc -l)
+            if [ $((nr_code_keyword%2)) -ne 0 ];then
+              echo >> ./text
+              echo "\`\`\`" >> ./text
+            fi
+
+            # Close all collapsible blocks
+            nr_open_details=$(cat ./text | grep '<details>' | wc -l)
+            nr_closed_details=$(cat ./text | grep '</details>' | wc -l)
+            for i in `seq $(($nr_open_details-$nr_closed_details))`; do echo >> ./text; echo "</details>" >> ./text;done
+
+            # Output artifact info
+            echo >> ./text
+            echo "# ..." >> ./text
+            echo >> ./text
+            printf "Comment size limit reached. " >> ./text
+            echo "Please download full artifacts from [here](https://github.com/${{ github.repository }}/suites/${{github.event.workflow_run.check_suite_id }}/artifacts/$(cat ./artifactid))." >> ./text
+          fi
+
+      - name: 'Add comment'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./nr'));
+            var issue_text = String(fs.readFileSync('./text'));
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: issue_text
+            });

--- a/.github/workflows/component_diff_check.yaml
+++ b/.github/workflows/component_diff_check.yaml
@@ -1,0 +1,41 @@
+---
+name: Vanagon Component Diff
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  vanagon_component_diff_check:
+    runs-on: ubuntu-latest
+    name: Check
+    steps:
+      - name: Checkout current PR
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install ruby version ${{ matrix.cfg.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+
+      - name: Bundle project
+        run: |
+          gem install bundler
+          bundle config set without packaging documentation
+          bundle install --jobs 3 --retry 3 --with development
+
+      - name: Save artifacts data
+        run: |
+          mkdir -p ./output
+          echo '${{ github.event.number }}' > ./output/nr
+          bundle exec rake vanagon:component_diff -- '-mpall' > ./output/text
+          cat ./output/text
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: output/

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,13 @@ gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.21')
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.8')
 gem 'rake', '~> 12.0'
 
+group(:development, optional: true) do
+  gem 'highline', require: false
+  gem 'parallel', require: false
+  gem 'colorize', require: false
+  gem 'hashdiff', require: false
+end
+
 #gem 'rubocop', "~> 0.34.2"
 
 eval_gemfile("#{__FILE__}.local") if File.exist?("#{__FILE__}.local")

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ rescue LoadError => e
   puts "Error loading packaging rake tasks: #{e}"
 end
 
+Dir.glob(File.join('tasks/**/*.rake')).each { |file| load file }
+
 namespace :package do
   task :bootstrap do
     puts 'Bootstrap is no longer needed, using packaging-as-a-gem'

--- a/tasks/vanagon_component_diff.rake
+++ b/tasks/vanagon_component_diff.rake
@@ -1,0 +1,290 @@
+namespace :vanagon do |args|
+  desc 'Show component diff'
+  task(:component_diff) do
+    require 'tempfile'
+    require 'highline/import'
+    require 'json'
+    require 'parallel'
+    require 'hashdiff'
+    require 'optparse'
+
+    class String
+      @@markdown = false
+      @@diff_open = false
+
+      def self.format_as_markdown
+        @@markdown = true
+      end
+
+      def self.is_in_markdown?
+        @@markdown
+      end
+
+      def self.start_diff(alternative = '')
+        return alternative unless @@markdown
+        @@diff_open = true
+        '```diff'
+      end
+
+      def self.end_diff(alternative = '')
+        return alternative unless @@markdown
+        @@diff_open = false
+        '```'
+      end
+
+      def self.start_collapsible(text)
+        return text unless @@markdown
+        text.delete!('`~*_').gsub!('&nbsp;','')
+        "<details>\n  <summary>#{text}</summary>\n\n"
+      end
+
+      def self.end_collapsible
+        return '' unless @@markdown
+        '</details>'
+      end
+
+      def self.hr
+        return "\n---\n" if @@markdown
+        ''
+      end
+
+      def +(text)
+        "#{self} #{text}"
+      end
+
+      def red
+        return @@diff_open ? self : "#{self} :x:" if @@markdown
+        "\e[31m#{self}\e[0m"
+      end
+
+      def green
+        return @@diff_open ? self : "#{self} :white_check_mark:" if @@markdown
+        "\e[32m#{self}\e[0m"
+      end
+
+      def cyan
+        return self if @@markdown
+        "\e[36m#{self}\e[0m"
+      end
+
+      def code
+        return "`#{self}`" if @@markdown
+        self.italic
+      end
+
+      def strike
+        return "~~#{self.strip}~~" if @@markdown
+        self
+      end
+
+      def bold
+        return "**#{self.strip}**" if @@markdown
+        "\e[1m#{self}\e[22m"
+      end
+
+      def italic
+        return "_#{self.strip}_" if @@markdown
+        "\e[3m#{self}\e[23m"
+      end
+
+      def tab(number = 1)
+        return @@diff_open ? self : "#{'&nbsp;'*4*number}#{self}" if @@markdown
+        "#{' '*4*number}#{self}"
+      end
+
+      def h(number)
+        return "#{'#'*number}" + self if @@markdown
+        self.bold
+      end
+    end
+
+    MAX_CPU = Etc.nprocessors - 1
+
+    def vanagon_inspect(project, ref, platforms)
+      files = {}
+
+      platforms.each do |platform|
+        files[platform] = Tempfile.new('vanagon_component_diff')
+      end
+      prev_branch = `git rev-parse --abbrev-ref HEAD`
+
+      `git checkout -q #{ref}`
+
+      Parallel.each(files, max_threads: MAX_CPU) do |platform, file|
+        `bundle exec vanagon inspect #{project} #{platform} > '#{file.path}' 2> /dev/null || echo '{}' > '#{file.path}'`
+      end
+
+      `git checkout -q #{prev_branch}`
+      files
+    end
+
+    git_from_rev = 'origin/master'
+    git_to_rev = 'HEAD'
+    default_projects = ['agent-runtime-main']
+    projects = []
+    default_platforms = ['el-7-x86_64']
+    platforms = []
+
+    parser = OptionParser.new do |opts|
+      opts.banner = 'Usage: ruby vanagon_component_diff.rb [options]'
+
+      opts.on('-f', '--from from_rev', "from git revision (default: #{git_from_rev})") do |from_rev|
+        git_from_rev = from_rev;
+      end
+
+      opts.on('-t', '--to to_rev', "to git revision (default: #{git_to_rev})") do |to_rev|
+        git_to_rev = to_rev;
+      end
+
+      opts.on('-P', '--project vanagon_project', "vanagon project name (default: #{projects}, can be specified multiple times); use 'all' to add all available") do |project_name|
+        if project_name == "all"
+          Dir.entries('configs/projects').each do | file_name |
+            next unless file_name.end_with?('.rb')
+            next if file_name.start_with?('_')
+            projects << File.basename(file_name, '.rb')
+          end
+        else
+          projects << project_name;
+        end
+      end
+
+      opts.on('-p', '--platform vanagon_platform', "vanagon platform names (default: #{default_platforms}, can be specified multiple times); use 'all' to add all available") do |platform_name|
+        if platform_name == "all"
+          Dir.entries('configs/platforms').each do | file_name |
+            next unless file_name.end_with?('.rb')
+            platforms << File.basename(file_name, '.rb')
+          end
+        else
+          platforms << platform_name;
+        end
+      end
+
+      opts.on('-i', '--interactive', 'interactive mode (prompt for settings)') do
+        git_from_rev = ask('Enter Git From Rev: ') { |q| q.default = git_from_rev }
+        git_to_rev = ask('Enter Git To Rev: ') { |q| q.default = git_to_rev }
+        projects = ask("Enter project name (default: #{default_projects.first}, write 'done' to finish project input): ") do |q|
+          q.default = default_projects
+          q.gather = "done"
+        end
+        platforms = ask("Enter platform name (default: #{default_platforms.first}, write 'done' to finish platform input): ") do |q|
+          q.default = default_platforms
+          q.gather = "done"
+        end
+      end
+
+      opts.on('-m', '--markdown', 'format output with markdown for GitHub') do
+        String.format_as_markdown
+      end
+
+      opts.on('-h', '--help', 'this message') do
+        puts opts
+        exit 1
+      end
+    end
+
+    args = parser.order!(ARGV) {}
+    parser.parse!(args)
+
+    if platforms.empty?
+      platforms = default_platforms
+    end
+
+    if projects.empty?
+      projects = default_projects
+    end
+
+    puts "Here is what your code changes would affect:".h(1)
+    puts
+    projects.each do | project |
+      puts "Project #{project.code}".h(2)
+      new_files = vanagon_inspect(project, git_to_rev, platforms)
+      old_files = vanagon_inspect(project, git_from_rev, platforms)
+
+      old, new = {}, {}
+      Parallel.each(old_files.zip(new_files), in_threads: MAX_CPU) do |old_file, new_file|
+        old[old_file.first] = JSON.parse(old_file.last.read)
+        new[new_file.first] = JSON.parse(new_file.last.read)
+      end
+
+      old_hash = old.each_with_object({}) do |k, v|
+        v[k.first] ||= {} # k.first = platform name
+        k.last.each do |component| # k.last = components
+          v[k.first][component.delete("name")] = component
+        end
+      end
+
+      new_hash = new.each_with_object({}) do |k, v|
+        v[k.first] ||= {}
+        k.last.each do |component|
+          v[k.first][component.delete("name")] = component
+        end
+      end
+
+      diff = {}
+      Parallel.each(platforms, in_threads: MAX_CPU) do |platform|
+        diff[platform] = Hashdiff.diff(old_hash[platform], new_hash[platform], delimiter: '|') # TODO investigate if the array_path option is useful
+      end
+
+      changes_found = false
+      diff.each do |platform, diff|
+        next if diff.empty?
+        puts String.hr if changes_found
+        changes_found = true
+        puts
+        if diff.all? { |elem| elem.first == '+' }
+          puts "Platform".bold.h(3) + platform.cyan.code + "was newly added, not showing diff for it".green
+          next
+        elsif diff.all? { |elem| elem.first == '-' }
+          puts "Platform".bold.h(3) + platform.cyan.code + "was removed, not showing diff for it".red
+          next
+        end
+        
+        puts "Platform name:".h(3) + platform.cyan.code
+        ordered_diff = diff.each_with_object({}) do |k, v|
+          name, field = k[1].match(/^([a-zA-Z\-._0-9]+)\|?(.*)?/).captures
+          if field.nil? || field.empty?
+            case k.first
+            when '+'
+              puts "Component '#{name}' was newly added, not showing diff for it".tab.green
+            when '-'
+              puts "Component '#{name}' was removed, not showing diff for it".tab.red
+            end
+            puts
+            next
+          end
+
+          diff = [k[0], k[2], k[3]].compact
+          next if field.start_with?('platform|provisioning') && ['/etc/yum.repos.d', '/etc/yum/repos.d', '/etc/apt/sources.list.d'].any?{ |noise| diff.last().include?(noise) }
+
+          v[name] ||= {}
+          v[name][field] ||= []
+          v[name][field] << diff unless v[name][field].include?(diff)
+        end
+
+        ordered_diff.each do |component, field_hash|
+          puts String.start_collapsible("Component".tab.bold + "'#{component.cyan}'")
+
+          field_hash.each do |field, diff|
+            puts "Field:".tab(2).bold + field.code.cyan
+
+            puts String.start_diff(('-'*20).tab(2))
+            diff.each do |line|
+              case line.first
+              when '-'
+                puts "- #{line[1]}".tab(2).red
+              when '+'
+                puts "+ #{line[1]}".tab(2).green
+              when '~'
+                puts "- #{line[1]}".tab(2).red
+                puts "+ #{line[2]}".tab(2).green
+              end
+            end
+            puts String.end_diff
+          end
+          puts String.end_collapsible
+        end
+      end
+      puts "Nothing is affected 😊" if !changes_found
+    end
+  end
+end


### PR DESCRIPTION
This currently runs only with `puppet-runtime` as project but with all available platforms (retrieved from `configs/platforms`). Comment example can be seen [here](https://github.com/luchihoratiu/puppet-runtime/pull/2#issuecomment-904591632) with changes done in a3c136d201cb60654e2fbdcf258dcea7a85867dc.