### PR TITLE
(maint) Make boost and yaml-cpp optional

### DIFF
--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -54,6 +54,7 @@ project 'agent-runtime-main' do |proj|
     proj.component 'rubygem-sys-filesystem'
   end
 
-  proj.component 'boost'
-  proj.component 'yaml-cpp'
+
+  proj.component 'boost' if ENV['NO_PXP_AGENT'].to_s.empty?
+  proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty?
 end


### PR DESCRIPTION
This commit alters the project file for agent-runtime to make boost and
yaml-cpp optional using the `NO_PXP_AGENT` env variable which was
already available and honored in the puppet-agent itself.

If `NO_PXP_AGENT` is defined, the project will skip boost and yaml-cpp
since facter does not need those anymore.