### PR TITLE
(PA-4187) Limits Windows gems to only build on Win

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -199,10 +199,15 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-yard'
 
   # Core Windows dependencies
-  proj.component 'rubygem-win32-dir'
-  proj.component 'rubygem-win32-process'
-  proj.component 'rubygem-win32-security'
-  proj.component 'rubygem-win32-service'
+
+  # Omits from non-Windows platforms to avoid licensing issues
+  if platform.is_windows?
+    proj.component 'rubygem-win32-dir'
+    proj.component 'rubygem-win32-process'
+    proj.component 'rubygem-win32-security'
+    proj.component 'rubygem-win32-service'
+  end
+  
   proj.component 'rubygem-windows_error'
   proj.component 'rubygem-winrm'
   proj.component 'rubygem-winrm-fs'

--- a/configs/projects/pe-installer-runtime-2019.8.x.rb
+++ b/configs/projects/pe-installer-runtime-2019.8.x.rb
@@ -144,12 +144,6 @@ project 'pe-installer-runtime-2019.8.x' do |proj|
     proj.component 'rubygem-ed25519'
   end
 
-  # Core Windows dependencies
-  proj.component 'rubygem-win32-dir'
-  proj.component 'rubygem-win32-process'
-  proj.component 'rubygem-win32-security'
-  proj.component 'rubygem-win32-service'
-
   # Components from puppet-runtime included to support apply on localhost
   # Only bundle SELinux gem for RHEL,Centos,Fedora
   if platform.is_el? || platform.is_fedora?


### PR DESCRIPTION
Addresses a licensing issue with Ruby gems specific to Windows that use the Artistic 2.0 license by preventing them from building on non-Windows platforms.