### PR TITLE
(maint) Add rexml to pe-bolt-server-runtime-2019.8.x

### DIFF
--- a/configs/components/rubygem-rexml.rb
+++ b/configs/components/rubygem-rexml.rb
@@ -1,0 +1,6 @@
+component 'rubygem-rexml' do |pkg, settings, platform|
+  pkg.version '3.2.3'
+  pkg.md5sum '6d3c7e28ac9a422c3e325b0d5baa6487'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/pe-bolt-server-runtime-2019.8.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2019.8.x.rb
@@ -6,4 +6,7 @@ project 'pe-bolt-server-runtime-2019.8.x' do |proj|
   # Once we are no longer using ruby 2.5 we can update.
   proj.setting(:no_doc, false)
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server.rb'))
+
+  # Ruby 2.5 does not include rexml as a vendored gem, so include it in 2019.8.x only.
+  proj.component('rubygem-rexml')
 end


### PR DESCRIPTION
This adds rexml as a component for pe-bolt-server-runtime-2019.8.x,
which is a dependency for gyoku. Since Ruby 2.5 does not ship with rexml
as a vendored gem, it is included here.