### PR TITLE
(PA-4037) Only apply patch on Windows

### DIFF
--- a/configs/components/ruby-2.7.3.rb
+++ b/configs/components/ruby-2.7.3.rb
@@ -39,8 +39,6 @@ component 'ruby-2.7.3' do |pkg, settings, platform|
   # Patch for https://bugs.ruby-lang.org/issues/14972
   pkg.apply_patch "#{base}/net_http_eof_14972_r2.5.patch"
 
-  pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
-
   if platform.is_cross_compiled?
     unless platform.is_macos?
       pkg.apply_patch "#{base}/uri_generic_remove_safe_nav_operator_r2.5.patch"
@@ -71,6 +69,7 @@ component 'ruby-2.7.3' do |pkg, settings, platform|
     pkg.apply_patch "#{base}/windows_ruby_2.5_fixup_generated_batch_files.patch"
     pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
     pkg.apply_patch "#{base}/win32_long_paths_support.patch"
+    pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
   end
 
   ####################


### PR DESCRIPTION
Commit 552f10e7 eliminated a seemingly unnecessary call to
`rb_realpath_internal`, which primarily benefits Windows due to its slow
`rb_check_realpath_emulate`[1].

However, when ruby parses a file, it generates an instruction sequence[2] and
stores the realpath in it[3]. Later any calls to `require_relative` are
performed relative to `rb_current_realfilepath`[4] which is implemented by
looking at the realpath for the previous control frame's instruction
sequence[5].

So the patch meant it's possible for a file to be double-required. Once using
its real path, and if another file (B) is loaded via a symlink and B tries to
`require_relative A`. If A happens to be Puppet::FileSystem::Uniquefile, then
puppet will fail to load.

This commit reverts the patch for non-Windows platforms, but preserves it on
Windows where symlinks are much less likely.

[1] https://github.com/ruby/ruby/blob/v2_7_3/file.c#L4425
[2] https://github.com/ruby/ruby/blob/v2_7_3/load.c#L581
[3] https://github.com/ruby/ruby/blob/v2_7_3/iseq.c#L480
[4] https://github.com/ruby/ruby/blob/v2_7_3/load.c#L825
[5] https://github.com/ruby/ruby/blob/v2_7_3/vm_eval.c#L2467