### PR TITLE
(maint) Don't build OpenSSL docs for Raspberry pi (armhf)

### DIFF
--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -172,7 +172,12 @@ component 'openssl' do |pkg, settings, platform|
     install_commands << "slibclean"
   end
 
-  install_commands << "#{platform[:make]} #{install_prefix} install"
+  # Don't build all the docs for armhf
+  if  platform.architecture == 'armhf'
+    install_commands << "#{platform[:make]} #{install_prefix} install_sw install_ssldirs"
+  else
+    install_commands << "#{platform[:make]} #{install_prefix} install"
+  end
 
   if settings[:runtime_project] == 'pdk'
     install_commands << "rm -f #{settings[:prefix]}/bin/{openssl,c_rehash}"


### PR DESCRIPTION
Building OpenSSL docs takes about 5 minutes on a raspberry pi and that
seems like something really isn't needed. This commit excludes the
building of docs on armhf architecture since they are slower builders.

⚠️ I would seriously consider doing this on all builds, but 🤷 .

FWIW, this saves about 20% of the time in the runtime build on a pi. 

