### PR TITLE
(PE-33126) Fix for building client-tools-runtime on redhatfips-8-x86_64

### DIFF
--- a/configs/platforms/redhatfips-8-x86_64.rb
+++ b/configs/platforms/redhatfips-8-x86_64.rb
@@ -1,31 +1,3 @@
 platform "redhatfips-8-x86_64" do |plat|
-  # Uncomment the following line when a vanagon with defaults for this platform is released
-  # plat.inherit_from_default
-
-  # Delete everything below when a vanagon with defaults for this platform is released
-  plat.servicedir "/usr/lib/systemd/system"
-  plat.defaultdir "/etc/sysconfig"
-  plat.servicetype "systemd"
-
-  packages = %w(
-    cmake
-    gcc-c++
-    java-1.8.0-openjdk-devel
-    libarchive
-    libsepol-devel
-    libselinux-devel
-    openssl-devel
-    pkgconfig 
-    readline-devel
-    rpm-build
-    rpmdevtools
-    rsync
-    swig
-    systemtap-sdt-devel
-    yum-utils
-    zlib-devel
-  )
-  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
-  plat.install_build_dependencies_with "yum install --assumeyes"
-  plat.vmpooler_template "redhat-fips-8-x86_64"
+  plat.inherit_from_default
 end

--- a/configs/projects/_shared-client-tools-runtime.rb
+++ b/configs/projects/_shared-client-tools-runtime.rb
@@ -7,7 +7,6 @@ unless defined?(proj)
 end
 
 proj.setting(:runtime_project, 'client-tools')
-proj.setting(:openssl_version, '1.1.1')
 
 proj.generate_archives true
 proj.generate_packages false
@@ -20,6 +19,15 @@ proj.identifier "com.puppetlabs"
 proj.version_from_git
 
 platform = proj.get_platform
+
+# We need to explicitly define 1.1.1k here to avoid
+# build dep conflicts between openssl-1.1.1 needed by curl
+# and krb5-devel
+if platform.name =~ /^redhatfips-8/
+  proj.setting(:openssl_version, '1.1.1k')
+else 
+  proj.setting(:openssl_version, '1.1.1')
+end
 
 proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
 proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")


### PR DESCRIPTION
The openssl-1.1.1 package needed as a build dep for curl was conflicting with krb5-devel. This specifically uses openssl-1.1.1k on redhatfips8, which plays nicely with krb5-devel.