### PR TITLE
(PA-4620) Install ruby@2.5 from our homebrew-puppet tap

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -48,7 +48,12 @@ elsif platform.is_windows?
 elsif platform.is_macos?
   pkg.environment 'optflags', settings[:cflags]
   if platform.is_cross_compiled?
-    pkg.build_requires "ruby@#{ruby_version_y}"
+    # Pin to an older version of ruby@2.5. This can be removed once we're no longer cross-compiling
+    if ruby_version_y == "2.5"
+      pkg.build_requires "puppetlabs/puppet/ruby@2.5"
+    else
+      pkg.build_requires "ruby@#{ruby_version_y}"
+    end
     pkg.environment 'CC', 'clang -target arm64-apple-macos11' if platform.name =~ /osx-11/
     pkg.environment 'CC', 'clang -target arm64-apple-macos12' if platform.name =~ /osx-12/
   end


### PR DESCRIPTION
When building `agent-runtime-6.x` on macOS 11 & 12 M1, we now install ruby@2.5 from our `homebrew-puppet` tap.

Note these changes would affect pdk-runtime too, but we don't currently support pdk on M1 (as it still relies on ruby@2.4 which was disabled a long time ago).

~~Blocked on https://github.com/puppetlabs/homebrew-puppet/pull/357~~