### PR TITLE
(PA-4460) Adds macOS 12 Monterey M1/ARM64 platform

### DIFF
--- a/configs/components/_base-ruby-augeas.rb
+++ b/configs/components/_base-ruby-augeas.rb
@@ -36,7 +36,8 @@ if platform.is_solaris?
 elsif platform.is_cross_compiled?
   if platform.is_linux? || platform.is_macos?
     pkg.environment "RUBY", host_ruby
-    pkg.environment "CC", "clang -target arm64-apple-macos11" if platform.is_macos?
+    pkg.environment "CC", "clang -target arm64-apple-macos11" if platform.name =~ /osx-11/ 
+    pkg.environment "CC", "clang -target arm64-apple-macos12" if platform.name =~ /osx-12/ 
     ruby = "#{host_ruby} -r#{settings[:datadir]}/doc/rbconfig-#{ruby_version}-orig.rb"
     pkg.environment "LDFLAGS", settings[:ldflags]
   end

--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -49,8 +49,9 @@ elsif platform.is_macos?
   pkg.environment 'optflags', settings[:cflags]
   if platform.is_cross_compiled?
     pkg.build_requires "ruby@#{ruby_version_y}"
-    pkg.environment 'CC', 'clang -target arm64-apple-macos11'
-  end
+    pkg.environment "CC", "clang -target arm64-apple-macos11" if platform.name =~ /osx-11/ 
+    pkg.environment "CC", "clang -target arm64-apple-macos12" if platform.name =~ /osx-12/ 
+   end
 end
 
 ####################

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -89,7 +89,10 @@ component 'augeas' do |pkg, settings, platform|
   elsif platform.is_macos?
     pkg.environment "PATH", "$(PATH):/usr/local/bin"
     pkg.environment "CFLAGS", settings[:cflags]
-    pkg.environment "CC", "clang -target arm64-apple-macos11" if platform.is_cross_compiled?
+    if platform.is_cross_compiled?
+      pkg.environment "CC", "clang -target arm64-apple-macos11" if platform.name =~ /osx-11/ 
+      pkg.environment "CC", "clang -target arm64-apple-macos12" if platform.name =~ /osx-12/ 
+    end
   end
 
   if platform.name =~ /sles-15|el-8|debian-10/ || platform.is_fedora?

--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -63,8 +63,10 @@ component "boost" do |pkg, settings, platform|
   elsif platform.is_macos?
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
     linkflags = ""
-    gpp = if platform.is_cross_compiled?
+    gpp = if platform.is_cross_compiled? && platform.name =~ /osx-11/
             "clang++ -target arm64-apple-macos11"
+          elsif platform.is_cross_compiled? && platform.name =~ /osx-12/
+            "clang++ -target arm64-apple-macos12"
           else
             "clang++"
           end

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -35,7 +35,8 @@ component 'curl' do |pkg, settings, platform|
 
   extra_cflags = []
   if platform.is_cross_compiled? && platform.is_macos?
-    extra_cflags << '-mmacosx-version-min=11.0 -arch arm64'
+    extra_cflags << '-mmacosx-version-min=11.0 -arch arm64' if platform.name =~ /osx-11/ 
+    extra_cflags << '-mmacosx-version-min=12.0 -arch arm64' if platform.name =~ /osx-12/ 
   end
 
   if (platform.is_solaris? && platform.os_version == "11") || platform.is_aix?

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -31,7 +31,8 @@ component "libxml2" do |pkg, settings, platform|
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", settings[:cflags]
     if platform.is_cross_compiled?
-      pkg.environment "CC", "clang -target arm64-apple-macos11"
+      pkg.environment "CC", "clang -target arm64-apple-macos11" if platform.name =~ /osx-11/ 
+      pkg.environment "CC", "clang -target arm64-apple-macos12" if platform.name =~ /osx-12/ 
     end
   else
     if platform.is_el? && platform.name =~ /-5/

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -27,7 +27,10 @@ component "libxslt" do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/libxslt/disable-version-script.patch'
     pkg.apply_patch 'resources/patches/libxslt/Update-missing-script-to-return-0.patch'
   elsif platform.is_macos?
-    pkg.environment "CC", "clang -target arm64-apple-macos11" if platform.is_cross_compiled?
+    if platform.is_cross_compiled?
+      pkg.environment "CC", "clang -target arm64-apple-macos11" if platform.name =~ /osx-11/ 
+      pkg.environment "CC", "clang -target arm64-apple-macos12" if platform.name =~ /osx-12/ 
+    end
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", settings[:cflags]
   else

--- a/configs/components/ruby-2.5.9.rb
+++ b/configs/components/ruby-2.5.9.rb
@@ -109,6 +109,7 @@ component 'ruby-2.5.9' do |pkg, settings, platform|
     'el-7-ppc64le',
     'el-7-aarch64',
     'osx-11-arm64',
+    'osx-12-arm64',
     'redhatfips-7-x86_64',
     'sles-11-x86_64',
     'sles-11-i386',
@@ -194,8 +195,10 @@ component 'ruby-2.5.9' do |pkg, settings, platform|
   if platform.is_aix?
     rbconfig_changes["CC"] = "gcc"
   elsif platform.is_cross_compiled? || platform.is_solaris?
-    if platform.is_macos?
+    if platform.name =~ /osx-11/
       rbconfig_changes["CC"] = "clang -target arm64-apple-macos11"
+    elsif platform.name =~ /osx-12/
+      rbconfig_changes["CC"] = "clang -target arm64-apple-macos12"
     else
       rbconfig_changes["CC"] = "gcc"
       rbconfig_changes["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wno-maybe-uninitialized"

--- a/configs/components/ruby-2.7.6.rb
+++ b/configs/components/ruby-2.7.6.rb
@@ -113,6 +113,7 @@ component 'ruby-2.7.6' do |pkg, settings, platform|
     'el-7-ppc64le',
     'el-7-aarch64',
     'osx-11-arm64',
+    'osx-12-arm64',
     'redhatfips-7-x86_64',
     'sles-12-ppc64le',
     'solaris-11-sparc',
@@ -193,8 +194,10 @@ component 'ruby-2.7.6' do |pkg, settings, platform|
   if platform.is_aix?
     rbconfig_changes["CC"] = "gcc"
   elsif platform.is_cross_compiled? || platform.is_solaris?
-    if platform.is_macos?
+    if platform.name =~ /osx-11/
       rbconfig_changes["CC"] = "clang -target arm64-apple-macos11"
+    elsif platform.name =~ /osx-12/
+      rbconfig_changes["CC"] = "clang -target arm64-apple-macos12"
     else
       rbconfig_changes["CC"] = "gcc"
       rbconfig_changes["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wno-maybe-uninitialized"

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -23,7 +23,10 @@ component "yaml-cpp" do |pkg, settings, platform|
   elsif platform.is_macos?
     cmake_toolchain_file = ""
     cmake = "/usr/local/bin/cmake"
-    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
+    if platform.is_cross_compiled?
+      pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.name =~ /osx-11/
+      pkg.environment "CXX", "clang++ -target arm64-apple-macos12" if platform.name =~ /osx-12/
+    end
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
     mkdir = '/usr/bin/mkdir'

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -1,0 +1,29 @@
+platform 'osx-12-arm64' do |plat|
+    plat.servicetype 'launchd'
+    plat.servicedir '/Library/LaunchDaemons'
+    plat.codename 'monterey'
+
+    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+    plat.provision_with 'export HOMEBREW_VERBOSE=true'
+
+    plat.provision_with 'sudo dscl . -create /Users/test'
+    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+    plat.provision_with 'sudo dscl . -passwd /Users/test password'
+    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+    plat.provision_with 'mkdir -p /etc/homebrew'
+    plat.provision_with 'cd /etc/homebrew'
+    plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
+    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
+
+    packages = %w[cmake pkg-config yaml-cpp]
+
+    plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+
+    plat.vmpooler_template 'macos-12-x86_64'
+    plat.cross_compiled true
+    plat.output_dir File.join('apple', '12', 'PC1', 'arm64')
+  end


### PR DESCRIPTION
Adds support for building agent-runtime-main and agent-runtime-6.x
packages for macOS 12 Monterey ARM64 (m1) via cross-compilation on
an x86-64 host.

Built both runtimes successfully manually on vmpooler machines with `vanagon build`