### PR TITLE
(PA-4323) Update nokogiri gem for main, drop support for 6.x

### DIFF
--- a/configs/components/rubygem-mini_portile2.rb
+++ b/configs/components/rubygem-mini_portile2.rb
@@ -1,6 +1,6 @@
 component 'rubygem-mini_portile2' do |pkg, _settings, _platform|
-  pkg.version '2.6.1'
-  pkg.sha256sum '385fd7a2f3cda0ea5a0cb85551a936da941d7580fc9037a75dea820843aa7dd3'
+  pkg.version '2.8.0'
+  pkg.sha256sum '1e06b286ff19b73cfc9193cb3dd2bd80416f8262443564b25b23baea74a05765'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -1,6 +1,6 @@
 component 'rubygem-nokogiri' do |pkg, _settings, _platform|
-  pkg.version '1.12.5'
-  pkg.sha256sum '2b20905942acc580697c8c496d0d1672ab617facb9d30d156b3c7676e67902ec'
+  pkg.version '1.13.3'
+  pkg.sha256sum 'bf1b1bceff910abb0b7ad825535951101a0361b859c2ad1be155c010081ecbdc'
   instance_eval File.read('configs/components/_base-rubygem.rb')
 
   pkg.build_requires 'rubygem-racc'

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -61,5 +61,4 @@ if platform.is_macos?
   proj.component 'rubygem-CFPropertyList'
   proj.component 'rubygem-racc'
   proj.component 'rubygem-mini_portile2'
-  proj.component 'rubygem-nokogiri'
 end

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -54,6 +54,9 @@ project 'agent-runtime-main' do |proj|
     proj.component 'rubygem-sys-filesystem'
   end
 
+  if platform.is_macos?
+    proj.component 'rubygem-nokogiri'
+  end
 
   proj.component 'boost' if ENV['NO_PXP_AGENT'].to_s.empty?
   proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty?


### PR DESCRIPTION
This PR bumps nokogiri gem due to a security issue. The nokogiri minor
version bump drops support for Ruby 2.5. So we can't support nokogiri on
the 6.x puppet runtime.
Also the mini_portile2 needed to be bumped due to a dependacy from nokogiri.