### PR TITLE
(PE-32928) Ship PE Bolt Server with pre-release Puppet gem

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -9,9 +9,14 @@ component 'rubygem-puppet' do |pkg, settings, platform|
     pkg.md5sum '801e1945b1c483d1d5a4cb9b1caf7578'
   when '6.24.0'
     pkg.md5sum 'af6bbabf8ba8b11184f3ff143d4217ac'
+  when '6.24.0.167.g62c2cba'
+    pkg.md5sum 'e6b598b24e68d6e97d071757559d44bf'
   else
     raise "Invalid version #{version} for rubygem-puppet; Cannot continue."
   end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
+  if version == '6.24.0.167.g62c2cba'
+    pkg.url("#{settings[:artifactory_url]}/rubygems/gems/puppet-#{version}.gem")
+  end
 end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -43,6 +43,7 @@ proj.setting(:runtime_project, 'pe-bolt-server')
 proj.setting(:rubygem_gettext_version, '3.2.9')
 proj.setting(:rubygem_deep_merge_version, '1.2.1')
 proj.setting(:rubygem_net_ssh_version, '6.1.0')
+proj.setting(:rubygem_puppet_version, '6.24.0.167.g62c2cba')
 
 # (pe-bolt-server does not run on Windows, so only the *nix path is here)
 proj.setting(:prefix, '/opt/puppetlabs/server/apps/bolt-server')


### PR DESCRIPTION
This updates the PE Bolt server runtime projects to set a pre-release
version of the Puppet 6.x series gem, and additionally updates the
Puppet rubygem component definition to use Artifactory when pulling in
the pre-release version instead of rubygems, since the gem won't be
published there.

This is in order to pull in changes are loading scripts in modules in
Puppet that are required for testing work in Orchestrator around loading
scripts. For now we plan to pin to this gem version since it should have
all of the changes we need, and doesn't need to be updated with new
changes.

Once Puppet 6.25 is availabe these changes can be removed.