### PR TITLE
(maint) Fix solaris-10-i386 agent-runtime-main

### DIFF
--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -50,8 +50,9 @@ basedir=default" > /var/tmp/vanagon-noask;
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep libffi_dev libreadline6 autoconf|| exit 1;
-
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep libffi_dev libreadline6;
+  /opt/csw/bin/pkgutil -i -y autoconf|| exit 1;
+  ln /opt/csw/bin/autoconf /usr/bin/autoconf
   # Install base build dependencies
   for pkg in #{base_pkgs.map { |pkg| "SUNW#{pkg}.pkg.gz" }.join(' ')}; do \
   tmpdir=$(mktemp -p /var/tmp -d); (cd ${tmpdir} && curl -O #{base_url}/${pkg} && gunzip -c ${pkg} | pkgadd -d /dev/stdin -a /var/tmp/vanagon-noask all); \

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -51,7 +51,7 @@ basedir=default" > /var/tmp/vanagon-noask;
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake libgcc_s1 libreadline6 pkgconfig ggrep ruby20 ruby20_dev gcc4g++ autoconf || exit 1;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake libgcc_s1 libreadline6 pkgconfig ggrep ruby20 ruby20_dev gcc4g++|| exit 1;
   # For some reason, the bison reference is invalid on our artifactory mirror, so get it directly from opencsw.
   /opt/csw/bin/pkgutil -y -i bison;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -41,7 +41,6 @@ action=nocheck
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
   pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-  /opt/csw/bin/pkgutil -U && /opt/csw/bin/pkgutil -y -i gcc4g++ bison autoconf|| exit 1
-
+  /opt/csw/bin/pkgutil -U && /opt/csw/bin/pkgutil -y -i gcc4g++ bison|| exit 1
   ntpdate pool.ntp.org]
 end


### PR DESCRIPTION
Autoconf is required.
SPARC is currently broken, I'm removing the autoconf from them for now while I decide if it is required. 