### PR TITLE
(maint) Update Bolt dependency gems

### DIFF
--- a/configs/components/rubygem-addressable.rb
+++ b/configs/components/rubygem-addressable.rb
@@ -1,6 +1,6 @@
 component 'rubygem-addressable' do |pkg, _settings, _platform|
-  pkg.version '2.7.0'
-  pkg.md5sum '0428adce40bb7468884ee739b61792fd'
+  pkg.version '2.8.0'
+  pkg.md5sum '9cd03fc88dd69b3c3491ce73de27f2f7'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.470.0"
-  pkg.md5sum "364c2925fbaa664be7db168f0e935eb4"
+  pkg.version "1.491.0"
+  pkg.md5sum "a6aa3f71eae58b73aeee3a62989d1cec"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.115.0"
-  pkg.md5sum "7a95ddd58115f245452dd2b11e5aea2f"
+  pkg.version "3.119.1"
+  pkg.md5sum "95cb2050f42194e3329d09720b02d0f7"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.245.0"
-  pkg.md5sum "55d03fecb2bbd058f40b931828227f43"
+  pkg.version "1.259.0"
+  pkg.md5sum "e93081b9c457f7efda1299e19602d794"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sigv4.rb
+++ b/configs/components/rubygem-aws-sigv4.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sigv4" do |pkg, settings, platform|
-  pkg.version "1.2.3"
-  pkg.md5sum "31f1b1fdf70e5f63a143a42b04747088"
+  pkg.version "1.2.4"
+  pkg.md5sum "dc1674c1675fea2b561433e3632c3be5"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-bootsnap.rb
+++ b/configs/components/rubygem-bootsnap.rb
@@ -1,6 +1,6 @@
 component 'rubygem-bootsnap' do |pkg, settings, platform|
-  pkg.version '1.7.2'
-  pkg.md5sum 'dc8b1a2fc84e9a9f3e8934294418692d'
+  pkg.version '1.8.0'
+  pkg.md5sum 'c5cad76ae2201d2f7da394f665df4dee'
 
   pkg.build_requires 'rubygem-msgpack'
   

--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '4.2.1'
-  pkg.md5sum '404fda5456d8806611eac9778b001536'
+  pkg.version '4.2.3'
+  pkg.md5sum 'af11344fd0cd8b09c9fcffcca0c278ed'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-molinillo.rb
+++ b/configs/components/rubygem-molinillo.rb
@@ -1,6 +1,6 @@
 component "rubygem-molinillo" do |pkg, settings, platform|
-  pkg.version "0.7.0"
-  pkg.md5sum "3da77c3c3b5d604aa654b29390f25cb0"
+  pkg.version "0.8.0"
+  pkg.md5sum "877866cc996d5ce819dd8843b3116b5f"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet-strings.rb
+++ b/configs/components/rubygem-puppet-strings.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet-strings' do |pkg, settings, platform|
-  pkg.version '2.7.0'
-  pkg.md5sum '75c44c7202e916986aa9db30a0b13f68'
+  pkg.version '2.8.0'
+  pkg.md5sum '35d27e52d4604955ed7fe7d5ecbd637d'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,13 +1,14 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
-  # Projects may define a :rubygem_puppet_version setting, or we use 6.20.0 by default:
-  version = settings[:rubygem_puppet_version] || '6.23.0'
+  # Projects may define a :rubygem_puppet_version setting, or we use this
+  # version by default
+  version = settings[:rubygem_puppet_version] || '6.24.0'
   pkg.version version
 
   case version
-  when '7.7.0'
-    pkg.md5sum '81cfcab6f6998bf7cfbcf0c91a72a469'
-  when '6.23.0'
-    pkg.md5sum '10dbdce584a286bed95835420e2fba48'
+  when '7.10.0'
+    pkg.md5sum '801e1945b1c483d1d5a4cb9b1caf7578'
+  when '6.24.0'
+    pkg.md5sum 'af6bbabf8ba8b11184f3ff143d4217ac'
   else
     raise "Invalid version #{version} for rubygem-puppet; Cannot continue."
   end

--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,6 +1,6 @@
 component 'rubygem-r10k' do |pkg, settings, platform|
-  pkg.version '3.9.2'
-  pkg.md5sum 'a5a29f904dbbf2802a06304614e16bf2'
+  pkg.version '3.11.0'
+  pkg.md5sum 'bf5790e7d6f4c5f438358c2dca06a62d'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-rubyzip.rb
+++ b/configs/components/rubygem-rubyzip.rb
@@ -1,6 +1,6 @@
 component 'rubygem-rubyzip' do |pkg, settings, platform|
-  pkg.version '2.3.0'
-  pkg.md5sum '3a836c8f901f875882dde4e58178bbf8'
+  pkg.version '2.3.2'
+  pkg.md5sum 'd8396c7f2cefde071353f2a09ee7d2f6'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -8,7 +8,7 @@ project 'bolt-runtime' do |proj|
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_gettext_version, '3.2.9')
   proj.setting(:rubygem_deep_merge_version, '1.2.1')
-  proj.setting(:rubygem_puppet_version, '7.7.0')
+  proj.setting(:rubygem_puppet_version, '7.10.0')
 
   platform = proj.get_platform
 


### PR DESCRIPTION
Updates gem versions to their latest resolved versions for dependencies
of Bolt and pe-bolt-server.

Verified this builds + runs for both Bolt and pe-bolt-server packages.