### PR TITLE
add snyk scan

### DIFF
--- a/.github/workflows/snyk_scan.yaml
+++ b/.github/workflows/snyk_scan.yaml
@@ -1,0 +1,26 @@
+---
+name: vanagon check PRs
+
+on:
+ pull_request:
+    branches:
+      - master
+
+jobs:
+ snyk_vanagon:
+   runs-on: ubuntu-latest
+   steps:
+    - name: checkout the current PR
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Run Vanagon Snyk Scan
+      uses: puppetlabs/security-snyk-vanagon-action@v1.0.0
+      with:
+        snykToken: ${{ secrets.SNYK_PE_TOKEN }}
+        snykOrg: 'puppet-enterprise'
+        skipProjects: 'agent-runtime-5.5.x,agent-runtime-1.10.x,client-tools-runtime-irving,pdk-runtime'
+        skipPlatforms: 'cisco-wrlinux-5-x86_64,cisco-wrlinux-7-x86_64,debian-10-armhf,eos-4-i386,fedora-30-x86_64,fedora-31-x86_64,osx-10.14-x86_64'
+    - name: Check output
+      if: steps.scan.outputs.vulns != ''
+      run: echo "Vulnerabilities detected; ${{ steps.scan.outputs.vulns }}" && exit 1


### PR DESCRIPTION
This PR adds the snyk scan GitHub action from:

https://github.com/puppetlabs/security-snyk-vanagon-action

The `skipProjects` and `skipPlatforms` sections are set based on the last set of artifacts built to make the process faster.

This action will: 

* fail on PRs to main that have vulnerabilities but not license issues
* add snyk monitoring to the current state (add to the web console)