### PR TITLE
(maint) Downgrade multipart-post for bolt, bolt-server

### DIFF
--- a/configs/components/rubygem-multipart-post.rb
+++ b/configs/components/rubygem-multipart-post.rb
@@ -1,6 +1,6 @@
 component 'rubygem-multipart-post' do |pkg, settings, platform|
-  pkg.version '2.2.0'
-  pkg.md5sum '487ba29eef18022a162d6dd098136cd1'
+  pkg.version '2.1.1'
+  pkg.md5sum '8383db0bd5bc3cbe9243f6e47222cf24'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This downgrades the `multipart-post` gem component for bolt and
bolt-server. Both projects pin the `faraday` gem component to the 0.x
series, which uses deprecated namespaces in newer versions of the
`multipart-post` gem, causing warnings to bubble up to the console when
running Bolt.

![image](https://user-images.githubusercontent.com/30373575/172484354-a899265f-93ae-43ef-808b-5e35b0e62508.png)