### PR TITLE
(PA-4551) Add a patch for openssl-1.1.1q for macos

### DIFF
--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -116,6 +116,13 @@ component 'openssl' do |pkg, settings, platform|
     end
   end
 
+  # OpenSSL 1.1.1q has a bug with a test not including a required library that caueses
+  # packing failures on macos. Probably safe to look at the 1.1.1r release to see if
+  # this can be removed.
+  if platform.is_macos?
+    pkg.apply_patch 'resources/patches/openssl/openssl_1.1.1q_fix_c_include.patch'
+  end
+
   # OpenSSL Configure doesn't honor CFLAGS or LDFLAGS as environment variables.
   # Instead, those should be passed to Configure at the end of its options, as
   # any unrecognized options are passed straight through to ${CC}. Defining

--- a/resources/patches/openssl/openssl_1.1.1q_fix_c_include.patch
+++ b/resources/patches/openssl/openssl_1.1.1q_fix_c_include.patch
@@ -1,0 +1,12 @@
+diff --git a/test/v3ext.c b/test/v3ext.c
+index 7a240cd706..6cec6f1a9b 100644
+--- a/test/v3ext.c
++++ b/test/v3ext.c
+@@ -15,6 +15,7 @@
+ #include <openssl/err.h>
+ #include "internal/nelem.h"
+ 
++#include <string.h>
+ #include "testutil.h"
+ 
+ static const char *infile;


### PR DESCRIPTION
https://github.com/openssl/openssl/issues/18720
^^ Above issue causes failures on macos, this PR patches a fix for that.
Future openssl should fix this and we can remove the patch.