### PR TITLE
(PA-4715) Add Ruby 3.2 to puppet-runtime, validated with EL-7 & EL-8

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -6,6 +6,8 @@
 ruby_version_condensed = pkg.get_version.tr('.', '')
 # Y version, e.g. '2.4.3' -> '2.4'
 ruby_version_y = pkg.get_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+# Strip the -preview from 3.2-preview, can be removed once ruby 3.2 is released
+ruby_version_y = ruby_version_y.gsub(/(\d+)\.(\d+)-preview(\d+)/, '\1.\2') if ruby_version_y =~ /-preview/
 
 pkg.mirror "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
 pkg.url "https://cache.ruby-lang.org/pub/ruby/#{ruby_version_y}/ruby-#{pkg.get_version}.tar.gz"

--- a/configs/components/libffi.rb
+++ b/configs/components/libffi.rb
@@ -1,0 +1,45 @@
+component 'libffi' do |pkg, settings, platform|
+  pkg.version '3.4.3'
+  pkg.md5sum 'b57b0ac1d1072681cee9148a417bd2ec'
+  pkg.url "https://github.com/libffi/libffi/releases/download/#{pkg.get_name}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+
+  if platform.is_aix?
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
+  elsif platform.is_cross_compiled_linux?
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
+    pkg.environment "CFLAGS", settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
+  elsif platform.is_solaris?
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
+    pkg.environment "CFLAGS", "#{settings[:cflags]} -std=c99"
+    pkg.environment "LDFLAGS", settings[:ldflags]
+  elsif platform.is_macos?
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
+    if platform.is_cross_compiled?
+      pkg.environment 'CC', 'clang -target arm64-apple-macos11' if platform.name =~ /osx-11/
+      pkg.environment 'CC', 'clang -target arm64-apple-macos12' if platform.name =~ /osx-12/
+    end
+  else
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
+  end
+
+  pkg.build_requires "runtime-#{settings[:runtime_project]}"
+
+  pkg.configure do
+    ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/libffi --disable-multi-os-directory #{settings[:host]}"]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    [
+      "#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
+      "rm -rf #{settings[:datadir]}/doc/#{pkg.get_name}*"
+    ]
+  end
+end

--- a/configs/components/libyaml.rb
+++ b/configs/components/libyaml.rb
@@ -1,0 +1,45 @@
+component 'libyaml' do |pkg, settings, platform|
+  pkg.version '0.2.5'
+  pkg.md5sum 'bb15429d8fb787e7d3f1c83ae129a999'
+  pkg.url "https://github.com/yaml/libyaml/releases/download/#{pkg.get_name}/yaml-#{pkg.get_version}-0.2.5.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/yaml-#{pkg.get_version}.tar.gz"
+
+  if platform.is_aix?
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
+  elsif platform.is_cross_compiled_linux?
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
+    pkg.environment "CFLAGS", settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
+  elsif platform.is_solaris?
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
+    pkg.environment "CFLAGS", "#{settings[:cflags]} -std=c99"
+    pkg.environment "LDFLAGS", settings[:ldflags]
+  elsif platform.is_macos?
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
+    if platform.is_cross_compiled?
+      pkg.environment 'CC', 'clang -target arm64-apple-macos11' if platform.name =~ /osx-11/
+      pkg.environment 'CC', 'clang -target arm64-apple-macos12' if platform.name =~ /osx-12/
+    end
+  else
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
+  end
+
+  pkg.build_requires "runtime-#{settings[:runtime_project]}"
+
+  pkg.configure do
+    ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/libyaml #{settings[:host]}"]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    [
+      "#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
+      "rm -rf #{settings[:datadir]}/doc/#{pkg.get_name}*"
+    ]
+  end
+end

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -1,0 +1,240 @@
+component 'ruby-3.2.0' do |pkg, settings, platform|
+  pkg.version '3.2.0-preview2'
+  pkg.sha256sum '8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891'
+
+  # rbconfig-update is used to munge rbconfigs after the fact.
+  pkg.add_source("file://resources/files/ruby/rbconfig-update.rb")
+
+  # PDK packages multiple rubies and we need to tweak some settings
+  # if this is not the *primary* ruby.
+  if pkg.get_version !~ /preview/ && pkg.get_version != settings[:ruby_version]
+    # not primary ruby
+
+    # ensure we have config for this ruby
+    unless settings.key?(:additional_rubies) && settings[:additional_rubies].key?(pkg.get_version)
+      raise "missing config for additional ruby #{pkg.get_version}"
+    end
+
+    ruby_settings = settings[:additional_rubies][pkg.get_version]
+
+    ruby_dir = ruby_settings[:ruby_dir]
+    ruby_bindir = ruby_settings[:ruby_bindir]
+    host_ruby = ruby_settings[:host_ruby]
+  else
+    # primary ruby
+    ruby_dir = settings[:ruby_dir]
+    ruby_bindir = settings[:ruby_bindir]
+    host_ruby = settings[:host_ruby]
+  end
+
+  # Most ruby configuration happens in the base ruby config:
+  instance_eval File.read('configs/components/_base-ruby.rb')
+  # Configuration below should only be applicable to ruby 2.5
+
+  #########
+  # PATCHES
+  #########
+
+  base = 'resources/patches/ruby_32'
+
+  if platform.is_cross_compiled?
+    unless platform.is_macos?
+#      pkg.apply_patch "#{base}/uri_generic_remove_safe_nav_operator_r2.5.patch"
+#      pkg.apply_patch "#{base}/lib_optparse_remove_safe_nav_operator.patch"
+#      pkg.apply_patch "#{base}/revert_delete_prefix.patch"
+#      pkg.apply_patch "#{base}/remove_squiggly_heredocs.patch"
+#      pkg.apply_patch "#{base}/remove_deprecate_constant_statements.patch"
+#      pkg.apply_patch "#{base}/ruby2_keywords_guard.patch"
+#      pkg.apply_patch "#{base}/ruby_version_extra_guards.patch"
+#      pkg.apply_patch "#{base}/ruby_20_guards.patch"
+#      pkg.apply_patch "#{base}/Replace-reference-to-RUBY-var-with-opt-pl-build-tool.patch"
+    end
+
+ #   pkg.apply_patch "#{base}/rbinstall_gem_path.patch"
+ #   pkg.apply_patch "#{base}/revert_host_value_changes.patch"
+  end
+
+  if platform.is_aix?
+    # TODO: Remove this patch once PA-1607 is resolved.
+ #   pkg.apply_patch "#{base}/aix_configure.patch"
+ #   pkg.apply_patch "#{base}/aix-fix-libpath-in-configure.patch"
+ #   pkg.apply_patch "#{base}/aix-do-not-use-realpath.patch"
+ #   pkg.apply_patch "#{base}/aix_ruby_2.1_fix_make_test_failure_r2.5.patch"
+ #   pkg.apply_patch "#{base}/Remove-O_CLOEXEC-check-for-AIX-builds_r2.5.patch"
+  end
+
+  if platform.is_windows?
+ #   pkg.apply_patch "#{base}/windows_ruby_2.5_fixup_generated_batch_files.patch"
+ #   pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
+ #   pkg.apply_patch "#{base}/win32_long_paths_support.patch"
+ #   pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
+ #   pkg.apply_patch "#{base}/windows_configure.patch"
+  end
+
+  ####################
+  # ENVIRONMENT, FLAGS
+  ####################
+
+  if platform.is_macos?
+    pkg.environment 'optflags', settings[:cflags]
+  elsif platform.is_windows?
+    pkg.environment 'optflags', settings[:cflags] + ' -O3'
+    pkg.environment 'MAKE', 'make'
+  elsif platform.is_cross_compiled?
+    pkg.environment 'CROSS_COMPILING', 'true'
+  else
+    pkg.environment 'optflags', '-O2'
+  end
+
+  special_flags = " --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
+
+  if platform.name =~ /sles-15|el-8|debian-10/
+    special_flags += " CFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}' CPPFLAGS='#{settings[:cppflags]}' "
+  end
+
+  if platform.is_aix?
+    # This normalizes the build string to something like AIX 7.1.0.0 rather
+    # than AIX 7.1.0.2 or something
+    special_flags += " --build=#{settings[:platform_triple]} "
+  elsif platform.is_cross_compiled? && platform.is_linux?
+    special_flags += " --with-baseruby=#{host_ruby} "
+  elsif platform.is_cross_compiled? && platform.is_macos?
+    # When the target arch is aarch64, ruby incorrectly selects the 'ucontext' coroutine
+    # implementation instead of 'arm64', so specify 'amd64' explicitly
+    # https://github.com/ruby/ruby/blob/c9c2245c0a25176072e02db9254f0e0c84c805cd/configure.ac#L2329-L2330
+    special_flags += " --with-baseruby=#{host_ruby} --with-coroutine=arm64 "
+  elsif platform.is_solaris? && platform.architecture == "sparc"
+    special_flags += " --with-baseruby=#{host_ruby} --enable-close-fds-by-recvmsg-with-peek "
+  elsif platform.name =~ /el-6/
+    special_flags += " --with-baseruby=no "
+  elsif platform.is_windows?
+    special_flags = " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
+  end
+
+  without_dtrace = [
+    'aix-7.1-ppc',
+    'el-7-ppc64le',
+    'el-7-aarch64',
+    'osx-11-arm64',
+    'osx-12-arm64',
+    'redhatfips-7-x86_64',
+    'sles-12-ppc64le',
+    'solaris-11-sparc',
+    'windows-2012r2-x64',
+    'windows-2012r2-x86',
+    'windows-2019-x64',
+    'windowsfips-2012r2-x64'
+  ]
+
+  unless without_dtrace.include? platform.name
+    special_flags += ' --enable-dtrace '
+  end
+
+  ###########
+  # CONFIGURE
+  ###########
+
+  # TODO: Remove this once PA-1607 is resolved.
+  # TODO: Can we use native autoconf? The dependencies seemed a little too extensive
+  pkg.configure { ["/opt/pl-build-tools/bin/autoconf"] } if platform.is_aix?
+
+  pkg.configure do
+    [
+      "bash configure \
+        --enable-shared \
+        --disable-install-doc \
+        --disable-install-rdoc \
+        #{settings[:host]} \
+        #{special_flags}"
+    ]
+  end
+
+  #########
+  # INSTALL
+  #########
+
+  if platform.is_windows?
+    # With ruby 2.5, ruby will generate cmd files instead of bat files; These
+    # cmd wrappers work fine in our environment if they're just renamed as batch
+    # files. Rake is omitted here on purpose - it retains the old batch wrapper.
+    #
+    # Note that this step must happen after the install step above.
+    pkg.install do
+      %w{erb gem irb rdoc ri}.map do |name|
+        "mv #{ruby_bindir}/#{name}.cmd #{ruby_bindir}/#{name}.bat"
+      end
+    end
+  end
+
+  target_doubles = {
+    'powerpc-ibm-aix7.1.0.0' => 'powerpc-aix7.1.0.0',
+    'aarch64-apple-darwin' => 'aarch64-darwin',
+    'aarch64-redhat-linux' => 'aarch64-linux',
+    'ppc64-redhat-linux' => 'powerpc64-linux',
+    'ppc64le-redhat-linux' => 'powerpc64le-linux',
+    'powerpc64le-suse-linux' => 'powerpc64le-linux',
+    'powerpc64le-linux-gnu' => 'powerpc64le-linux',
+    'i386-pc-solaris2.10' => 'i386-solaris2.10',
+    'sparc-sun-solaris2.10' => 'sparc-solaris2.10',
+    'i386-pc-solaris2.11' => 'i386-solaris2.11',
+    'sparc-sun-solaris2.11' => 'sparc-solaris2.11',
+    'arm-linux-gnueabihf' => 'arm-linux-eabihf',
+    'arm-linux-gnueabi' => 'arm-linux-eabi',
+    'x86_64-w64-mingw32' => 'x64-mingw32',
+    'i686-w64-mingw32' => 'i386-mingw32'
+  }
+  if target_doubles.key?(settings[:platform_triple])
+    rbconfig_topdir = File.join(ruby_dir, 'lib', 'ruby', '3.2.0', target_doubles[settings[:platform_triple]])
+  else
+    rbconfig_topdir = "$$(#{ruby_bindir}/ruby -e \"puts RbConfig::CONFIG[\\\"topdir\\\"]\")"
+  end
+
+  rbconfig_changes = {}
+  if platform.is_aix?
+    rbconfig_changes["CC"] = "gcc"
+  elsif platform.is_cross_compiled? || platform.is_solaris?
+    if platform.name =~ /osx-11/
+      rbconfig_changes["CC"] = 'clang -target arm64-apple-macos11'
+    elsif platform.name =~ /osx-12/
+      rbconfig_changes["CC"] = 'clang -target arm64-apple-macos12'
+    else
+      rbconfig_changes["CC"] = "gcc"
+      rbconfig_changes["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wno-maybe-uninitialized"
+    end
+    if platform.name =~ /el-7-ppc64/
+      # EL 7 on POWER will fail with -Wl,--compress-debug-sections=zlib so this
+      # will remove that entry
+      # Matches both endians
+      rbconfig_changes["DLDFLAGS"] = "-Wl,-rpath=/opt/puppetlabs/puppet/lib -L/opt/puppetlabs/puppet/lib  -Wl,-rpath,/opt/puppetlabs/puppet/lib"
+    elsif platform.name =~ /sles-12-ppc64le/
+      # the ancient gcc version on sles-12-ppc64le does not understand -fstack-protector-strong, so remove the `strong` part
+      rbconfig_changes["LDFLAGS"] = "-L. -Wl,-rpath=/opt/puppetlabs/puppet/lib -fstack-protector -rdynamic -Wl,-export-dynamic -L/opt/puppetlabs/puppet/lib"
+    end
+  elsif platform.is_windows?
+    rbconfig_changes["CC"] = "x86_64-w64-mingw32-gcc"
+  end
+
+  pkg.add_source("file://resources/files/ruby_vendor_gems/operating_system.rb")
+  defaults_dir = File.join(settings[:libdir], "ruby/3.2.0/rubygems/defaults")
+  pkg.directory(defaults_dir)
+  pkg.install_file "../operating_system.rb", File.join(defaults_dir, 'operating_system.rb')
+
+  certs_dir = File.join(settings[:libdir], 'ruby/3.2.0/rubygems/ssl_certs/puppetlabs.net')
+  pkg.directory(certs_dir)
+
+  pkg.add_source('file://resources/files/rubygems/COMODO_RSA_Certification_Authority.pem')
+  pkg.install_file '../COMODO_RSA_Certification_Authority.pem', File.join(certs_dir, 'COMODO_RSA_Certification_Authority.pem')
+
+  pkg.add_source('file://resources/files/rubygems/GlobalSignRootCA_R3.pem')
+  pkg.install_file '../GlobalSignRootCA_R3.pem', File.join(certs_dir, 'GlobalSignRootCA_R3.pem')
+
+  if rbconfig_changes.any?
+    pkg.install do
+      [
+        "#{host_ruby} ../rbconfig-update.rb \"#{rbconfig_changes.to_s.gsub('"', '\"')}\" #{rbconfig_topdir}",
+        "cp original_rbconfig.rb #{settings[:datadir]}/doc/rbconfig-#{pkg.get_version}-orig.rb",
+        "cp new_rbconfig.rb #{rbconfig_topdir}/rbconfig.rb",
+      ]
+    end
+  end
+end

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -41,6 +41,15 @@ component "ruby-shadow" do |pkg, settings, platform|
     end
   end
 
+  matchdata = platform.settings[:ruby_version].match /(\d+)\.(\d+)\.\d+/
+  ruby_major_version = matchdata[1].to_i
+  if ruby_major_version >= 3
+    base = "resources/patches/ruby_32"
+    # https://github.com/apalmblad/ruby-shadow/issues/26
+    # if ruby-shadow gets a 3 release this should be removed
+    pkg.apply_patch "#{base}/ruby-shadow-2.5.0-cflags.patch", strip: "0"
+  end
+
   pkg.build do
     ["#{ruby} extconf.rb",
      "#{platform[:make]} -e -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -13,6 +13,14 @@ end
 # Common components required by all agent branches
 proj.component 'runtime-agent'
 
+matchdata = platform.settings[:ruby_version].match /(\d+)\.\d+\.\d+/
+ruby_major_version = matchdata[1].to_i
+# Ruby 3.2 does not package these two libraries so we need to add them as a component
+if ruby_major_version >= 3
+  proj.component 'libffi'
+  proj.component 'libyaml'
+end
+
 if platform.name =~ /^redhatfips-.*/
   proj.component "openssl-1.1.1-fips"
 else

--- a/configs/projects/agent-runtime-main_ruby_32.rb
+++ b/configs/projects/agent-runtime-main_ruby_32.rb
@@ -1,0 +1,76 @@
+project 'agent-runtime-main_ruby_32' do |proj|
+
+  # Set preferred component versions if they differ from defaults:
+  proj.setting :ruby_version, '3.2.0'
+  proj.setting :rubygem_deep_merge_version, '1.2.2'
+  # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0
+  if platform.is_solaris? || platform.is_aix?
+    proj.setting :augeas_version, '1.12.0'
+  else
+    proj.setting :augeas_version, '1.13.0'
+  end
+
+  ########
+  # Load shared agent settings
+  ########
+
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-settings.rb'))
+
+  ########
+  # Settings specific to the next branch
+  ########
+
+  # Directory for gems shared by puppet and puppetserver
+  proj.setting(:puppet_gem_vendor_dir, File.join(proj.libdir, "ruby", "vendor_gems"))
+
+  # Ruby 2.7 loads openssl on installation. Because pl-ruby was not
+  # built with openssl support, we switch to compile with system
+  # rubies.
+  # Solaris 11 seems to work with pl-ruby, and 10 is handled in _shared-agent-settings.rb.
+  if platform.is_cross_compiled_linux?
+    proj.setting(:host_ruby, "/usr/bin/ruby")
+  end
+
+  # Ruby 2.6 (RubyGems 3.0.1) removed the --ri and --rdoc
+  # options. Switch to using --no-document which is available starting
+  # with RubyGems 2.0.0preview2. This should also cover cross-compiled
+  # platforms that use older rubies.
+  proj.setting(:gem_install, "#{proj.host_gem} install --no-document --local")
+
+  ########
+  # Load shared agent components
+  ########
+
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-components.rb'))
+
+  ########
+  # Components specific to the main branch
+  ########
+
+  # When adding components to this list, please
+  # add them to pe-installer-runtime-main as well
+  proj.component 'rubygem-concurrent-ruby'
+  proj.component 'rubygem-ffi'
+  proj.component 'rubygem-multi_json'
+  proj.component 'rubygem-optimist'
+  proj.component 'rubygem-highline'
+  proj.component 'rubygem-hiera-eyaml'
+  proj.component 'rubygem-thor'
+  proj.component 'rubygem-scanf'
+
+  if platform.is_linux?
+    proj.component "virt-what"
+    proj.component "dmidecode" unless platform.architecture =~ /ppc64/
+  end
+
+  unless platform.is_windows?
+    proj.component 'rubygem-sys-filesystem'
+  end
+
+  if platform.is_macos?
+    proj.component 'rubygem-nokogiri'
+  end
+
+  proj.component 'boost' if ENV['NO_PXP_AGENT'].to_s.empty?
+  proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty?
+end

--- a/resources/patches/ruby_32/ruby-shadow-2.5.0-cflags.patch
+++ b/resources/patches/ruby_32/ruby-shadow-2.5.0-cflags.patch
@@ -1,0 +1,16 @@
+--- extconf.rb~	2017-10-05 20:21:59.480315863 +0200
++++ extconf.rb	2017-10-05 20:23:55.077931560 +0200
+@@ -6,12 +6,7 @@
+ 
+ require 'mkmf'
+ require 'rbconfig'
+-
+-$CFLAGS = case RUBY_VERSION
+-          when /^1\.9/; '-DRUBY19'
+-          when /^2\./; '-DRUBY19'
+-          else; ''
+-          end
++$CFLAGS = "#{$CFLAGS} -DRUBY19"
+ 
+ implementation = case CONFIG['host_os']
+                  when /linux/i; 'shadow'


### PR DESCRIPTION
This PR adds ruby 3.2 as a component to puppet runtime. It also copies the agent-runtime-main into a new project that has ruby 3.2. Until we have a branch of puppet-agent to promote ruby 2.7.6 to we'll need to seperate out this.
There are three changes that are needed to get Ruby 3.2 to build:
  * Package libffi
  * Package libyaml
  * Patch ruby-shadow Starting with Ruby 3.2 libffi and libyaml are no longer packaged with Ruby, so we need to take care of that. Ruby-shadow is a gem dependcy that is way out of date and wont build with Ruby 3, there is a simple patch we apply that allow us to build it.

The scope of this PR is just to build against EL-7 and EL-8, there is further work to do to get all other supported platforms to build.