### PR TITLE
(maint) Revert concurrent-ruby bump

### DIFF
--- a/configs/components/rubygem-concurrent-ruby.rb
+++ b/configs/components/rubygem-concurrent-ruby.rb
@@ -1,6 +1,6 @@
 component 'rubygem-concurrent-ruby' do |pkg, settings, platform|
-  pkg.version '1.1.10'
-  pkg.md5sum '4588a61d5af26e9ee12e9b8babc1b755'
+  pkg.version '1.1.9'
+  pkg.md5sum '417a23cac840f6ea8bdd0841429c3c19'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Partially reverts 107e5fe057673c39d9eefcfcf673307fbf0335c3 as we 1.1.10
requires ruby >= 2.2 and we still rely on ruby 2.1.9 in pl-build-tools.
Will need to revisit next week.