### PR TITLE
(maint) Bump Bolt gem dependencies

### DIFF
--- a/configs/components/rubygem-aws-eventstream.rb
+++ b/configs/components/rubygem-aws-eventstream.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-eventstream" do |pkg, settings, platform|
-  pkg.version "1.1.1"
-  pkg.md5sum "15511340519ce63d360f33d8ae2c34a4"
+  pkg.version "1.2.0"
+  pkg.md5sum "47689acbf31e71cd5fb3877cce3d9d58"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.491.0"
-  pkg.md5sum "a6aa3f71eae58b73aeee3a62989d1cec"
+  pkg.version "1.510.0"
+  pkg.md5sum "2b6b74a39fab464fd63690f961c8c5b9"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.119.1"
-  pkg.md5sum "95cb2050f42194e3329d09720b02d0f7"
+  pkg.version "3.121.1"
+  pkg.md5sum "bb6b99401878fb7471e4b8b435ee0c32"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.259.0"
-  pkg.md5sum "e93081b9c457f7efda1299e19602d794"
+  pkg.version "1.266.0"
+  pkg.md5sum "34b730c219852e2e20a0388fcf7615ba"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sigv4.rb
+++ b/configs/components/rubygem-aws-sigv4.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sigv4" do |pkg, settings, platform|
-  pkg.version "1.2.4"
-  pkg.md5sum "dc1674c1675fea2b561433e3632c3be5"
+  pkg.version "1.4.0"
+  pkg.md5sum "addb440cc9427db9ddb6ede8519a3758"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '4.2.3'
-  pkg.md5sum 'af11344fd0cd8b09c9fcffcca0c278ed'
+  pkg.version '4.2.5'
+  pkg.md5sum '2f3f8d02a4ec422e78e484d3a413548f'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -5,8 +5,8 @@ component 'rubygem-puppet' do |pkg, settings, platform|
   pkg.version version
 
   case version
-  when '7.10.0'
-    pkg.md5sum '801e1945b1c483d1d5a4cb9b1caf7578'
+  when '7.11.0'
+    pkg.md5sum '496625a3d6ae63eb68614b8b7d99f986'
   when '6.24.0'
     pkg.md5sum 'af6bbabf8ba8b11184f3ff143d4217ac'
   when '6.24.0.167.g62c2cba'

--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,6 +1,6 @@
 component 'rubygem-r10k' do |pkg, settings, platform|
-  pkg.version '3.11.0'
-  pkg.md5sum 'bf5790e7d6f4c5f438358c2dca06a62d'
+  pkg.version '3.12.1'
+  pkg.md5sum '9710edbb5b2ee0992396b448b4920fb6'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-terminal-table.rb
+++ b/configs/components/rubygem-terminal-table.rb
@@ -1,6 +1,6 @@
 component 'rubygem-terminal-table' do |pkg, settings, platform|
-  pkg.version '1.8.0'
-  pkg.md5sum 'd78db9d71f70aaadd7e689641078e7e7'
+  pkg.version '3.0.2'
+  pkg.md5sum '3916a3147871d6421688e575d5939e12'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-unicode-display_width.rb
+++ b/configs/components/rubygem-unicode-display_width.rb
@@ -1,6 +1,6 @@
 component 'rubygem-unicode-display_width' do |pkg, settings, platform|
-  pkg.version '1.7.0'
-  pkg.md5sum 'fc5d1a566bb85b63054e7dcd2b40661a'
+  pkg.version '1.8.0'
+  pkg.md5sum '7b2f281dffe19a8eec5b698cca66c85a'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -8,7 +8,7 @@ project 'bolt-runtime' do |proj|
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_gettext_version, '3.2.9')
   proj.setting(:rubygem_deep_merge_version, '1.2.1')
-  proj.setting(:rubygem_puppet_version, '7.10.0')
+  proj.setting(:rubygem_puppet_version, '7.11.0')
 
   platform = proj.get_platform
 


### PR DESCRIPTION
This bumps Bolt gem dependencies to latest available versions, including
the terminal-table gem.

Built bolt-runtime and pe-bolt-server-main-runtime for el-8 successfully