### PR TITLE
(maint) Add --use-system-powershell for Wix

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -26,7 +26,7 @@ platform "windows-2012r2-x64" do |plat|
     "pl-zlib-#{self._platform.architecture}",
     "mingw-w64 -version 5.2.0 -debug",
     "mingw",
-    "Wix310 -version 3.10.2 -debug -x86"
+    "Wix310 -version 3.10.2 -debug -x86 --use-system-powershell"
   ]
 
   packages.each do |name|

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -25,7 +25,7 @@ platform "windows-2012r2-x86" do |plat|
     "pl-toolchain-#{self._platform.architecture}",
     "pl-zlib-#{self._platform.architecture}",
     "mingw-w32 -version 5.2.0 -debug -x86",
-    "Wix310 -version 3.10.2 -debug -x86"
+    "Wix310 -version 3.10.2 -debug -x86 --use-system-powershell"
   ]
 
   packages.each do |name|

--- a/configs/platforms/windows-2019-x64.rb
+++ b/configs/platforms/windows-2019-x64.rb
@@ -25,7 +25,7 @@ platform "windows-2019-x64" do |plat|
     "pl-toolchain-#{self._platform.architecture}",
     "pl-zlib-#{self._platform.architecture}",
     "mingw-w64 -version 5.2.0 -debug",
-    "Wix310 -version 3.10.2 -debug -x86"
+    "Wix310 -version 3.10.2 -debug -x86 --use-system-powershell"
   ]
 
   packages.each do |name|


### PR DESCRIPTION
For some reason, the Chocolatey machinery seems to think Wix is failing to install, which in fact it is installing fine. The use of the --use-system-powershell flag bypasses whatever error is happening in the Chocolatey machinery and allows the build to continue.