### PR TITLE
(PA-4496) Updates puppet-ca-bundle to 1.0.11

### DIFF
--- a/configs/components/puppet-ca-bundle.json
+++ b/configs/components/puppet-ca-bundle.json
@@ -1,4 +1,4 @@
 {
   "url": "https://github.com/puppetlabs/puppet-ca-bundle.git",
-  "ref": "refs/tags/1.0.10"
+  "ref": "refs/tags/1.0.11"
 }


### PR DESCRIPTION
puppet-ca-bundle 1.0.11 contains updated root certificate authority
certificates, as well as a new certificate bundle and keystore.