### PR TITLE
(PE-34844) Stop compiling bolt/ace-server gems against system openssl

### DIFF
--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -18,11 +18,6 @@ unless pe_version && !pe_version.empty?
   exit(1)
 end
 
-if platform.name =~ /^redhatfips-.*/
-  # Link against the system openssl instead of our vendored version:
-  proj.setting(:system_openssl, true)
-end
-
 proj.description('The PE Bolt runtime contains third-party components needed for PE Bolt server packaging')
 proj.license('See components')
 proj.vendor('Puppet, Inc.  <info@puppet.com>')


### PR DESCRIPTION
Previously we were using the `systemssl` flag when building shared bolt/ace server runtime artifacts. This should no longer be necessary as the vendored openssl versions should be compatible.