### PR TITLE
(PA-4767) Update Nokogiri for CVE-2022-2309

### DIFF
--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -1,6 +1,6 @@
 component 'rubygem-nokogiri' do |pkg, _settings, _platform|
-  pkg.version '1.13.6'
-  pkg.sha256sum 'b1512fdc0aba446e1ee30de3e0671518eb363e75fab53486e99e8891d44b8587'
+  pkg.version '1.13.9'
+  pkg.sha256sum '96f37c1baf0234d3ae54c2c89aef7220d4a8a1b03d2675ff7723565b0a095531'
   instance_eval File.read('configs/components/_base-rubygem.rb')
 
   pkg.build_requires 'rubygem-mini_portile2'


### PR DESCRIPTION
Nokogiri includes libxml2, older versions of which are vulnerable to CVE-2022-2309 NULL pointer derefence.

This commit updates Nokogiri to 1.13.9, which includes a patched version of libxml2.