### PR TITLE
(PA-4131) Patch CVE in date gem for Ruby 2.5.9

### DIFF
--- a/configs/components/ruby-2.5.9.rb
+++ b/configs/components/ruby-2.5.9.rb
@@ -42,6 +42,7 @@ component 'ruby-2.5.9' do |pkg, settings, platform|
   pkg.apply_patch "#{base}/libyaml_document_end_r2.5.patch"
   # Patch for https://bugs.ruby-lang.org/issues/14972
   pkg.apply_patch "#{base}/net_http_eof_14972_r2.5.patch"
+  pkg.apply_patch "#{base}/date-parsing-method-regexp-dos-cve-2021-41817.patch", fuzz: 1
 
   if platform.is_cross_compiled? && !platform.is_macos?
     pkg.apply_patch "#{base}/uri_generic_remove_safe_nav_operator_r2.5.patch"

--- a/resources/patches/ruby_25/date-parsing-method-regexp-dos-cve-2021-41817.patch
+++ b/resources/patches/ruby_25/date-parsing-method-regexp-dos-cve-2021-41817.patch
@@ -1,0 +1,918 @@
+From 4f9b8e946ba98f0a1774f8e677baa4a45637ebb3 Mon Sep 17 00:00:00 2001
+From: Yusuke Endoh <mame@ruby-lang.org>
+Date: Fri, 12 Nov 2021 12:11:13 +0900
+Subject: [PATCH] Add length limit option for methods that parses date strings
+
+`Date.parse` now raises an ArgumentError when a given date string is
+longer than 128. You can configure the limit by giving `limit` keyword
+arguments like `Date.parse(str, limit: 1000)`. If you pass `limit: nil`,
+the limit is disabled.
+
+Not only `Date.parse` but also the following methods are changed.
+
+* Date._parse
+* Date.parse
+* DateTime.parse
+* Date._iso8601
+* Date.iso8601
+* DateTime.iso8601
+* Date._rfc3339
+* Date.rfc3339
+* DateTime.rfc3339
+* Date._xmlschema
+* Date.xmlschema
+* DateTime.xmlschema
+* Date._rfc2822
+* Date.rfc2822
+* DateTime.rfc2822
+* Date._rfc822
+* Date.rfc822
+* DateTime.rfc822
+* Date._jisx0301
+* Date.jisx0301
+* DateTime.jisx0301
+---
+ date.gemspec                 |   2 +-
+ ext/date/date_core.c         | 384 +++++++++++++++++++++++++++--------
+ test/date/test_date_parse.rb |  29 +++
+ 3 files changed, 326 insertions(+), 89 deletions(-)
+
+/* diff --git a/date.gemspec b/date.gemspec */
+/* index ddb9608..81ee3f3 100644 */
+/* --- a/date.gemspec */
+/* +++ b/date.gemspec */
+/* @@ -1,7 +1,7 @@ */
+/*  # frozen_string_literal: true */
+/*  Gem::Specification.new do |s| */
+/*    s.name = "date" */
+/* -  s.version = '2.0.0' */
+/* +  s.version = '2.0.1' */
+/*    s.summary = "A subclass of Object includes Comparable module for handling dates." */
+/*    s.description = "A subclass of Object includes Comparable module for handling dates." */
+ 
+diff --git a/ext/date/date_core.c b/ext/date/date_core.c
+index 49027e9..1c6fda0 100644
+--- a/ext/date/date_core.c
++++ b/ext/date/date_core.c
+@@ -4292,12 +4292,37 @@ date_s_strptime(int argc, VALUE *argv, VALUE klass)
+ 
+ VALUE date__parse(VALUE str, VALUE comp);
+ 
++static size_t
++get_limit(VALUE opt)
++{
++    if (!NIL_P(opt)) {
++        VALUE limit = rb_hash_aref(opt, ID2SYM(rb_intern("limit")));
++        if (NIL_P(limit)) return SIZE_MAX;
++        return NUM2SIZET(limit);
++    }
++    return 128;
++}
++
++static void
++check_limit(VALUE str, VALUE opt)
++{
++    StringValue(str);
++    size_t slen = RSTRING_LEN(str);
++    size_t limit = get_limit(opt);
++    if (slen > limit) {
++	rb_raise(rb_eArgError,
++		 "string length (%"PRI_SIZE_PREFIX"u) exceeds the limit %"PRI_SIZE_PREFIX"u", slen, limit);
++    }
++}
++
+ static VALUE
+ date_s__parse_internal(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE vstr, vcomp, hash;
++    VALUE vstr, vcomp, hash, opt;
+ 
+-    rb_scan_args(argc, argv, "11", &vstr, &vcomp);
++    rb_scan_args(argc, argv, "11:", &vstr, &vcomp, &opt);
++    if (!NIL_P(opt)) argc--;
++    check_limit(vstr, opt);
+     StringValue(vstr);
+     if (!rb_enc_str_asciicompat_p(vstr))
+ 	rb_raise(rb_eArgError,
+@@ -4322,7 +4347,7 @@ date_s__parse_internal(int argc, VALUE *argv, VALUE klass)
+ 
+ /*
+  * call-seq:
+- *    Date._parse(string[, comp=true])  ->  hash
++ *    Date._parse(string[, comp=true], limit: 128)  ->  hash
+  *
+  * Parses the given representation of date and time, and returns a
+  * hash of parsed elements.  This method does not function as a
+@@ -4333,6 +4358,10 @@ date_s__parse_internal(int argc, VALUE *argv, VALUE klass)
+  * it full.
+  *
+  *    Date._parse('2001-02-03')	#=> {:year=>2001, :mon=>2, :mday=>3}
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s__parse(int argc, VALUE *argv, VALUE klass)
+@@ -4342,7 +4371,7 @@ date_s__parse(int argc, VALUE *argv, VALUE klass)
+ 
+ /*
+  * call-seq:
+- *    Date.parse(string='-4712-01-01'[, comp=true[, start=Date::ITALY]])  ->  date
++ *    Date.parse(string='-4712-01-01'[, comp=true[, start=Date::ITALY]], limit: 128)  ->  date
+  *
+  * Parses the given representation of date and time, and creates a
+  * date object.  This method does not function as a validator.
+@@ -4354,13 +4383,18 @@ date_s__parse(int argc, VALUE *argv, VALUE klass)
+  *    Date.parse('2001-02-03')		#=> #<Date: 2001-02-03 ...>
+  *    Date.parse('20010203')		#=> #<Date: 2001-02-03 ...>
+  *    Date.parse('3rd Feb 2001')	#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_parse(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, comp, sg;
++    VALUE str, comp, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "03", &str, &comp, &sg);
++    rb_scan_args(argc, argv, "03:", &str, &comp, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -4372,11 +4406,12 @@ date_s_parse(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE argv2[2], hash;
+-
+-	argv2[0] = str;
+-	argv2[1] = comp;
+-	hash = date_s__parse(2, argv2, klass);
++        int argc2 = 2;
++	VALUE argv2[3];
++        argv2[0] = str;
++        argv2[1] = comp;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__parse(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+@@ -4390,19 +4425,28 @@ VALUE date__jisx0301(VALUE);
+ 
+ /*
+  * call-seq:
+- *    Date._iso8601(string)  ->  hash
++ *    Date._iso8601(string, limit: 128)  ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__iso8601(VALUE klass, VALUE str)
++date_s__iso8601(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__iso8601(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.iso8601(string='-4712-01-01'[, start=Date::ITALY])  ->  date
++ *    Date.iso8601(string='-4712-01-01'[, start=Date::ITALY], limit: 128)  ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some typical ISO 8601 formats.
+@@ -4410,13 +4454,18 @@ date_s__iso8601(VALUE klass, VALUE str)
+  *    Date.iso8601('2001-02-03')	#=> #<Date: 2001-02-03 ...>
+  *    Date.iso8601('20010203')		#=> #<Date: 2001-02-03 ...>
+  *    Date.iso8601('2001-W05-6')	#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_iso8601(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -4426,38 +4475,56 @@ date_s_iso8601(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__iso8601(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__iso8601(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    Date._rfc3339(string)  ->  hash
++ *    Date._rfc3339(string, limit: 128)  ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__rfc3339(VALUE klass, VALUE str)
++date_s__rfc3339(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__rfc3339(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.rfc3339(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY])  ->  date
++ *    Date.rfc3339(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY], limit: 128)  ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some typical RFC 3339 formats.
+  *
+  *    Date.rfc3339('2001-02-03T04:05:06+07:00')	#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_rfc3339(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -4467,38 +4534,56 @@ date_s_rfc3339(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__rfc3339(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__rfc3339(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    Date._xmlschema(string)  ->  hash
++ *    Date._xmlschema(string, limit: 128)  ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__xmlschema(VALUE klass, VALUE str)
++date_s__xmlschema(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__xmlschema(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.xmlschema(string='-4712-01-01'[, start=Date::ITALY])  ->  date
++ *    Date.xmlschema(string='-4712-01-01'[, start=Date::ITALY], limit: 128)  ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some typical XML Schema formats.
+  *
+  *    Date.xmlschema('2001-02-03')	#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_xmlschema(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -4508,41 +4593,58 @@ date_s_xmlschema(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__xmlschema(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__xmlschema(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    Date._rfc2822(string)  ->  hash
+- *    Date._rfc822(string)   ->  hash
++ *    Date._rfc2822(string, limit: 128)  ->  hash
++ *    Date._rfc822(string, limit: 128)   ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__rfc2822(VALUE klass, VALUE str)
++date_s__rfc2822(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__rfc2822(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.rfc2822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY])  ->  date
+- *    Date.rfc822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY])   ->  date
++ *    Date.rfc2822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY], limit: 128)  ->  date
++ *    Date.rfc822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY], limit: 128)   ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some typical RFC 2822 formats.
+  *
+  *    Date.rfc2822('Sat, 3 Feb 2001 00:00:00 +0000')
+  *						#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_rfc2822(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
+ 
+     switch (argc) {
+       case 0:
+@@ -4552,39 +4654,56 @@ date_s_rfc2822(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__rfc2822(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__rfc2822(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    Date._httpdate(string)  ->  hash
++ *    Date._httpdate(string, limit: 128)  ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__httpdate(VALUE klass, VALUE str)
++date_s__httpdate(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__httpdate(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.httpdate(string='Mon, 01 Jan -4712 00:00:00 GMT'[, start=Date::ITALY])  ->  date
++ *    Date.httpdate(string='Mon, 01 Jan -4712 00:00:00 GMT'[, start=Date::ITALY], limit: 128)  ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some RFC 2616 format.
+  *
+  *    Date.httpdate('Sat, 03 Feb 2001 00:00:00 GMT')
+  *						#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_httpdate(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
+ 
+     switch (argc) {
+       case 0:
+@@ -4594,38 +4713,56 @@ date_s_httpdate(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__httpdate(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__httpdate(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    Date._jisx0301(string)  ->  hash
++ *    Date._jisx0301(string, limit: 128)  ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__jisx0301(VALUE klass, VALUE str)
++date_s__jisx0301(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__jisx0301(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.jisx0301(string='-4712-01-01'[, start=Date::ITALY])  ->  date
++ *    Date.jisx0301(string='-4712-01-01'[, start=Date::ITALY], limit: 128)  ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some typical JIS X 0301 formats.
+  *
+  *    Date.jisx0301('H13.02.03')		#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_jisx0301(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -4635,7 +4772,11 @@ date_s_jisx0301(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__jisx0301(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__jisx0301(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+@@ -7951,7 +8092,7 @@ datetime_s_strptime(int argc, VALUE *argv, VALUE klass)
+ 
+ /*
+  * call-seq:
+- *    DateTime.parse(string='-4712-01-01T00:00:00+00:00'[, comp=true[, start=Date::ITALY]])  ->  datetime
++ *    DateTime.parse(string='-4712-01-01T00:00:00+00:00'[, comp=true[, start=Date::ITALY]], limit: 128)  ->  datetime
+  *
+  * Parses the given representation of date and time, and creates a
+  * DateTime object.  This method does not function as a validator.
+@@ -7965,13 +8106,18 @@ datetime_s_strptime(int argc, VALUE *argv, VALUE klass)
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  *    DateTime.parse('3rd Feb 2001 04:05:06 PM')
+  *				#=> #<DateTime: 2001-02-03T16:05:06+00:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_parse(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, comp, sg;
++    VALUE str, comp, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "03", &str, &comp, &sg);
++    rb_scan_args(argc, argv, "03:", &str, &comp, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -7983,18 +8129,20 @@ datetime_s_parse(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE argv2[2], hash;
+-
+-	argv2[0] = str;
+-	argv2[1] = comp;
+-	hash = date_s__parse(2, argv2, klass);
++        int argc2 = 2;
++        VALUE argv2[3];
++        argv2[0] = str;
++        argv2[1] = comp;
++        argv2[2] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__parse(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    DateTime.iso8601(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY])  ->  datetime
++ *    DateTime.iso8601(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY], limit: 128)  ->  datetime
+  *
+  * Creates a new DateTime object by parsing from a string according to
+  * some typical ISO 8601 formats.
+@@ -8005,13 +8153,18 @@ datetime_s_parse(int argc, VALUE *argv, VALUE klass)
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  *    DateTime.iso8601('2001-W05-6T04:05:06+07:00')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_iso8601(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8021,27 +8174,37 @@ datetime_s_iso8601(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__iso8601(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2--;
++	VALUE hash = date_s__iso8601(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    DateTime.rfc3339(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY])  ->  datetime
++ *    DateTime.rfc3339(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY], limit: 128)  ->  datetime
+  *
+  * Creates a new DateTime object by parsing from a string according to
+  * some typical RFC 3339 formats.
+  *
+  *    DateTime.rfc3339('2001-02-03T04:05:06+07:00')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_rfc3339(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8051,27 +8214,37 @@ datetime_s_rfc3339(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__rfc3339(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__rfc3339(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    DateTime.xmlschema(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY])  ->  datetime
++ *    DateTime.xmlschema(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY], limit: 128)  ->  datetime
+  *
+  * Creates a new DateTime object by parsing from a string according to
+  * some typical XML Schema formats.
+  *
+  *    DateTime.xmlschema('2001-02-03T04:05:06+07:00')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_xmlschema(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8081,28 +8254,38 @@ datetime_s_xmlschema(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__xmlschema(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__xmlschema(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    DateTime.rfc2822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY])  ->  datetime
+- *    DateTime.rfc822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY])   ->  datetime
++ *    DateTime.rfc2822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY], limit: 128)  ->  datetime
++ *    DateTime.rfc822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY], limit: 128)   ->  datetime
+  *
+  * Creates a new DateTime object by parsing from a string according to
+  * some typical RFC 2822 formats.
+  *
+  *     DateTime.rfc2822('Sat, 3 Feb 2001 04:05:06 +0700')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_rfc2822(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8112,7 +8295,12 @@ datetime_s_rfc2822(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__rfc2822(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__rfc2822(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+@@ -8126,13 +8314,18 @@ datetime_s_rfc2822(int argc, VALUE *argv, VALUE klass)
+  *
+  *    DateTime.httpdate('Sat, 03 Feb 2001 04:05:06 GMT')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+00:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_httpdate(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8142,27 +8335,37 @@ datetime_s_httpdate(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__httpdate(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__httpdate(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    DateTime.jisx0301(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY])  ->  datetime
++ *    DateTime.jisx0301(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY], limit: 128)  ->  datetime
+  *
+  * Creates a new DateTime object by parsing from a string according to
+  * some typical JIS X 0301 formats.
+  *
+  *    DateTime.jisx0301('H13.02.03T04:05:06+07:00')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_jisx0301(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8172,7 +8375,12 @@ datetime_s_jisx0301(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__jisx0301(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__jisx0301(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+@@ -9323,19 +9531,19 @@ Init_date_core(void)
+     rb_define_singleton_method(cDate, "strptime", date_s_strptime, -1);
+     rb_define_singleton_method(cDate, "_parse", date_s__parse, -1);
+     rb_define_singleton_method(cDate, "parse", date_s_parse, -1);
+-    rb_define_singleton_method(cDate, "_iso8601", date_s__iso8601, 1);
++    rb_define_singleton_method(cDate, "_iso8601", date_s__iso8601, -1);
+     rb_define_singleton_method(cDate, "iso8601", date_s_iso8601, -1);
+-    rb_define_singleton_method(cDate, "_rfc3339", date_s__rfc3339, 1);
++    rb_define_singleton_method(cDate, "_rfc3339", date_s__rfc3339, -1);
+     rb_define_singleton_method(cDate, "rfc3339", date_s_rfc3339, -1);
+-    rb_define_singleton_method(cDate, "_xmlschema", date_s__xmlschema, 1);
++    rb_define_singleton_method(cDate, "_xmlschema", date_s__xmlschema, -1);
+     rb_define_singleton_method(cDate, "xmlschema", date_s_xmlschema, -1);
+-    rb_define_singleton_method(cDate, "_rfc2822", date_s__rfc2822, 1);
+-    rb_define_singleton_method(cDate, "_rfc822", date_s__rfc2822, 1);
++    rb_define_singleton_method(cDate, "_rfc2822", date_s__rfc2822, -1);
++    rb_define_singleton_method(cDate, "_rfc822", date_s__rfc2822, -1);
+     rb_define_singleton_method(cDate, "rfc2822", date_s_rfc2822, -1);
+     rb_define_singleton_method(cDate, "rfc822", date_s_rfc2822, -1);
+-    rb_define_singleton_method(cDate, "_httpdate", date_s__httpdate, 1);
++    rb_define_singleton_method(cDate, "_httpdate", date_s__httpdate, -1);
+     rb_define_singleton_method(cDate, "httpdate", date_s_httpdate, -1);
+-    rb_define_singleton_method(cDate, "_jisx0301", date_s__jisx0301, 1);
++    rb_define_singleton_method(cDate, "_jisx0301", date_s__jisx0301, -1);
+     rb_define_singleton_method(cDate, "jisx0301", date_s_jisx0301, -1);
+ 
+     rb_define_method(cDate, "initialize", date_initialize, -1);
+diff --git a/test/date/test_date_parse.rb b/test/date/test_date_parse.rb
+index ac0eb85..f9b160e 100644
+--- a/test/date/test_date_parse.rb
++++ b/test/date/test_date_parse.rb
+@@ -1,6 +1,7 @@
+ # frozen_string_literal: true
+ require 'test/unit'
+ require 'date'
++require 'timeout'
+ 
+ class TestDateParse < Test::Unit::TestCase
+ 
+@@ -1122,4 +1123,32 @@ def test_given_string
+     assert_equal(s0, s)
+   end
+ 
++  def test_length_limit
++    assert_raise(ArgumentError) { Date._parse("1" * 1000) }
++    assert_raise(ArgumentError) { Date._iso8601("1" * 1000) }
++    assert_raise(ArgumentError) { Date._rfc3339("1" * 1000) }
++    assert_raise(ArgumentError) { Date._xmlschema("1" * 1000) }
++    assert_raise(ArgumentError) { Date._rfc2822("1" * 1000) }
++    assert_raise(ArgumentError) { Date._rfc822("1" * 1000) }
++    assert_raise(ArgumentError) { Date._jisx0301("1" * 1000) }
++
++    assert_raise(ArgumentError) { Date.parse("1" * 1000) }
++    assert_raise(ArgumentError) { Date.iso8601("1" * 1000) }
++    assert_raise(ArgumentError) { Date.rfc3339("1" * 1000) }
++    assert_raise(ArgumentError) { Date.xmlschema("1" * 1000) }
++    assert_raise(ArgumentError) { Date.rfc2822("1" * 1000) }
++    assert_raise(ArgumentError) { Date.rfc822("1" * 1000) }
++    assert_raise(ArgumentError) { Date.jisx0301("1" * 1000) }
++
++    assert_raise(ArgumentError) { DateTime.parse("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.iso8601("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.rfc3339("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.xmlschema("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.rfc2822("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.rfc822("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.jisx0301("1" * 1000) }
++
++    assert_raise(ArgumentError) { Date._parse("Jan " + "9" * 1000000) }
++    assert_raise(Timeout::Error) { Timeout.timeout(1) { Date._parse("Jan " + "9" * 1000000, limit: nil) } }
++  end
+ end


### PR DESCRIPTION
ruby/date#master commit: https://github.com/ruby/date/commit/3959accef8da5c128f8a8e2fd54e932a4fb253b0
ruby/ruby commit: https://github.com/ruby/ruby/commit/489c8cebf575741d62effd0d212f1319beff3c40
GitHub Advisory DB: https://github.com/advisories/GHSA-qg54-694p-wgpp

The commit from the master branch does not apply cleanly to 2.5.9, but the issue was fixed on multiple versions of the date gem, the oldest one being 2.0.1, which I was able to apply on the Ruby 2.5.9 source: https://github.com/ruby/date/commit/4f9b8e946ba98f0a1774f8e677baa4a45637ebb3

vanagon-generic-builder: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1218/