### PR TITLE
(maint) Adopt Puppet 7.12 and bump Bolt dependencies

### DIFF
--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.510.0"
-  pkg.md5sum "2b6b74a39fab464fd63690f961c8c5b9"
+  pkg.version "1.514.0"
+  pkg.md5sum "295dca1f9ebdfc2b0217b21f1be1c59e"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.266.0"
-  pkg.md5sum "34b730c219852e2e20a0388fcf7615ba"
+  pkg.version "1.269.0"
+  pkg.md5sum "e6c7d2dff829193048872555219e2665"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -5,8 +5,8 @@ component 'rubygem-puppet' do |pkg, settings, platform|
   pkg.version version
 
   case version
-  when '7.11.0'
-    pkg.md5sum '496625a3d6ae63eb68614b8b7d99f986'
+  when '7.12.0'
+    pkg.md5sum '47cacbe6ac520e817ee5761a769916cc'
   when '6.24.0'
     pkg.md5sum 'af6bbabf8ba8b11184f3ff143d4217ac'
   when '6.24.0.167.g62c2cba'

--- a/configs/components/rubygem-rgen.rb
+++ b/configs/components/rubygem-rgen.rb
@@ -1,6 +1,6 @@
 component 'rubygem-rgen' do |pkg, settings, platform|
-  pkg.version '0.8.2'
-  pkg.md5sum '89e5cb40cef4f86ec297df14c3073885'
+  pkg.version '0.9.0'
+  pkg.md5sum 'c0c6ae4351cf7d1deca2ab052e87d7ab'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -8,7 +8,7 @@ project 'bolt-runtime' do |proj|
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_gettext_version, '3.2.9')
   proj.setting(:rubygem_deep_merge_version, '1.2.1')
-  proj.setting(:rubygem_puppet_version, '7.11.0')
+  proj.setting(:rubygem_puppet_version, '7.12.0')
 
   platform = proj.get_platform
 


### PR DESCRIPTION
This bumps Bolt's dependencies and picks up the new Puppet for Bolt.