### PR TITLE
(PE-31696) Use Puppet 7 gem for pe-bolt-server main

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,22 +1,17 @@
 component 'rubygem-puppet' do |pkg, settings, platform|
   # Projects may define a :rubygem_puppet_version setting, or we use this
   # version by default
-  version = settings[:rubygem_puppet_version] || '6.24.0'
+  version = settings[:rubygem_puppet_version] || '6.25.0'
   pkg.version version
 
   case version
   when '7.12.0'
     pkg.md5sum '47cacbe6ac520e817ee5761a769916cc'
-  when '6.24.0'
-    pkg.md5sum 'af6bbabf8ba8b11184f3ff143d4217ac'
-  when '6.24.0.167.g62c2cba'
-    pkg.md5sum 'e6b598b24e68d6e97d071757559d44bf'
+  when '6.25.0'
+    pkg.md5sum 'c0b48b70a9faafd7449434b60c8428ec'
   else
     raise "Invalid version #{version} for rubygem-puppet; Cannot continue."
   end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
-  if version == '6.24.0.167.g62c2cba'
-    pkg.url("#{settings[:artifactory_url]}/rubygems/gems/puppet-#{version}.gem")
-  end
 end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -43,7 +43,6 @@ proj.setting(:runtime_project, 'pe-bolt-server')
 proj.setting(:rubygem_gettext_version, '3.2.9')
 proj.setting(:rubygem_deep_merge_version, '1.2.1')
 proj.setting(:rubygem_net_ssh_version, '6.1.0')
-proj.setting(:rubygem_puppet_version, '6.24.0.167.g62c2cba')
 
 # (pe-bolt-server does not run on Windows, so only the *nix path is here)
 proj.setting(:prefix, '/opt/puppetlabs/server/apps/bolt-server')
@@ -72,9 +71,6 @@ if proj.no_doc
 else
   proj.setting(:gem_install, "#{proj.host_gem} install --no-rdoc --no-ri --local --bindir=#{proj.bindir}")
 end
-
-
-
 
 # What to build?
 # --------------
@@ -151,6 +147,7 @@ proj.component('rubygem-rgen')
 proj.component('rubygem-rubyntlm')
 proj.component('rubygem-ruby_smb')
 proj.component('rubygem-rubyzip')
+proj.component('rubygem-scanf')
 proj.component('rubygem-terminal-table')
 proj.component('rubygem-thor')
 proj.component('rubygem-unicode-display_width')

--- a/configs/projects/pe-bolt-server-runtime-2019.8.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2019.8.x.rb
@@ -1,5 +1,6 @@
 project 'pe-bolt-server-runtime-2019.8.x' do |proj|
   proj.setting(:pe_version, '2019.8')
+  proj.setting(:rubygem_puppet_version, '6.25.0')
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.5 we need to use a --no-ri --no-rdoc flag
   # for gem installs instead of --no-document. This setting allows us to use this while we support both ruby 2.5 and 2.7
   # Once we are no longer using ruby 2.5 we can update.

--- a/configs/projects/pe-bolt-server-runtime-main.rb
+++ b/configs/projects/pe-bolt-server-runtime-main.rb
@@ -1,5 +1,6 @@
 project 'pe-bolt-server-runtime-main' do |proj|
   proj.setting(:pe_version, 'main')
+  proj.setting(:rubygem_puppet_version, '7.12.0')
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.7 we need to use a --no-document flag
   # for gem installs instead of --no-ri --no-rdoc. This setting allows us to use this while we support both ruby 2.5 and 2.7
   # Once we are no longer using ruby 2.5 we can update.


### PR DESCRIPTION
This updates the pe-bolt-server project to continue to use Puppet 6 gem
in the 2019.8.x stream, and adopt Puppet 7 in the main stream.

This also bumps the Puppet version for 2019.8.x to 6.25