### PR TITLE
(PA-4494) Bump Augeas to 1.1.13

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -4,6 +4,10 @@ component 'augeas' do |pkg, settings, platform|
   pkg.version version
 
   case version
+  when '1.13.0'
+    pkg.md5sum '909b9934190f32ffcbc2c5a92efaf9d2'
+    pkg.url "https://github.com/hercules-team/augeas/releases/download/release-1.13.0/augeas-1.13.0.tar.gz"
+    pkg.apply_patch 'resources/patches/augeas/augeas-1.13.0-patch_security_context-t_out.patch'
   when '1.8.1'
     pkg.md5sum '623ff89d71a42fab9263365145efdbfa'
   when '1.11.0'
@@ -17,7 +21,7 @@ component 'augeas' do |pkg, settings, platform|
     raise "augeas version #{version} has not been configured; Cannot continue."
   end
 
-  if ['1.11.0', '1.12.0'].include?(version)
+  if ['1.11.0', '1.12.0', '1.13.0'].include?(version)
     if platform.is_el? || platform.is_fedora?
       # Augeas 1.11.0 needs a libselinux pkgconfig file on these platforms:
       pkg.build_requires 'ruby-selinux'

--- a/configs/platforms/osx-10.15-x86_64.rb
+++ b/configs/platforms/osx-10.15-x86_64.rb
@@ -1,9 +1,10 @@
 platform 'osx-10.15-x86_64' do |plat|
   plat.inherit_from_default
   packages = %w(
-    cmake 
-    pkg-config 
+    cmake
+    pkg-config
     yaml-cpp
+    readline
   )
   plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 end

--- a/configs/platforms/osx-11-arm64.rb
+++ b/configs/platforms/osx-11-arm64.rb
@@ -22,6 +22,9 @@ platform 'osx-11-arm64' do |plat|
   packages = %w[cmake pkg-config yaml-cpp]
 
   plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+  plat.provision_with "chmod 777 /etc/homebrew"
+  plat.provision_with "su test -c 'HOMEBREW_CACHE=/etc/homebrew /usr/local/bin/brew fetch --force --bottle-tag=arm64_monterey readline'"
+  plat.provision_with "su test -c '/usr/local/bin/brew install /etc/homebrew/downloads/*'"
 
   plat.vmpooler_template 'macos-112-x86_64'
   plat.cross_compiled true

--- a/configs/platforms/osx-11-x86_64.rb
+++ b/configs/platforms/osx-11-x86_64.rb
@@ -19,7 +19,7 @@ platform 'osx-11-x86_64' do |plat|
     plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
     plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
 
-    packages = %w[cmake pkg-config yaml-cpp]
+    packages = %w[cmake pkg-config yaml-cpp readline]
 
     plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -22,6 +22,9 @@ platform 'osx-12-arm64' do |plat|
     packages = %w[cmake pkg-config yaml-cpp]
 
     plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+    plat.provision_with 'chmod 777 /etc/homebrew'
+    plat.provision_with "su test -c 'HOMEBREW_CACHE=/etc/homebrew /usr/local/bin/brew fetch --force --bottle-tag=arm64_monterey readline'"
+    plat.provision_with "su test -c '/usr/local/bin/brew install /etc/homebrew/downloads/*'"
 
     plat.vmpooler_template 'macos-12-x86_64'
     plat.cross_compiled true

--- a/configs/platforms/osx-12-x86_64.rb
+++ b/configs/platforms/osx-12-x86_64.rb
@@ -19,7 +19,7 @@ platform 'osx-12-x86_64' do |plat|
     plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
     plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
 
-    packages = %w[cmake pkg-config yaml-cpp]
+    packages = %w[cmake pkg-config yaml-cpp readline]
 
     plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -212,11 +212,11 @@ if platform.is_macos?
   # define it or try to force it in the linker, because this might
   # break gcc or clang if they try to use the RPATH values we forced.
   proj.setting(:cppflags, "-I#{proj.includedir}")
-  proj.setting(:ldflags, "-L#{proj.libdir} ")
+  proj.setting(:ldflags, "-L#{proj.libdir} -L/usr/local/opt/readline/lib ")
   if platform.is_cross_compiled?
-    proj.setting(:cflags, "#{proj.cppflags}")
+    proj.setting(:cflags, "#{proj.cppflags} -I/usr/local/opt/readline/include -DHAVE_RL_CRLF -DHAVE_RL_REPLACE_LINE")
   else
-    proj.setting(:cflags, "-march=core2 -msse4 #{proj.cppflags}")
+    proj.setting(:cflags, "-march=core2 -msse4 #{proj.cppflags} -I/usr/local/opt/readline/include -DHAVE_RL_CRLF -DHAVE_RL_REPLACE_LINE -DHAVE_SELINUX_LABEL_H")
   end
 end
 

--- a/configs/projects/agent-runtime-6.x.rb
+++ b/configs/projects/agent-runtime-6.x.rb
@@ -1,7 +1,13 @@
 project 'agent-runtime-6.x' do |proj|
   # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.5.9'
-  proj.setting :augeas_version, '1.12.0'
+
+  # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0
+  if platform.is_solaris? || platform.is_aix?
+    proj.setting :augeas_version, '1.12.0'
+  else
+    proj.setting :augeas_version, '1.13.0'
+  end
 
   ########
   # Load shared agent settings

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -1,8 +1,14 @@
 project 'agent-runtime-main' do |proj|
+
   # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.7.6'
-  proj.setting :augeas_version, '1.12.0'
   proj.setting :rubygem_deep_merge_version, '1.2.2'
+  # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0
+  if platform.is_solaris? || platform.is_aix?
+    proj.setting :augeas_version, '1.12.0'
+  else
+    proj.setting :augeas_version, '1.13.0'
+  end
 
   ########
   # Load shared agent settings

--- a/resources/patches/augeas/augeas-1.13.0-patch_security_context-t_out.patch
+++ b/resources/patches/augeas/augeas-1.13.0-patch_security_context-t_out.patch
@@ -1,0 +1,13 @@
+diff --git a/src/transform.c b/src/transform.c
+index 176482b9..d46f2c49 100644
+--- a/src/transform.c
++++ b/src/transform.c
+@@ -918,7 +918,7 @@ static int transfer_file_attrs(FILE *from, FILE *to,
+     struct stat st;
+     int ret = 0;
+     int selinux_enabled = (is_selinux_enabled() > 0);
+-    security_context_t con = NULL;
++    char *con = NULL;
+ 
+     int from_fd;
+     int to_fd = fileno(to);


### PR DESCRIPTION
This PR bumps Augeas for all platforms except for Solaris. The readline that is bundled
with Solaris is pretty old and Augeas has a function call that is not defined by readline on
Solaris.
So we are choosing not to bump Augeas for Solaris but for every other platform we can bump it.
On OSX we also need to install readline. 