### PR TITLE
(BOLT-1587) Bump faraday for bolt, pe-bolt-server

### DIFF
--- a/configs/components/rubygem-faraday-em_http.rb
+++ b/configs/components/rubygem-faraday-em_http.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-em_http' do |pkg, settings, platform|
+  pkg.version '1.0.0'
+  pkg.md5sum '4b14f4a6132802f235f79e8ab987e3c2'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday-em_synchrony.rb
+++ b/configs/components/rubygem-faraday-em_synchrony.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-em_synchrony' do |pkg, settings, platform|
+  pkg.version '1.0.0'
+  pkg.md5sum '95c919f72c9c13de42cdd19c4caebcc5'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday-excon.rb
+++ b/configs/components/rubygem-faraday-excon.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-excon' do |pkg, settings, platform|
+  pkg.version '1.1.0'
+  pkg.md5sum '91d075ce12868a30a520af0588930927'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday-httpclient.rb
+++ b/configs/components/rubygem-faraday-httpclient.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-httpclient' do |pkg, settings, platform|
+  pkg.version '1.0.1'
+  pkg.md5sum '97c44d6016b1db347252b54a57f3e424'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday-multipart.rb
+++ b/configs/components/rubygem-faraday-multipart.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-multipart' do |pkg, settings, platform|
+  pkg.version '1.0.4'
+  pkg.md5sum '84b6d08b9165737064b3db89c71fb422'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday-net_http.rb
+++ b/configs/components/rubygem-faraday-net_http.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-net_http' do |pkg, settings, platform|
+  pkg.version '1.0.1'
+  pkg.md5sum '73db9270982cb4a0d5c0cc9de07d8a51'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday-net_http_persistent.rb
+++ b/configs/components/rubygem-faraday-net_http_persistent.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-net_http_persistent' do |pkg, settings, platform|
+  pkg.version '1.2.0'
+  pkg.md5sum 'e13bafd2297cbf703e0385e142c9ce62'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday-patron.rb
+++ b/configs/components/rubygem-faraday-patron.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-patron' do |pkg, settings, platform|
+  pkg.version '1.0.0'
+  pkg.md5sum '918c3b3a432993441e083c1f37715c8d'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday-rack.rb
+++ b/configs/components/rubygem-faraday-rack.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-rack' do |pkg, settings, platform|
+  pkg.version '1.0.0'
+  pkg.md5sum 'e1f15e1a8e72e3d38c7973550e11925e'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday-retry.rb
+++ b/configs/components/rubygem-faraday-retry.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-retry' do |pkg, settings, platform|
+  pkg.version '1.0.3'
+  pkg.md5sum '77177d55f1b8df8a3dcb06aab3e03389'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday.rb
+++ b/configs/components/rubygem-faraday.rb
@@ -1,6 +1,6 @@
 component 'rubygem-faraday' do |pkg, settings, platform|
-  pkg.version '0.17.4'
-  pkg.md5sum '4dc35e83a4667e91e9e612fdfd13fe6d'
+  pkg.version '1.10.0'
+  pkg.md5sum '3a6d2c5453421b00cfc39d717823e616'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-faraday_middleware.rb
+++ b/configs/components/rubygem-faraday_middleware.rb
@@ -1,6 +1,6 @@
 component 'rubygem-faraday_middleware' do |pkg, settings, platform|
-  pkg.version '0.14.0'
-  pkg.md5sum '70d2826ffc3f0280e336c97e79ad8e54'
+  pkg.version '1.2.0'
+  pkg.md5sum 'e4e21d7a623046f9c23657c74d5cf7de'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-multipart-post.rb
+++ b/configs/components/rubygem-multipart-post.rb
@@ -1,6 +1,6 @@
 component 'rubygem-multipart-post' do |pkg, settings, platform|
-  pkg.version '2.1.1'
-  pkg.md5sum '8383db0bd5bc3cbe9243f6e47222cf24'
+  pkg.version '2.2.3'
+  pkg.md5sum 'ebcd6ee70446d58c85ceb926f664a883'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-orchestrator_client.rb
+++ b/configs/components/rubygem-orchestrator_client.rb
@@ -1,6 +1,6 @@
 component 'rubygem-orchestrator_client' do |pkg, settings, platform|
-  pkg.version '0.5.4'
-  pkg.md5sum 'f686c10f9dfd17b0296669fc5cbb91bd'
+  pkg.version '0.6.1'
+  pkg.md5sum 'a556e34451e9985a518230d6d79e90a3'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet_forge.rb
+++ b/configs/components/rubygem-puppet_forge.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet_forge' do |pkg, settings, platform|
-  pkg.version '2.3.4'
-  pkg.md5sum '28a74b4f97fbd3ce8ee184ad81317beb'
+  pkg.version '3.2.0'
+  pkg.md5sum '501d5f9f742007504d0d60ce6cf0c27f'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-ruby2_keywords.rb
+++ b/configs/components/rubygem-ruby2_keywords.rb
@@ -1,0 +1,6 @@
+component 'rubygem-ruby2_keywords' do |pkg, settings, platform|
+  pkg.version '0.0.5'
+  pkg.md5sum '89bc1e9231e63a0f93599772ae871e03'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -89,10 +89,25 @@ proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
 proj.component 'rubygem-semantic_puppet'
 
-# hiera-eyaml and it's dependencies
+# hiera-eyaml and its dependencies
 proj.component('rubygem-highline')
 proj.component('rubygem-optimist')
 proj.component('rubygem-hiera-eyaml')
+
+# faraday and its dependencies
+proj.component('rubygem-faraday')
+proj.component('rubygem-faraday-em_http')
+proj.component('rubygem-faraday-em_synchrony')
+proj.component('rubygem-faraday-excon')
+proj.component('rubygem-faraday-httpclient')
+proj.component('rubygem-faraday-multipart')
+proj.component('rubygem-faraday-net_http')
+proj.component('rubygem-faraday-net_http_persistent')
+proj.component('rubygem-faraday-patron')
+proj.component('rubygem-faraday-rack')
+proj.component('rubygem-faraday-retry')
+proj.component('rubygem-faraday_middleware')
+proj.component('rubygem-ruby2_keywords')
 
 # Core dependencies
 proj.component('rubygem-addressable')
@@ -112,8 +127,6 @@ proj.component('rubygem-cri')
 proj.component('rubygem-ed25519')
 proj.component('rubygem-erubi')
 proj.component('rubygem-facter')
-proj.component('rubygem-faraday')
-proj.component('rubygem-faraday_middleware')
 proj.component('rubygem-ffi')
 proj.component('rubygem-gssapi')
 proj.component('rubygem-gyoku')

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -136,10 +136,25 @@ project 'bolt-runtime' do |proj|
   # R10k dependencies
   proj.component 'rubygem-gettext-setup'
 
-  # hiera-eyaml and it's dependencies
+  # hiera-eyaml and its dependencies
   proj.component 'rubygem-highline'
   proj.component 'rubygem-optimist'
   proj.component 'rubygem-hiera-eyaml'
+
+  # faraday and its dependencies
+  proj.component 'rubygem-faraday'
+  proj.component 'rubygem-faraday-em_http'
+  proj.component 'rubygem-faraday-em_synchrony'
+  proj.component 'rubygem-faraday-excon'
+  proj.component 'rubygem-faraday-httpclient'
+  proj.component 'rubygem-faraday-multipart'
+  proj.component 'rubygem-faraday-net_http'
+  proj.component 'rubygem-faraday-net_http_persistent'
+  proj.component 'rubygem-faraday-patron'
+  proj.component 'rubygem-faraday-rack'
+  proj.component 'rubygem-faraday-retry'
+  proj.component 'rubygem-faraday_middleware'
+  proj.component 'rubygem-ruby2_keywords'
 
   # Core dependencies
   proj.component 'rubygem-addressable'
@@ -157,8 +172,6 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-cri'
   proj.component 'rubygem-erubi'
   proj.component 'rubygem-facter'
-  proj.component 'rubygem-faraday'
-  proj.component 'rubygem-faraday_middleware'
   proj.component 'rubygem-ffi'
   proj.component 'rubygem-gssapi'
   proj.component 'rubygem-gyoku'


### PR DESCRIPTION
This bumps faraday for the bolt and pe-bolt-server projects to the 1.x
series. It also adds several dependencies for the 1.x series as gem
components in both projects.

---

Successfully built runtimes & packages for bolt, pe-bolt-server-main, and pe-bolt-server-2019.8.x, and also successfully ran acceptance tests for both pe-bolt-server packages. 👍 