### PR TITLE
(PA-3769) Add RedHat 8 FIPS platform

### DIFF
--- a/configs/platforms/redhatfips-8-x86_64.rb
+++ b/configs/platforms/redhatfips-8-x86_64.rb
@@ -1,0 +1,31 @@
+platform "redhatfips-8-x86_64" do |plat|
+  # Uncomment the following line when a vanagon with defaults for this platform is released
+  # plat.inherit_from_default
+
+  # Delete everything below when a vanagon with defaults for this platform is released
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  packages = %w(
+    cmake
+    gcc-c++
+    java-1.8.0-openjdk-devel
+    libarchive
+    libsepol-devel
+    libselinux-devel
+    openssl-devel
+    pkgconfig 
+    readline-devel
+    rpm-build
+    rpmdevtools
+    rsync
+    swig
+    systemtap-sdt-devel
+    yum-utils
+    zlib-devel
+  )
+  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.vmpooler_template "redhat-fips-8-x86_64"
+end

--- a/tasks/vanagon_component_diff.rake
+++ b/tasks/vanagon_component_diff.rake
@@ -271,6 +271,7 @@ namespace :vanagon do |args|
         puts "Platform name:".h(3) + platform.cyan.code
         ordered_diff = diff.each_with_object({}) do |k, v|
           name, field = k[1].match(/^([a-zA-Z\-._0-9]+)\|?(.*)?/).captures
+          next if ['_settings', '_platform'].include?(name)
           if field.nil? || field.empty?
             case k.first
             when '+'


### PR DESCRIPTION
I was able to build both `agent-runtime-6.x` and `agent-runtime-main` for RedHat 8 FIPS with these changes.