### PR TITLE
(maint) Convince ruby 2.7.6 to build on Solaris 11

### DIFF
--- a/configs/components/ruby-2.7.6.rb
+++ b/configs/components/ruby-2.7.6.rb
@@ -73,6 +73,10 @@ component 'ruby-2.7.6' do |pkg, settings, platform|
     pkg.apply_patch "#{base}/windows_configure.patch"
   end
 
+  if platform.is_solaris?
+    pkg.apply_patch "#{base}/solaris-do-not-use-qsort_s.patch"
+  end
+
   ####################
   # ENVIRONMENT, FLAGS
   ####################
@@ -139,6 +143,8 @@ component 'ruby-2.7.6' do |pkg, settings, platform|
   # TODO: Remove this once PA-1607 is resolved.
   # TODO: Can we use native autoconf? The dependencies seemed a little too extensive
   pkg.configure { ["/opt/pl-build-tools/bin/autoconf"] } if platform.is_aix?
+
+  pkg.configure { ['/usr/bin/autoconf'] } if platform.is_solaris?
 
   # Here we set --enable-bundled-libyaml to ensure that the libyaml included in
   # ruby is used, even if the build system has a copy of libyaml available

--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -1,7 +1,9 @@
 platform "solaris-11-i386" do |plat|
   plat.inherit_from_default
+  plat.vmpooler_template 'solaris-114-x86_64'
 
   packages = %w(
+    autoconf
     pl-binutils-i386
     pl-cmake
     pl-gcc-i386

--- a/resources/patches/ruby_27/solaris-do-not-use-qsort_s.patch
+++ b/resources/patches/ruby_27/solaris-do-not-use-qsort_s.patch
@@ -1,0 +1,15 @@
+# qsort_s gets us into trouble on Solaris 11
+# It assumes the Bounds Checking Extension to
+# C11, which we do not have. So just don't use it.
+diff --git a/configure.ac b/configure.ac
+index 826a688..ff2ce7e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1891,7 +1891,6 @@ AC_CHECK_FUNCS(ppoll)
+ AC_CHECK_FUNCS(pread)
+ AC_CHECK_FUNCS(pwrite)
+ AC_CHECK_FUNCS(qsort_r)
+-AC_CHECK_FUNCS(qsort_s)
+ AC_CHECK_FUNCS(readlink)
+ AC_CHECK_FUNCS(realpath)
+ AC_CHECK_FUNCS(round)


### PR DESCRIPTION
A companion to https://github.com/puppetlabs/puppet-runtime/pull/595, add some hackery to get ruby-2.7.6 to build on solaris-11