### PR TITLE
(VANAGON-171) Use vanagon defaults for Ubuntu 18.04 aarch64

### DIFF
--- a/configs/platforms/ubuntu-18.04-aarch64.rb
+++ b/configs/platforms/ubuntu-18.04-aarch64.rb
@@ -1,10 +1,6 @@
 platform "ubuntu-18.04-aarch64" do |plat|
-  plat.servicedir "/lib/systemd/system"
-  plat.defaultdir "/etc/default"
-  plat.servicetype "systemd"
-  plat.codename "bionic"
-
-  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.inherit_from_default
+  plat.clear_provisioning
 
   packages = %w(
     libbz2-dev
@@ -20,7 +16,4 @@ platform "ubuntu-18.04-aarch64" do |plat|
     zlib1g-dev
   )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq && apt-get install -qy --no-install-recommends #{packages.join(' ')}"
-
-  plat.vmpooler_template "ubuntu-1804-arm64"
-  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end


### PR DESCRIPTION
Normally we'd need to wait for a vanagon release in order to merge this, but our internal pipelines already run with `main`, so it shouldn't matter :shrug:.