### PR TITLE
Update virt-what

### DIFF
--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -1,6 +1,6 @@
 component "virt-what" do |pkg, settings, platform|
-  pkg.version "1.22"
-  pkg.md5sum "0e9923de6a6c6f07bc0ddc3ec8fc1018"
+  pkg.version "1.25"
+  pkg.md5sum "2345f1ec5fa0836bff4071659730ac8f"
 
   pkg.url "https://people.redhat.com/~rjones/virt-what/files/virt-what-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/virt-what-#{pkg.get_version}.tar.gz"


### PR DESCRIPTION
Puppet currently bundles `virt-what` 1.22, which incorrectly reports Illumos/SmartOS/OmniOS LX virtualization.  This PR updates to the latest version (which fixes that issue).

- [x] [agent-runtime-main (only linux)](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2795/)
- [x] [agent-runtime-7.x (only linux)](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2796/)