### PR TITLE
(PA-4423) Adds virt-what and dmidecode components

### DIFF
--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -1,0 +1,36 @@
+component 'dmidecode' do |pkg, settings, platform|
+    pkg.version '3.3'
+    pkg.md5sum 'afca949fd71a23dd39c4a3c9cd946dc0'
+
+    pkg.apply_patch 'resources/patches/dmidecode/1117390c.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/11e134e5.patch'
+  
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-install-to-bin.patch'
+    pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.xz"
+    pkg.mirror "#{settings[:buildsources_url]}/dmidecode-#{pkg.get_version}.tar.xz"
+  
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
+  
+    if platform.is_cross_compiled?
+      # The Makefile doesn't honor environment overrides, so we need to
+      # edit it directly for cross-compiling
+      pkg.configure do
+        ["sed -i \"s|gcc|/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc|g\" Makefile"]
+      end
+    end
+  
+    pkg.build do
+      ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+    end
+  
+    pkg.install do
+      [
+        "#{platform[:make]} prefix=#{settings[:prefix]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
+        "rm -f #{settings[:bindir]}/vpddecode #{settings[:bindir]}/biosdecode #{settings[:bindir]}/ownership",
+        "rm -f #{settings[:mandir]}/man8/ownership.8 #{settings[:mandir]}/man8/biosdecode.8 #{settings[:mandir]}/man8/vpddecode.8"
+      ]
+    end
+  end
+  
+  

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -1,0 +1,47 @@
+component "virt-what" do |pkg, settings, platform|
+    pkg.version "1.22"
+    pkg.md5sum "0e9923de6a6c6f07bc0ddc3ec8fc1018"
+  
+    pkg.url "https://people.redhat.com/~rjones/virt-what/files/virt-what-#{pkg.get_version}.tar.gz"
+    pkg.mirror "#{settings[:buildsources_url]}/virt-what-#{pkg.get_version}.tar.gz"
+  
+    pkg.replaces 'pe-virt-what'
+  
+    # Run-time requirements
+    unless platform.is_deb?
+      requires "util-linux"
+    end
+  
+    if platform.is_rpm?
+      pkg.build_requires "util-linux"
+    end
+  
+    if platform.is_linux?
+      if platform.architecture =~ /ppc64le$/
+        host_opt = '--host powerpc64le-unknown-linux-gnu'
+      elsif platform.architecture =~ /ppc64$/
+        host_opt = '--host powerpc64-unknown-linux-gnu'
+      end
+    end
+  
+    if platform.is_cross_compiled_linux?
+      host_opt = "--host #{settings[:platform_triple]}"
+  
+      pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+      pkg.environment "CFLAGS" => settings[:cflags]
+      pkg.environment "LDFLAGS" => settings[:ldflags]
+    end
+  
+    pkg.configure do
+      ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/virt-what #{host_opt}"]
+    end
+  
+    pkg.build do
+      ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+    end
+  
+    pkg.install do
+      ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+    end
+  end
+  

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -52,6 +52,11 @@ project 'agent-runtime-main' do |proj|
   proj.component 'rubygem-thor'
   proj.component 'rubygem-scanf'
 
+  if platform.is_linux?
+    proj.component "virt-what"
+    proj.component "dmidecode" unless platform.architecture =~ /ppc64/
+  end
+
   unless platform.is_windows?
     proj.component 'rubygem-sys-filesystem'
   end

--- a/resources/patches/dmidecode/1117390c.patch
+++ b/resources/patches/dmidecode/1117390c.patch
@@ -1,0 +1,28 @@
+author	Tianjia Zhang <tianjia.zhang@linux.alibaba.com>	2021-01-05 10:36:29 +0100
+committer	Jean Delvare <jdelvare@suse.de>	2021-01-05 10:36:29 +0100
+commit	1117390ccd9cea139638db6f460bb6de70e28f94 (patch)
+tree	92d703ba6d96dbbc2f6963546ac93731e5cdf0be
+parent	3c111e4f6134855580f20f8e01fee26eff455fff (diff)
+download	dmidecode-1117390ccd9cea139638db6f460bb6de70e28f94.tar.gz
+dmidecode: Fix the condition error in ascii_filter
+The normal printable ASCII range is 32 to 127 (not included),
+so fix the error in this if condition.
+
+Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+Diffstat
+-rw-r--r--	dmidecode.c	2	
+		
+1 files changed, 1 insertions, 1 deletions
+diff --git a/dmidecode.c b/dmidecode.c
+index 27d5494..864a193 100644
+--- a/dmidecode.c
++++ b/dmidecode.c
+@@ -116,7 +116,7 @@ static void ascii_filter(char *bp, size_t len)
+ 	size_t i;
+ 
+ 	for (i = 0; i < len; i++)
+-		if (bp[i] < 32 || bp[i] == 127)
++		if (bp[i] < 32 || bp[i] >= 127)
+ 			bp[i] = '.';
+ }

--- a/resources/patches/dmidecode/11e134e5.patch
+++ b/resources/patches/dmidecode/11e134e5.patch
@@ -1,0 +1,33 @@
+author	Jean Delvare <jdelvare@suse.de>	2021-01-19 16:26:01 +0100
+committer	Jean Delvare <jdelvare@suse.de>	2021-01-19 16:26:01 +0100
+commit	11e134e54d15e67a64c39a623f492a28df922517 (patch)
+tree	e93f12a63524c810eea8b1532886d1a59043d16c
+parent	bd8636e4b5e2fe95373b3ade1cdc5ec2d6578ca4 (diff)
+download	dmidecode-11e134e54d15e67a64c39a623f492a28df922517.tar.gz
+dmidecode: Fix crash with -u option
+A segmentation fault was reported with option -u. Turns out to be a
+stupid thinko where the buffer offset was reset at the wrong loop
+depth.
+
+Reported-by: Jerry Hoemann <jerry.hoemann@hpe.com>
+Fixes: da06888d08b9 ("dmidecode: Use the print helpers in dump mode too")
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+Diffstat
+-rw-r--r--	dmidecode.c	2	
+		
+1 files changed, 1 insertions, 1 deletions
+diff --git a/dmidecode.c b/dmidecode.c
+index 572cb1a..69ea0e8 100644
+--- a/dmidecode.c
++++ b/dmidecode.c
+@@ -248,9 +248,9 @@ static void dmi_dump(const struct dmi_header *h)
+ 			{
+ 				int j, l = strlen(s) + 1;
+ 
+-				off = 0;
+ 				for (row = 0; row < ((l - 1) >> 4) + 1; row++)
+ 				{
++					off = 0;
+ 					for (j = 0; j < 16 && j < l - (row << 4); j++)
+ 						off += sprintf(raw_data + off,
+ 						       j ? " %02X" : "%02X",

--- a/resources/patches/dmidecode/dmidecode-install-to-bin.patch
+++ b/resources/patches/dmidecode/dmidecode-install-to-bin.patch
@@ -1,0 +1,30 @@
+diff --git a/Makefile b/Makefile
+index 55378bb..b43b218 100644
+--- a/Makefile
++++ b/Makefile
+@@ -27,7 +27,7 @@ LDFLAGS =
+ 
+ DESTDIR =
+ prefix  = /usr/local
+-sbindir = $(prefix)/sbin
++bindir  = $(prefix)/bin
+ mandir  = $(prefix)/share/man
+ man8dir = $(mandir)/man8
+ docdir  = $(prefix)/share/doc/dmidecode
+@@ -110,13 +110,13 @@ install : install-bin install-man install-doc
+ uninstall : uninstall-bin uninstall-man uninstall-doc
+ 
+ install-bin : $(PROGRAMS)
+-	$(INSTALL_DIR) $(DESTDIR)$(sbindir)
++	$(INSTALL_DIR) $(DESTDIR)$(bindir)
+ 	for program in $(PROGRAMS) ; do \
+-	$(INSTALL_PROGRAM) $$program $(DESTDIR)$(sbindir) ; done
++	$(INSTALL_PROGRAM) $$program $(DESTDIR)$(bindir) ; done
+ 
+ uninstall-bin :
+ 	for program in $(PROGRAMS) ; do \
+-	$(RM) $(DESTDIR)$(sbindir)/$$program ; done
++	$(RM) $(DESTDIR)$(bindir)/$$program ; done
+ 
+ install-man :
+ 	$(INSTALL_DIR) $(DESTDIR)$(man8dir)


### PR DESCRIPTION
These components were previously included in the puppet-agent
repository; this commit moves these components into puppet-runtime,
updates and patches them, and includes them in agent-runtime-main.

These components were removed at https://github.com/puppetlabs/puppet-agent/pull/1958/commits/a1a06ba3f42419e43faa4d0f1f89bed8104a106a

Blocked on https://github.com/puppetlabs/vanagon/pull/747, will test after it's merged