### PR TITLE
(PE-33792) Define net-ssh version before pulling in shared components

### DIFF
--- a/configs/projects/pe-installer-runtime-2019.8.x.rb
+++ b/configs/projects/pe-installer-runtime-2019.8.x.rb
@@ -61,6 +61,9 @@ project 'pe-installer-runtime-2019.8.x' do |proj|
   # --------------
   #
 
+  # rubygem-net-ssh included in shared-agent-components
+  proj.setting(:rubygem_net_ssh_version, '5.2.0')
+
   ########
   # Load shared agent components
   # When we want to run Bolt from the pe-installer package, we want our
@@ -75,8 +78,6 @@ project 'pe-installer-runtime-2019.8.x' do |proj|
   # R10k dependencies
   proj.component 'rubygem-gettext-setup'
 
-  # rubygem-net-ssh included in shared-agent-components
-  proj.setting(:rubygem_net_ssh_version, '5.2.0')
 
   # net-ssh dependencies for el8's OpenSSH default key format
   proj.component 'rubygem-bcrypt_pbkdf'

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -63,6 +63,9 @@ project 'pe-installer-runtime-main' do |proj|
   # --------------
   #
 
+  # rubygem-net-ssh included in shared-agent-components
+  proj.setting(:rubygem_net_ssh_version, '5.2.0')
+
   ########
   # Load shared agent components
   # When we want to run Bolt from the pe-installer package, we want our
@@ -77,9 +80,6 @@ project 'pe-installer-runtime-main' do |proj|
 
   # R10k dependencies
   proj.component 'rubygem-gettext-setup'
-
-  # rubygem-net-ssh included in shared-agent-components
-  proj.setting(:rubygem_net_ssh_version, '5.2.0')
 
   # net-ssh dependencies for el8's OpenSSH default key format
   proj.component 'rubygem-bcrypt_pbkdf'


### PR DESCRIPTION
Because defining the version of net-ssh happened after we pulled in the shared agent components, it ended up using the default of 4.2 rather than our desired 5.2. This moves the setting above where we pull in the shared components.