### PR TITLE
(PUP-11592) Use arm64 coroutines when cross compiling for M1

### DIFF
--- a/configs/components/ruby-2.7.6.rb
+++ b/configs/components/ruby-2.7.6.rb
@@ -98,8 +98,13 @@ component 'ruby-2.7.6' do |pkg, settings, platform|
     # This normalizes the build string to something like AIX 7.1.0.0 rather
     # than AIX 7.1.0.2 or something
     special_flags += " --build=#{settings[:platform_triple]} "
-  elsif platform.is_cross_compiled? && (platform.is_linux? || platform.is_macos?)
+  elsif platform.is_cross_compiled? && platform.is_linux?
     special_flags += " --with-baseruby=#{host_ruby} "
+  elsif platform.is_cross_compiled? && platform.is_macos?
+    # When the target arch is aarch64, ruby incorrectly selects the 'ucontext' coroutine
+    # implementation instead of 'arm64', so specify 'amd64' explicitly
+    # https://github.com/ruby/ruby/blob/c9c2245c0a25176072e02db9254f0e0c84c805cd/configure.ac#L2329-L2330
+    special_flags += " --with-baseruby=#{host_ruby} --with-coroutine=arm64 "
   elsif platform.is_solaris? && platform.architecture == "sparc"
     special_flags += " --with-baseruby=#{host_ruby} --enable-close-fds-by-recvmsg-with-peek "
   elsif platform.name =~ /el-6/


### PR DESCRIPTION
Ruby's configure script incorrectly selects the 'ucontext' coroutine
implementation instead of 'amd64' when the target architecture is 'aarch64'.
This resulted in a crash when using coroutines (or fibers). The crash could be
triggered using:

    # lldb -- /opt/puppetlabs/puppet/bin/ruby -e 'Fiber.new {}.resume'
    (lldb) target create "/opt/puppetlabs/puppet/bin/ruby"
    Current executable set to '/opt/puppetlabs/puppet/bin/ruby' (arm64).
    (lldb) settings set -- target.run-args  "-e" "Fiber.new {}.resume"
    (lldb) run
    Process 698 launched: '/opt/puppetlabs/puppet/bin/ruby' (arm64)
    Process 698 stopped
    * thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x101b620)
        frame #0: 0x00000001007753f4 libruby.2.7.dylib`coroutine_trampoline + 12
    libruby.2.7.dylib`coroutine_trampoline:
    ->  0x1007753f4 <+12>: ldr    x0, [x1, #0x370]
        0x1007753f8 <+16>: blr    x8
    0x1007753fc <+0>:  ldrsb  w8, [x0]
    0x100775400 <+4>:  asr    w8, w8, #31

Now we specify the coroutine implementation when cross compiling macos. Linux
cross compiles are unchanged.