### PR TITLE
(maint) Update the runtime for Solaris now that we're using version 11.4

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -42,6 +42,7 @@ component 'curl' do |pkg, settings, platform|
   if (platform.is_solaris? && platform.os_version == "11") || platform.is_aix?
     # Makefile generation with automatic dependency tracking fails on these platforms
     configure_options << "--disable-dependency-tracking"
+    configure_options << "--without-nghttp2"
   end
 
   pkg.configure do

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -22,7 +22,7 @@ component "libxslt" do |pkg, settings, platform|
   elsif platform.is_solaris?
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
     pkg.environment "CFLAGS", settings[:cflags]
-    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "LDFLAGS", "#{settings[:ldflags]} -Wl,-z,gnu-version-script-compat"
     # Configure on Solaris incorrectly passes flags to ld
     pkg.apply_patch 'resources/patches/libxslt/disable-version-script.patch'
     pkg.apply_patch 'resources/patches/libxslt/Update-missing-script-to-return-0.patch'


### PR DESCRIPTION
Two changes so far that get things passing for 6.x, but still issues for main:

- Curl failed to build with an error around not finding nghttp2, by default it used to try to not build with that. Add a configure option flag to be explict about don't build with nghttp2.
- libxsxlt failed with: ```ld: fatal: option --version-script requires option -z gnu-version-script-compat to be specified```. Need to pass in some load flags to get that to pass. 