### PR TITLE
(maint) Fix gcc installation from AIX Toolbox

### DIFF
--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -41,7 +41,8 @@ uncompress openssl-1.0.2.1800.tar.Z;
 tar xvf openssl-1.0.2.1800.tar;
 cd openssl-1.0.2.1800 && /usr/sbin/installp -acgwXY -d $PWD openssl.base;
 curl -O http://ftp.software.ibm.com/aix/freeSoftware/aixtoolbox/ezinstall/ppc/yum.sh && sh yum.sh;
-yum install -y gcc-c++]
+yum install -y gcc-c++;
+ln -sf /opt/freeware/lib/gcc/powerpc-ibm-aix7.1.0.0/8/libgcc_s.a /opt/freeware/lib/libgcc_s.a]
 
   # We use --force with rpm because the pl-gettext and pl-autoconf
   # packages conflict with a charset.alias file.


### PR DESCRIPTION
IBM recently updated their AIX Toolbox gcc packages, including the
absolute path of libgcc_s.a (from lib/gcc/powerpc-ibm-aix6.1.0.0 to
lib/gcc/powerpc-ibm-aix7.1.0.0).

The absolute path is pointed to by the symlink at
/opt/freeware/lib/libgcc_s.a which is handled by the libgcc-8-1 package,
which doesn't update the link from 6.1.0.0 to 7.1.0.0.

This causes any binary that depends on libgcc_s.a (yum, gcc) to fail.

As a quick workaround, manually overwrite the symlink to point to the
correct library.