### PR TITLE
(PA-4717) Build Ruby 3.2 runtime for Windows

### DIFF
--- a/configs/components/libffi.rb
+++ b/configs/components/libffi.rb
@@ -28,12 +28,25 @@ component 'libffi' do |pkg, settings, platform|
 
   pkg.build_requires "runtime-#{settings[:runtime_project]}"
 
+  if platform.is_windows?
+    # In Windows, libffi is unable to find the C programs (like mingw) to configure and build so the path must be set first
+    c_tools_path = 'export PATH="/cygdrive/c/tools/mingw64/bin:$(PATH)"'
+  else
+    c_tools_path = ""
+  end
+
   pkg.configure do
-    ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/libffi --disable-multi-os-directory #{settings[:host]}"]
+    [
+      "#{c_tools_path}",
+      "./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/libffi --disable-multi-os-directory #{settings[:host]}"
+    ]
   end
 
   pkg.build do
-    ["#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+    [
+      "#{c_tools_path}",
+      "#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"
+    ]
   end
 
   pkg.install do

--- a/configs/components/libyaml.rb
+++ b/configs/components/libyaml.rb
@@ -28,16 +28,30 @@ component 'libyaml' do |pkg, settings, platform|
 
   pkg.build_requires "runtime-#{settings[:runtime_project]}"
 
+  if platform.is_windows?
+     # In Windows, libyaml is unable to find the C programs (like mingw) to configure and build so the path must be set first
+    c_tools_path = 'export PATH="/cygdrive/c/tools/mingw64/bin:$(PATH)"'
+  else
+    c_tools_path = ""
+  end
+
   pkg.configure do
-    ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/libyaml #{settings[:host]}"]
+    [
+      "#{c_tools_path}",
+      "./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/libyaml #{settings[:host]}"
+    ]
   end
 
   pkg.build do
-    ["#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+    [
+      "#{c_tools_path}",
+      "#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"
+    ]
   end
 
   pkg.install do
     [
+      "#{c_tools_path}",
       "#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
       "rm -rf #{settings[:datadir]}/doc/#{pkg.get_name}*"
     ]

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -69,6 +69,10 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
  #   pkg.apply_patch "#{base}/win32_long_paths_support.patch"
  #   pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
  #   pkg.apply_patch "#{base}/windows_configure.patch"
+    # In Ruby 3.0, they added the esent.h for WCHAR to be included which is provided by 
+    # mingw-w64, but puppet-runtime uses an old version of mingw that's missing esent.h.
+    # To work around this, we will include basetsd.h. See patch for more information.
+    pkg.apply_patch "#{base}/win32-only-include-base-windows-types.patch"
   end
 
   ####################

--- a/resources/patches/ruby_32/win32-only-include-base-windows-types.patch
+++ b/resources/patches/ruby_32/win32-only-include-base-windows-types.patch
@@ -1,0 +1,28 @@
+From 1670e96c0ddf9e17e94e25517fb424f3a8e20e33 Mon Sep 17 00:00:00 2001
+From: Josh Cooper <joshcooper@users.noreply.github.com>
+Date: Tue, 25 Oct 2022 16:22:57 -0700
+Subject: [PATCH] [win32] Only include base windows types
+
+esent.h is the header for MS essential storage engine (JET) which is not
+needed in ruby. basetsd.h has existed since _MSC_VER >= 1200 (VS 6.0)
+and is the preferred header to use for WCHAR.
+---
+ win32/dir.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/win32/dir.h b/win32/dir.h
+index de12f79158..0292c27c9c 100644
+--- a/win32/dir.h
++++ b/win32/dir.h
+@@ -1,7 +1,7 @@
+ #ifndef RUBY_WIN32_DIR_H
+ #define RUBY_WIN32_DIR_H
+ #include <stdint.h>             /* for uint8_t */
+-#include <esent.h>              /* for WCHAR */
++#include <basetsd.h>            /* for WCHAR */
+ #include "ruby/encoding.h"      /* for rb_encoding */
+ 
+ #define DT_UNKNOWN 0
+-- 
+2.38.0
+


### PR DESCRIPTION
libffi and libyaml are unable to find mingw64 when configuring and building, so the path for mingw64 must be set before running those commands. Aditionally, Ruby includes esent.h for WCHAR, which is proivded by mingw-w64 but the mingw version used in puppet-runtime is too old to include that header. So, a patch is needed to include basetsd.h for WCHAR.

This PR is still a **work in progress**, there are still some errors preventing Ruby 3.2 runtime to build on Windows.