### PR TITLE
(maint) Update to latest Augeas for pdk-runtime

### DIFF
--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -2,6 +2,7 @@ project 'pdk-runtime' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, "pdk")
   proj.setting(:openssl_version, '1.1.1')
+  proj.setting(:augeas_version, '1.13.0')
   platform = proj.get_platform
 
   proj.version_from_git


### PR DESCRIPTION
We recently made changes to the Augeas component and this looks to have broken pdk-runtime for MacOS platforms. If we bump the version of Augeas from 1.8.1 to the latest of 1.13.0 then pdk-runtime will build on MacOS.