### PR TITLE
(PA-4440) puppet-ca-bundle now always installs a keystore as part of the install target

### DIFF
--- a/configs/components/puppet-ca-bundle.rb
+++ b/configs/components/puppet-ca-bundle.rb
@@ -16,13 +16,6 @@ component "puppet-ca-bundle" do |pkg, settings, platform|
     "#{platform[:make]} install OPENSSL=#{openssl_cmd} USER=0 GROUP=0 DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
   ]
 
-  # Include the keystore for the agent if the agent has a java
-  if settings[:runtime_project] == 'agent'
-    if platform.name =~ /el-(6|7|8)|sles-(11|12)|debian-(9|10)|ubuntu-(14|15|16|18)/
-      install_commands << "#{platform[:make]} keystore OPENSSL=#{openssl_cmd} DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
-    end
-  end
-
   pkg.install do
     install_commands
   end


### PR DESCRIPTION
It's no longer necessary to call `make keystore` since the `puppet-cacerts` java keystore is already pregenerated and copied during the previous `make install` step.