### PR TITLE
(PA-4737) Reset CPP rbconfig

### DIFF
--- a/configs/components/ruby-2.7.6.rb
+++ b/configs/components/ruby-2.7.6.rb
@@ -208,6 +208,10 @@ component 'ruby-2.7.6' do |pkg, settings, platform|
       rbconfig_changes["CC"] = 'clang -target arm64-apple-macos12'
     else
       rbconfig_changes["CC"] = "gcc"
+      if platform.is_solaris?
+        # this should probably be done for aix and cross compiled targets too
+        rbconfig_changes["CPP"] = "gcc -E"
+      end
       rbconfig_changes["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wno-maybe-uninitialized"
     end
     if platform.name =~ /el-7-ppc64/


### PR DESCRIPTION
When building ruby 2.7, `RbConfig::CONFIG['CPP']` contains the interpolated value of `$(CC) -E`. When building for Solaris (10 & 11, x86_64 and SPARC), the interpolated value is of the form:

    /opt/pl-build-tools/bin/<arch>-pc-solaris2.1x-gcc -E

However, pl-build-tools doesn't exist on the end target. So reset the `CPP` option to `gcc -E`, similar to what is done for `CC`

This only affects Solaris for now, but should probably be done for all hosts that are cross-compiled and/or use pl-build-tools.