### PR TITLE
(maint) add public key to ubuntu 20.04 provisioning

### DIFF
--- a/configs/platforms/ubuntu-20.04-amd64.rb
+++ b/configs/platforms/ubuntu-20.04-amd64.rb
@@ -12,4 +12,5 @@ platform "ubuntu-20.04-amd64" do |plat|
     zlib1g-dev
   )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq && apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  plat.provision_with "curl https://artifactory.delivery.puppetlabs.net/artifactory/api/gpg/key/public | apt-key add -"
 end


### PR DESCRIPTION
This adds the artifactory public gpg key to the apt setup in ubuntu 20.04