### PR TITLE
(maint) Add webrick to bolt, pe-bolt-server

### DIFF
--- a/configs/components/rubygem-webrick.rb
+++ b/configs/components/rubygem-webrick.rb
@@ -1,0 +1,6 @@
+component 'rubygem-webrick' do |pkg, settings, platform|
+  pkg.version '1.7.0'
+  pkg.md5sum '00739c2de1b9986f8db84355ac0da787'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -164,6 +164,7 @@ proj.component('rubygem-scanf')
 proj.component('rubygem-terminal-table')
 proj.component('rubygem-thor')
 proj.component('rubygem-unicode-display_width')
+proj.component('rubygem-webrick')
 proj.component('rubygem-yard')
 
 # Core Windows dependencies

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -208,6 +208,7 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-terminal-table'
   proj.component 'rubygem-thor'
   proj.component 'rubygem-unicode-display_width'
+  proj.component 'rubygem-webrick'
   proj.component 'rubygem-yard'
 
   # Core Windows dependencies


### PR DESCRIPTION
This adds webrick 1.7.0 to bolt and pe-bolt-server, which is required by
puppet-strings >= 2.9.0