### PR TITLE
(PA-3974) Bump openssl-fips to 1.1.1k-4 and patch openssl 1.0.2

### DIFF
--- a/configs/components/openssl-1.0.2.rb
+++ b/configs/components/openssl-1.0.2.rb
@@ -95,6 +95,11 @@ component 'openssl' do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/openssl/openssl-1.0.0l-use-gcc-instead-of-makedepend.patch'
   end
   pkg.apply_patch 'resources/patches/openssl/CVE-2020-1968.patch'
+  pkg.apply_patch 'resources/patches/openssl/CVE-2020-1971.patch'
+  pkg.apply_patch 'resources/patches/openssl/CVE-2021-23839.patch'
+  pkg.apply_patch 'resources/patches/openssl/CVE-2021-23840.patch'
+  pkg.apply_patch 'resources/patches/openssl/CVE-2021-23841.patch'
+  pkg.apply_patch 'resources/patches/openssl/CVE-2021-3712.patch'
 
   ###########
   # CONFIGURE

--- a/resources/patches/openssl/CVE-2020-1971.patch
+++ b/resources/patches/openssl/CVE-2020-1971.patch
@@ -1,0 +1,98 @@
+From 2154ab83e14ede338d2ede9bbe5cdfce5d5a6c9e Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Wed, 11 Nov 2020 16:12:58 +0000
+Subject: [PATCH] Correctly compare EdiPartyName in GENERAL_NAME_cmp()
+
+If a GENERAL_NAME field contained EdiPartyName data then it was
+incorrectly being handled as type "other". This could lead to a
+segmentation fault.
+
+Many thanks to David Benjamin from Google for reporting this issue.
+
+CVE-2020-1971
+
+Reviewed-by: Tomas Mraz <tmraz@fedoraproject.org>
+---
+ crypto/x509v3/v3_genn.c | 45 ++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 42 insertions(+), 3 deletions(-)
+
+diff --git a/crypto/x509v3/v3_genn.c b/crypto/x509v3/v3_genn.c
+index 8db64c745518..b96ed5eb1689 100644
+--- a/crypto/x509v3/v3_genn.c
++++ b/crypto/x509v3/v3_genn.c
+@@ -108,6 +108,37 @@ GENERAL_NAME *GENERAL_NAME_dup(GENERAL_NAME *a)
+                                     (char *)a);
+ }
+ 
++static int edipartyname_cmp(const EDIPARTYNAME *a, const EDIPARTYNAME *b)
++{
++    int res;
++
++    if (a == NULL || b == NULL) {
++        /*
++         * Shouldn't be possible in a valid GENERAL_NAME, but we handle it
++         * anyway. OTHERNAME_cmp treats NULL != NULL so we do the same here
++         */
++        return -1;
++    }
++    if (a->nameAssigner == NULL && b->nameAssigner != NULL)
++        return -1;
++    if (a->nameAssigner != NULL && b->nameAssigner == NULL)
++        return 1;
++    /* If we get here then both have nameAssigner set, or both unset */
++    if (a->nameAssigner != NULL) {
++        res = ASN1_STRING_cmp(a->nameAssigner, b->nameAssigner);
++        if (res != 0)
++            return res;
++    }
++    /*
++     * partyName is required, so these should never be NULL. We treat it in
++     * the same way as the a == NULL || b == NULL case above
++     */
++    if (a->partyName == NULL || b->partyName == NULL)
++        return -1;
++
++    return ASN1_STRING_cmp(a->partyName, b->partyName);
++}
++
+ /* Returns 0 if they are equal, != 0 otherwise. */
+ int GENERAL_NAME_cmp(GENERAL_NAME *a, GENERAL_NAME *b)
+ {
+@@ -117,8 +148,11 @@ int GENERAL_NAME_cmp(GENERAL_NAME *a, GENERAL_NAME *b)
+         return -1;
+     switch (a->type) {
+     case GEN_X400:
++        result = ASN1_TYPE_cmp(a->d.x400Address, b->d.x400Address);
++        break;
++
+     case GEN_EDIPARTY:
+-        result = ASN1_TYPE_cmp(a->d.other, b->d.other);
++        result = edipartyname_cmp(a->d.ediPartyName, b->d.ediPartyName);
+         break;
+ 
+     case GEN_OTHERNAME:
+@@ -165,8 +199,11 @@ void GENERAL_NAME_set0_value(GENERAL_NAME *a, int type, void *value)
+ {
+     switch (type) {
+     case GEN_X400:
++        a->d.x400Address = value;
++        break;
++
+     case GEN_EDIPARTY:
+-        a->d.other = value;
++        a->d.ediPartyName = value;
+         break;
+ 
+     case GEN_OTHERNAME:
+@@ -200,8 +237,10 @@ void *GENERAL_NAME_get0_value(GENERAL_NAME *a, int *ptype)
+         *ptype = a->type;
+     switch (a->type) {
+     case GEN_X400:
++        return a->d.x400Address;
++
+     case GEN_EDIPARTY:
+-        return a->d.other;
++        return a->d.ediPartyName;
+ 
+     case GEN_OTHERNAME:
+         return a->d.otherName;

--- a/resources/patches/openssl/CVE-2021-23839.patch
+++ b/resources/patches/openssl/CVE-2021-23839.patch
@@ -1,0 +1,64 @@
+From 30919ab80a478f2d81f2e9acdcca3fa4740cd547 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Fri, 22 Jan 2021 16:38:50 +0000
+Subject: [PATCH] Fix the RSA_SSLV23_PADDING padding type
+
+This also fixes the public function RSA_padding_check_SSLv23.
+
+Commit 6555a89 changed the padding check logic in RSA_padding_check_SSLv23
+so that padding is rejected if the nul delimiter byte is not immediately
+preceded by at least 8 bytes containing 0x03. Prior to that commit the
+padding is rejected if it *is* preceded by at least 8 bytes containing 0x03.
+
+Presumably this change was made to be consistent with what it says in
+appendix E.3 of RFC 5246. Unfortunately that RFC is in error, and the
+original behaviour was correct. This is fixed in later errata issued for
+that RFC.
+
+Applications that use SSLv2 or call RSA_paddin_check_SSLv23 directly, or
+use the RSA_SSLV23_PADDING mode may be impacted. The effect of the original
+error is that an RSA message encrypted by an SSLv2 only client will fail to
+be decrypted properly by a TLS capable server, or a message encrypted by a
+TLS capable client will fail to decrypt on an SSLv2 only server. Most
+significantly an RSA message encrypted by a TLS capable client will be
+successfully decrypted by a TLS capable server. This last case should fail
+due to a rollback being detected.
+
+Thanks to D. Katz and Joel Luellwitz (both from Trustwave) for reporting
+this issue.
+
+CVE-2021-23839
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+---
+ crypto/rsa/rsa_ssl.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/rsa/rsa_ssl.c b/crypto/rsa/rsa_ssl.c
+index 6f25acdac47a..bdc20c16c00a 100644
+--- a/crypto/rsa/rsa_ssl.c
++++ b/crypto/rsa/rsa_ssl.c
+@@ -104,7 +104,7 @@ int RSA_padding_add_SSLv23(unsigned char *to, int tlen,
+ 
+ /*
+  * Copy of RSA_padding_check_PKCS1_type_2 with a twist that rejects padding
+- * if nul delimiter is not preceded by 8 consecutive 0x03 bytes. It also
++ * if nul delimiter is preceded by 8 consecutive 0x03 bytes. It also
+  * preserves error code reporting for backward compatibility.
+  */
+ int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
+@@ -171,7 +171,13 @@ int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
+                                    RSA_R_NULL_BEFORE_BLOCK_MISSING);
+     mask = ~good;
+ 
+-    good &= constant_time_ge(threes_in_row, 8);
++    /*
++     * Reject if nul delimiter is preceded by 8 consecutive 0x03 bytes. Note
++     * that RFC5246 incorrectly states this the other way around, i.e. reject
++     * if it is not preceded by 8 consecutive 0x03 bytes. However this is
++     * corrected in subsequent errata for that RFC.
++     */
++    good &= constant_time_lt(threes_in_row, 8);
+     err = constant_time_select_int(mask | good, err,
+                                    RSA_R_SSLV3_ROLLBACK_ATTACK);
+     mask = ~good;

--- a/resources/patches/openssl/CVE-2021-23840.patch
+++ b/resources/patches/openssl/CVE-2021-23840.patch
@@ -1,0 +1,114 @@
+From 9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Tue, 2 Feb 2021 17:17:23 +0000
+Subject: [PATCH] Don't overflow the output length in EVP_CipherUpdate calls
+
+CVE-2021-23840
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+---
+ crypto/evp/evp.h     |  2 ++
+ crypto/evp/evp_enc.c | 27 +++++++++++++++++++++++++++
+ crypto/evp/evp_err.c |  4 +++-
+ 3 files changed, 32 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/evp/evp.h b/crypto/evp/evp.h
+index 883a9434899b..4ec0e25d07ac 100644
+--- a/crypto/evp/evp.h
++++ b/crypto/evp/evp.h
+@@ -1491,6 +1491,7 @@ void ERR_load_EVP_strings(void);
+ # define EVP_F_EVP_DECRYPTFINAL_EX                        101
+ # define EVP_F_EVP_DECRYPTUPDATE                          181
+ # define EVP_F_EVP_DIGESTINIT_EX                          128
++# define EVP_F_EVP_ENCRYPTDECRYPTUPDATE                   182
+ # define EVP_F_EVP_ENCRYPTFINAL_EX                        127
+ # define EVP_F_EVP_ENCRYPTUPDATE                          180
+ # define EVP_F_EVP_MD_CTX_COPY_EX                         110
+@@ -1602,6 +1603,7 @@ void ERR_load_EVP_strings(void);
+ # define EVP_R_NO_VERIFY_FUNCTION_CONFIGURED              105
+ # define EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE   150
+ # define EVP_R_OPERATON_NOT_INITIALIZED                   151
++# define EVP_R_OUTPUT_WOULD_OVERFLOW                      172
+ # define EVP_R_PKCS8_UNKNOWN_BROKEN_TYPE                  117
+ # define EVP_R_PRIVATE_KEY_DECODE_ERROR                   145
+ # define EVP_R_PRIVATE_KEY_ENCODE_ERROR                   146
+diff --git a/crypto/evp/evp_enc.c b/crypto/evp/evp_enc.c
+index c63fb53ac85e..f392f6d01363 100644
+--- a/crypto/evp/evp_enc.c
++++ b/crypto/evp/evp_enc.c
+@@ -57,6 +57,7 @@
+  */
+ 
+ #include <stdio.h>
++#include <limits.h>
+ #include "cryptlib.h"
+ #include <openssl/evp.h>
+ #include <openssl/err.h>
+@@ -357,6 +358,19 @@ static int evp_EncryptDecryptUpdate(EVP_CIPHER_CTX *ctx,
+             return 1;
+         } else {
+             j = bl - i;
++
++            /*
++             * Once we've processed the first j bytes from in, the amount of
++             * data left that is a multiple of the block length is:
++             * (inl - j) & ~(bl - 1)
++             * We must ensure that this amount of data, plus the one block that
++             * we process from ctx->buf does not exceed INT_MAX
++             */
++            if (((inl - j) & ~(bl - 1)) > INT_MAX - bl) {
++                EVPerr(EVP_F_EVP_ENCRYPTDECRYPTUPDATE,
++                       EVP_R_OUTPUT_WOULD_OVERFLOW);
++                return 0;
++            }
+             memcpy(&(ctx->buf[i]), in, j);
+             if (!M_do_cipher(ctx, out, ctx->buf, bl))
+                 return 0;
+@@ -482,6 +496,19 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+     OPENSSL_assert(b <= sizeof(ctx->final));
+ 
+     if (ctx->final_used) {
++        /*
++         * final_used is only ever set if buf_len is 0. Therefore the maximum
++         * length output we will ever see from evp_EncryptDecryptUpdate is
++         * the maximum multiple of the block length that is <= inl, or just:
++         * inl & ~(b - 1)
++         * Since final_used has been set then the final output length is:
++         * (inl & ~(b - 1)) + b
++         * This must never exceed INT_MAX
++         */
++        if ((inl & ~(b - 1)) > INT_MAX - b) {
++            EVPerr(EVP_F_EVP_DECRYPTUPDATE, EVP_R_OUTPUT_WOULD_OVERFLOW);
++            return 0;
++        }
+         memcpy(out, ctx->final, b);
+         out += b;
+         fix_len = 1;
+diff --git a/crypto/evp/evp_err.c b/crypto/evp/evp_err.c
+index 11647b92c613..0b1e59ead606 100644
+--- a/crypto/evp/evp_err.c
++++ b/crypto/evp/evp_err.c
+@@ -1,6 +1,6 @@
+ /* crypto/evp/evp_err.c */
+ /* ====================================================================
+- * Copyright (c) 1999-2019 The OpenSSL Project.  All rights reserved.
++ * Copyright (c) 1999-2021 The OpenSSL Project.  All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions
+@@ -94,6 +94,7 @@ static ERR_STRING_DATA EVP_str_functs[] = {
+     {ERR_FUNC(EVP_F_EVP_DECRYPTFINAL_EX), "EVP_DecryptFinal_ex"},
+     {ERR_FUNC(EVP_F_EVP_DECRYPTUPDATE), "EVP_DecryptUpdate"},
+     {ERR_FUNC(EVP_F_EVP_DIGESTINIT_EX), "EVP_DigestInit_ex"},
++    {ERR_FUNC(EVP_F_EVP_ENCRYPTDECRYPTUPDATE), "EVP_ENCRYPTDECRYPTUPDATE"},
+     {ERR_FUNC(EVP_F_EVP_ENCRYPTFINAL_EX), "EVP_EncryptFinal_ex"},
+     {ERR_FUNC(EVP_F_EVP_ENCRYPTUPDATE), "EVP_EncryptUpdate"},
+     {ERR_FUNC(EVP_F_EVP_MD_CTX_COPY_EX), "EVP_MD_CTX_copy_ex"},
+@@ -215,6 +216,7 @@ static ERR_STRING_DATA EVP_str_reasons[] = {
+     {ERR_REASON(EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE),
+      "operation not supported for this keytype"},
+     {ERR_REASON(EVP_R_OPERATON_NOT_INITIALIZED), "operaton not initialized"},
++    {ERR_REASON(EVP_R_OUTPUT_WOULD_OVERFLOW), "output would overflow"},
+     {ERR_REASON(EVP_R_PKCS8_UNKNOWN_BROKEN_TYPE),
+      "pkcs8 unknown broken type"},
+     {ERR_REASON(EVP_R_PRIVATE_KEY_DECODE_ERROR), "private key decode error"},

--- a/resources/patches/openssl/CVE-2021-23841.patch
+++ b/resources/patches/openssl/CVE-2021-23841.patch
@@ -1,0 +1,39 @@
+From 8252ee4d90f3f2004d3d0aeeed003ad49c9a7807 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Wed, 10 Feb 2021 16:10:36 +0000
+Subject: [PATCH] Fix Null pointer deref in X509_issuer_and_serial_hash()
+
+The OpenSSL public API function X509_issuer_and_serial_hash() attempts
+to create a unique hash value based on the issuer and serial number data
+contained within an X509 certificate. However it fails to correctly
+handle any errors that may occur while parsing the issuer field (which
+might occur if the issuer field is maliciously constructed). This may
+subsequently result in a NULL pointer deref and a crash leading to a
+potential denial of service attack.
+
+The function X509_issuer_and_serial_hash() is never directly called by
+OpenSSL itself so applications are only vulnerable if they use this
+function directly and they use it on certificates that may have been
+obtained from untrusted sources.
+
+CVE-2021-23841
+
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+Reviewed-by: Paul Dale <pauli@openssl.org>
+---
+ crypto/x509/x509_cmp.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/crypto/x509/x509_cmp.c b/crypto/x509/x509_cmp.c
+index a7b90e6a42f5..62868f0c9c2e 100644
+--- a/crypto/x509/x509_cmp.c
++++ b/crypto/x509/x509_cmp.c
+@@ -87,6 +87,8 @@ unsigned long X509_issuer_and_serial_hash(X509 *a)
+ 
+     EVP_MD_CTX_init(&ctx);
+     f = X509_NAME_oneline(a->cert_info->issuer, NULL, 0);
++    if (f == NULL)
++        goto err;
+     if (!EVP_DigestInit_ex(&ctx, EVP_md5(), NULL))
+         goto err;
+     if (!EVP_DigestUpdate(&ctx, (unsigned char *)f, strlen(f)))

--- a/resources/patches/openssl/CVE-2021-3712.patch
+++ b/resources/patches/openssl/CVE-2021-3712.patch
@@ -1,0 +1,56 @@
+From ccb0a11145ee72b042d10593a64eaf9e8a55ec12 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Tue, 17 Aug 2021 14:41:48 +0100
+Subject: [PATCH] Fix a read buffer overrun in X509_CERT_AUX_print()
+
+This is a backport of commit c5dc9ab965f to 1.0.2. That commit fixed
+the same bug but in master/1.1.1 it is in the function X509_aux_print().
+The original commit had the following description:
+
+Fix a read buffer overrun in X509_aux_print().
+
+The ASN1_STRING_get0_data(3) manual explitely cautions the reader
+that the data is not necessarily NUL-terminated, and the function
+X509_alias_set1(3) does not sanitize the data passed into it in any
+way either, so we must assume the return value from X509_alias_get0(3)
+is merely a byte array and not necessarily a string in the sense
+of the C language.
+
+I found this bug while writing manual pages for X509_print_ex(3)
+and related functions.  Theo Buehler <tb@openbsd.org> checked my
+patch to fix the same bug in LibreSSL, see
+
+http://cvsweb.openbsd.org/src/lib/libcrypto/asn1/t_x509a.c#rev1.9
+
+As an aside, note that the function still produces incomplete and
+misleading results when the data contains a NUL byte in the middle
+and that error handling is consistently absent throughout, even
+though the function provides an "int" return value obviously intended
+to be 1 for success and 0 for failure, and even though this function
+is called by another function that also wants to return 1 for success
+and 0 for failure and even does so in many of its code paths, though
+not in others.  But let's stay focussed.  Many things would be nice
+to have in the wide wild world, but a buffer overflow must not be
+allowed to remain in our backyard.
+
+CVE-2021-3712
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+---
+ crypto/asn1/t_x509a.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/asn1/t_x509a.c b/crypto/asn1/t_x509a.c
+index d1b897a469fd..b1bc9d0cd28b 100644
+--- a/crypto/asn1/t_x509a.c
++++ b/crypto/asn1/t_x509a.c
+@@ -104,7 +104,8 @@ int X509_CERT_AUX_print(BIO *out, X509_CERT_AUX *aux, int indent)
+     } else
+         BIO_printf(out, "%*sNo Rejected Uses.\n", indent, "");
+     if (aux->alias)
+-        BIO_printf(out, "%*sAlias: %s\n", indent, "", aux->alias->data);
++        BIO_printf(out, "%*sAlias: %.*s\n", indent, "", aux->alias->length,
++                   aux->alias->data);
+     if (aux->keyid) {
+         BIO_printf(out, "%*sKey Id: ", indent, "");
+         for (i = 0; i < aux->keyid->length; i++)

--- a/resources/patches/openssl/openssl-1.1.1-fips-edk2-build.patch
+++ b/resources/patches/openssl/openssl-1.1.1-fips-edk2-build.patch
@@ -1,0 +1,12 @@
+--- a/SOURCES/openssl-1.1.1-edk2-build.patch	2021-08-25 13:32:51.847965576 +0000
++++ b/SOURCES/openssl-1.1.1-edk2-build.patch	2021-08-25 13:32:57.886965493 +0000
+@@ -30,8 +30,8 @@
+ -#ifdef __linux
+ +#if defined(__linux) && !defined(OPENSSL_SYS_UEFI)
+  # include <sys/syscall.h>
+- # include <sys/random.h>
+  # ifdef DEVRANDOM_WAIT
++ #  include <sys/shm.h>
+ diff -up openssl-1.1.1g/include/crypto/fips.h.edk2-build openssl-1.1.1g/include/crypto/fips.h
+ --- openssl-1.1.1g/include/crypto/fips.h.edk2-build	2020-05-18 12:55:53.296548406 +0200
+ +++ openssl-1.1.1g/include/crypto/fips.h	2020-05-18 12:55:53.340548788 +0200

--- a/resources/patches/openssl/openssl-1.1.1-fips-post-rand.patch
+++ b/resources/patches/openssl/openssl-1.1.1-fips-post-rand.patch
@@ -1,19 +1,19 @@
---- a/SOURCES/openssl-1.1.1-fips-post-rand.patch	2019-05-11 00:45:38.000000000 +0000
-+++ b/SOURCES/openssl-1.1.1-fips-post-rand.patch	2020-01-13 15:16:28.537801288 +0000
-@@ -66,7 +66,7 @@
- diff -up openssl-1.1.1c/crypto/rand/rand_unix.c.fips-post-rand openssl-1.1.1c/crypto/rand/rand_unix.c
- --- openssl-1.1.1c/crypto/rand/rand_unix.c.fips-post-rand	2019-05-28 15:12:21.000000000 +0200
- +++ openssl-1.1.1c/crypto/rand/rand_unix.c	2019-05-29 16:54:16.471391802 +0200
--@@ -16,10 +16,12 @@
-+@@ -16,10 +16,11 @@
-  #include <openssl/rand.h>
-  #include "rand_lcl.h"
-  #include "internal/rand_int.h"
-@@ -76,7 +76,6 @@
-  #if defined(__linux)
- -# include <asm/unistd.h>
- +# include <sys/syscall.h>
+--- a/SOURCES/openssl-1.1.1-fips-post-rand.patch	2021-07-21 11:06:35.000000000 +0000
++++ b/SOURCES/openssl-1.1.1-fips-post-rand.patch	2021-08-25 13:16:29.438978978 +0000
+@@ -78,7 +78,7 @@
+ diff -up openssl-1.1.1i/crypto/rand/rand_unix.c.fips-post-rand openssl-1.1.1i/crypto/rand/rand_unix.c
+ --- openssl-1.1.1i/crypto/rand/rand_unix.c.fips-post-rand	2020-12-08 14:20:59.000000000 +0100
+ +++ openssl-1.1.1i/crypto/rand/rand_unix.c	2020-12-09 10:36:59.531221903 +0100
+-@@ -17,10 +17,12 @@
++@@ -17,10 +17,11 @@
+  #include <openssl/crypto.h>
+  #include "rand_local.h"
+  #include "crypto/rand.h"
+@@ -87,7 +87,6 @@
+  #include "internal/dso.h"
+  #ifdef __linux
+  # include <sys/syscall.h>
 -+# include <sys/random.h>
-  #endif
-  #if defined(__FreeBSD__)
-  # include <sys/types.h>
+  # ifdef DEVRANDOM_WAIT
+  #  include <sys/shm.h>
+  #  include <sys/utsname.h>

--- a/resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch
+++ b/resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch
@@ -1,15 +1,16 @@
 --- a/SPECS/openssl.spec	2019-05-11 00:45:45.000000000 +0000
 +++ b/SPECS/openssl.spec	2020-01-13 15:16:29.224852120 +0000
-@@ -67,17 +67,20 @@
- Patch52: openssl-1.1.1-s390x-update.patch
- Patch53: openssl-1.1.1-fips-crng-test.patch
- Patch54: openssl-1.1.1-regression-fixes.patch
-+Patch55: openssl-1.1.1-force-fips-on-init.patch
-+Patch56: openssl-1.1.1-openssl-cnf-fips-mode.patch
-+Patch57: openssl-1.1.1-remove-env-check.patch
+@@ -81,16 +81,21 @@
+ Patch56: openssl-1.1.1-s390x-ecc.patch
+ Patch74: openssl-1.1.1-addrconfig.patch
+ Patch75: openssl-1.1.1-tls13-curves.patch
++Patch100: openssl-1.1.1-force-fips-on-init.patch
++Patch101: openssl-1.1.1-openssl-cnf-fips-mode.patch
++Patch102: openssl-1.1.1-remove-env-check.patch
++Patch103: openssl-1.1.1l-sm2-plaintext.patch
++Patch104: openssl-1.1.1l-ec-group-new-from-ecparameters.patch
  
- License: OpenSSL
- Group: System Environment/Libraries
+ License: OpenSSL and ASL 2.0
  URL: http://www.openssl.org/
  BuildRequires: gcc
 -BuildRequires: coreutils, perl-interpreter, sed, zlib-devel, /usr/bin/cmp
@@ -22,35 +23,37 @@
 +BuildRequires: perl(Test::Harness), perl(Math::BigInt)
  BuildRequires: perl(Module::Load::Conditional), perl(File::Temp)
  BuildRequires: perl(Time::HiRes)
- Requires: coreutils
-@@ -94,7 +95,6 @@
- Group: System Environment/Libraries
+ BuildRequires: perl(FindBin), perl(lib), perl(File::Compare), perl(File::Copy)
+@@ -107,7 +112,6 @@
+ Summary: A general purpose cryptography library with TLS implementation
  Requires: ca-certificates >= 2008-5
  Requires: crypto-policies >= 20180730
 -Recommends: openssl-pkcs11%{?_isa}
  # Needed obsoletes due to the base/lib subpackage split
  Obsoletes: openssl < 1:1.0.1-0.3.beta3
  Obsoletes: openssl-fips < 1:1.0.1e-28
-@@ -131,7 +131,7 @@
+@@ -141,7 +145,7 @@
+ 
  %package perl
  Summary: Perl scripts provided with OpenSSL
- Group: Applications/Internet
 -Requires: perl-interpreter
 +Requires: perl
  Requires: %{name}%{?_isa} = %{epoch}:%{version}-%{release}
  
  %description perl
-@@ -177,6 +177,9 @@
- %patch52 -p1 -b .s390x-update
- %patch53 -p1 -b .crng-test
- %patch54 -p1 -b .regression
-+%patch55 -p1 -b .force-fips-on-init
-+%patch56 -p1 -b .openssl-cnf-fips-mode
-+%patch57 -p1 -b .remove-env-check
+@@ -200,6 +204,11 @@
+ %patch78 -p1 -b .addr-ipv6
+ %patch79 -p1 -b .servername-cb
+ %patch80 -p1 -b .s390x-test-aes
++%patch100 -p1 -b .force-fips-on-init
++%patch101 -p1 -b .openssl-cnf-fips-mode
++%patch102 -p1 -b .remove-env-check
++%patch103 -p1 -b .sm2-plaintext
++%patch104 -p1 -b .ec-parameters
  
  
  %build
-@@ -243,7 +244,7 @@
+@@ -266,7 +275,7 @@
  # marked as not requiring an executable stack.
  # Also add -DPURIFY to make using valgrind with openssl easier as we do not
  # want to depend on the uninitialized memory as a source of entropy anyway.
@@ -59,7 +62,7 @@
  
  export HASHBANGPERL=/usr/bin/perl
  
-@@ -252,8 +253,8 @@
+@@ -275,8 +284,8 @@
  # usable on all platforms.  The Configure script already knows to use -fPIC and
  # RPM_OPT_FLAGS, so we can skip specifiying them here.
  ./Configure \
@@ -70,7 +73,7 @@
  	zlib enable-camellia enable-seed enable-rfc3779 enable-sctp \
  	enable-cms enable-md2 enable-rc5\
  	enable-weak-ssl-ciphers \
-@@ -325,14 +326,14 @@
+@@ -348,14 +357,14 @@
  
  # Install a makefile for generating keys and self-signed certs, and a script
  # for generating them on the fly.
@@ -88,7 +91,7 @@
  
  # Drop the SSLv3 methods from includes
  sed -i '/ifndef OPENSSL_NO_SSL3_METHOD/,+4d' $RPM_BUILD_ROOT%{_includedir}/openssl/ssl.h
-@@ -359,19 +360,19 @@
+@@ -382,19 +391,19 @@
  done
  popd
  
@@ -117,7 +120,7 @@
  
  # Determine which arch opensslconf.h is going to try to #include.
  basearch=%{_arch}
-@@ -418,12 +419,12 @@
+@@ -441,12 +450,12 @@
  %files libs
  %{!?_licensedir:%global license %%doc}
  %license LICENSE
@@ -136,7 +139,7 @@
  %attr(0755,root,root) %{_libdir}/libcrypto.so.%{version}
  %attr(0755,root,root) %{_libdir}/libcrypto.so.%{soversion}
  %attr(0755,root,root) %{_libdir}/libssl.so.%{version}
-@@ -450,11 +451,11 @@
+@@ -473,11 +482,11 @@
  %{_mandir}/man1*/c_rehash*
  %{_mandir}/man1*/tsget*
  %{_mandir}/man1*/openssl-tsget*

--- a/resources/patches/openssl/openssl-1.1.1l-ec-group-new-from-ecparameters.patch
+++ b/resources/patches/openssl/openssl-1.1.1l-ec-group-new-from-ecparameters.patch
@@ -1,0 +1,18 @@
+--- /dev/null	2021-08-26 12:37:58.583000762 +0000
++++ b/SOURCES/openssl-1.1.1l-ec-group-new-from-ecparameters.patch	2021-08-26 12:43:58.517039490 +0000
+@@ -0,0 +1,15 @@
++diff -up openssl-1.1.1/crypto/ec/ec_asn1.c.ec-parameters openssl-1.1.1/crypto/ec/ec_asn1.c
++--- openssl-1.1.1/crypto/ec/ec_asn1.c.ec-parameters	2018-09-11 14:48:23.000000000 +0200
+++++ openssl-1.1.1/crypto/ec/ec_asn1.c	2018-09-17 12:53:33.850637181 +0200
++@@ -761,7 +761,10 @@ EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
++         ret->seed_len = params->curve->seed->length;
++     }
++
++-    if (!params->order || !params->base || !params->base->data) {
+++    if (params->order == NULL
+++            || params->base == NULL
+++            || params->base->data == NULL
+++            || params->base->length == 0) {
++         ECerr(EC_F_EC_GROUP_NEW_FROM_ECPARAMETERS, EC_R_ASN1_ERROR);
++         goto err;
++     }

--- a/resources/patches/openssl/openssl-1.1.1l-sm2-plaintext.patch
+++ b/resources/patches/openssl/openssl-1.1.1l-sm2-plaintext.patch
@@ -1,0 +1,84 @@
+--- /dev/null	2021-08-26 12:37:58.583000762 +0000
++++ openssl-1.1.1k-4-1/SOURCES/openssl-1.1.1l-sm2-plaintext.patch	2021-08-26 13:03:09.884163376 +0000
+@@ -0,0 +1,81 @@
++diff --git a/crypto/sm2/sm2_crypt.c b/crypto/sm2/sm2_crypt.c
++index ef505f64412b..1188abfc6b57 100644
++--- a/crypto/sm2/sm2_crypt.c
+++++ b/crypto/sm2/sm2_crypt.c
++@@ -61,29 +61,20 @@ static size_t ec_field_size(const EC_GROUP *group)
++     return field_size;
++ }
++ 
++-int sm2_plaintext_size(const EC_KEY *key, const EVP_MD *digest, size_t msg_len,
++-                       size_t *pt_size)
+++int sm2_plaintext_size(const unsigned char *ct, size_t ct_size, size_t *pt_size)
++ {
++-    const size_t field_size = ec_field_size(EC_KEY_get0_group(key));
++-    const int md_size = EVP_MD_size(digest);
++-    size_t overhead;
+++    struct SM2_Ciphertext_st *sm2_ctext = NULL;
++ 
++-    if (md_size < 0) {
++-        SM2err(SM2_F_SM2_PLAINTEXT_SIZE, SM2_R_INVALID_DIGEST);
++-        return 0;
++-    }
++-    if (field_size == 0) {
++-        SM2err(SM2_F_SM2_PLAINTEXT_SIZE, SM2_R_INVALID_FIELD);
++-        return 0;
++-    }
+++    sm2_ctext = d2i_SM2_Ciphertext(NULL, &ct, ct_size);
++ 
++-    overhead = 10 + 2 * field_size + (size_t)md_size;
++-    if (msg_len <= overhead) {
+++    if (sm2_ctext == NULL) {
++         SM2err(SM2_F_SM2_PLAINTEXT_SIZE, SM2_R_INVALID_ENCODING);
++         return 0;
++     }
++ 
++-    *pt_size = msg_len - overhead;
+++    *pt_size = sm2_ctext->C2->length;
+++    SM2_Ciphertext_free(sm2_ctext);
+++
++     return 1;
++ }
++ 
++diff --git a/crypto/sm2/sm2_pmeth.c b/crypto/sm2/sm2_pmeth.c
++index b42a14c32f26..27025fbf3a2c 100644
++--- a/crypto/sm2/sm2_pmeth.c
+++++ b/crypto/sm2/sm2_pmeth.c
++@@ -151,7 +151,7 @@ static int pkey_sm2_decrypt(EVP_PKEY_CTX *ctx,
++     const EVP_MD *md = (dctx->md == NULL) ? EVP_sm3() : dctx->md;
++ 
++     if (out == NULL) {
++-        if (!sm2_plaintext_size(ec, md, inlen, outlen))
+++        if (!sm2_plaintext_size(in, inlen, outlen))
++             return -1;
++         else
++             return 1;
++diff --git a/include/crypto/sm2.h b/include/crypto/sm2.h
++index 76ee80baff19..50851a83cea2 100644
++--- a/include/crypto/sm2.h
+++++ b/include/crypto/sm2.h
++@@ -60,8 +60,7 @@ int sm2_verify(const unsigned char *dgst, int dgstlen,
++ int sm2_ciphertext_size(const EC_KEY *key, const EVP_MD *digest, size_t msg_len,
++                         size_t *ct_size);
++ 
++-int sm2_plaintext_size(const EC_KEY *key, const EVP_MD *digest, size_t msg_len,
++-                       size_t *pt_size);
+++int sm2_plaintext_size(const unsigned char *ct, size_t ct_size, size_t *pt_size);
++ 
++ int sm2_encrypt(const EC_KEY *key,
++                 const EVP_MD *digest,
++diff --git a/test/sm2_internal_test.c b/test/sm2_internal_test.c
++index 2bb73947ff3b..41827bb82fcb 100644
++--- a/test/sm2_internal_test.c
+++++ b/test/sm2_internal_test.c
++@@ -185,7 +185,7 @@ static int test_sm2_crypt(const EC_GROUP *group,
++     if (!TEST_mem_eq(ctext, ctext_len, expected, ctext_len))
++         goto done;
++ 
++-    if (!TEST_true(sm2_plaintext_size(key, digest, ctext_len, &ptext_len))
+++    if (!TEST_true(sm2_plaintext_size(ctext, ctext_len, &ptext_len))
++             || !TEST_int_eq(ptext_len, msg_len))
++         goto done;
++ 


### PR DESCRIPTION
Bump the openssl-fips package to the 1.1.1k-4 version provided by CentOS, and also integrate the two CVE patches that went into the 1.1.1l release (CVE-2021-3712 and CVE-2021-3711).

Patch the following CVEs for openssl 1.0.2:
- CVE-2020-1971
- CVE-2021-23839
- CVE-2021-23840
- CVE-2021-23841
- CVE-2021-3712