### PR TITLE
(PA-4805) Bump Ruby to 2.7.7 for runtime-main

### DIFF
--- a/configs/components/ruby-2.7-augeas.rb
+++ b/configs/components/ruby-2.7-augeas.rb
@@ -1,5 +1,5 @@
 component 'ruby-2.7-augeas' do |pkg, settings, platform|
-  expected_ruby_version = '2.7.6'
+  expected_ruby_version = '2.7.7'
 
   unless settings[:ruby_version] == expected_ruby_version
     unless settings.key?(:additional_rubies) && settings[:additional_rubies].key?(expected_ruby_version)

--- a/configs/components/ruby-2.7-selinux.rb
+++ b/configs/components/ruby-2.7-selinux.rb
@@ -1,5 +1,5 @@
 component 'ruby-2.7-selinux' do |pkg, settings, platform|
-  expected_ruby_version = '2.7.6'
+  expected_ruby_version = '2.7.7'
 
   unless settings[:ruby_version] == expected_ruby_version
     unless settings.key?(:additional_rubies) && settings[:additional_rubies].key?(expected_ruby_version)

--- a/configs/components/ruby-2.7-stomp.rb
+++ b/configs/components/ruby-2.7-stomp.rb
@@ -1,5 +1,5 @@
 component 'ruby-2.7-stomp' do |pkg, settings, platform|
-  expected_ruby_version = '2.7.6'
+  expected_ruby_version = '2.7.7'
 
   unless settings[:ruby_version] == expected_ruby_version
     unless settings.key?(:additional_rubies) && settings[:additional_rubies].key?(expected_ruby_version)

--- a/configs/components/ruby-2.7.7.rb
+++ b/configs/components/ruby-2.7.7.rb
@@ -1,6 +1,6 @@
-component 'ruby-2.7.6' do |pkg, settings, platform|
-  pkg.version '2.7.6'
-  pkg.sha256sum 'e7203b0cc09442ed2c08936d483f8ac140ec1c72e37bb5c401646b7866cb5d10'
+component 'ruby-2.7.7' do |pkg, settings, platform|
+  pkg.version '2.7.7'
+  pkg.sha256sum 'e10127db691d7ff36402cfe88f418c8d025a3f1eea92044b162dd72f0b8c7b90'
 
   # rbconfig-update is used to munge rbconfigs after the fact.
   pkg.add_source("file://resources/files/ruby/rbconfig-update.rb")
@@ -53,6 +53,9 @@ component 'ruby-2.7.6' do |pkg, settings, platform|
         pkg.apply_patch "#{base}/Solaris-only-Replace-reference-to-RUBY-var-with-opt-pl-build-tool.patch"
       else
         pkg.apply_patch "#{base}/Replace-reference-to-RUBY-var-with-opt-pl-build-tool.patch"
+      end
+      if platform.name =~ /sparc/
+        pkg.apply_patch "#{base}/transform_mjit_header.patch"
       end
     end
     pkg.apply_patch "#{base}/rbinstall_gem_path.patch"

--- a/configs/projects/agent-runtime-7.x.rb
+++ b/configs/projects/agent-runtime-7.x.rb
@@ -1,7 +1,7 @@
 project 'agent-runtime-7.x' do |proj|
 
   # Set preferred component versions if they differ from defaults:
-  proj.setting :ruby_version, '2.7.6'
+  proj.setting :ruby_version, '2.7.7'
   proj.setting :rubygem_deep_merge_version, '1.2.2'
   # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0
   if platform.is_solaris? || platform.is_aix?

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -1,7 +1,7 @@
 project 'agent-runtime-main' do |proj|
 
   # Set preferred component versions if they differ from defaults:
-  proj.setting :ruby_version, '2.7.6'
+  proj.setting :ruby_version, '2.7.7'
   proj.setting :rubygem_deep_merge_version, '1.2.2'
   # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0
   if platform.is_solaris? || platform.is_aix?

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -1,7 +1,7 @@
 project 'bolt-runtime' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'bolt')
-  proj.setting(:ruby_version, '2.7.6')
+  proj.setting(:ruby_version, '2.7.7')
   proj.setting(:openssl_version, '1.1.1')
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
   proj.setting(:augeas_version, '1.11.0')

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -76,10 +76,10 @@ project 'pdk-runtime' do |proj|
 
   # TODO: build this with a helper method?
   additional_rubies = {
-    "2.7.6" => {
-      ruby_version: "2.7.6",
+    "2.7.7" => {
+      ruby_version: "2.7.7",
       ruby_api: "2.7.0",
-      ruby_dir: File.join(proj.privatedir, "ruby", "2.7.6"),
+      ruby_dir: File.join(proj.privatedir, "ruby", "2.7.7"),
     },
   }
 

--- a/configs/projects/pe-installer-runtime-2021.7.x.rb
+++ b/configs/projects/pe-installer-runtime-2021.7.x.rb
@@ -1,7 +1,7 @@
 project 'pe-installer-runtime-2021.7.x' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'pe-installer')
-  proj.setting(:ruby_version, '2.7.6')
+  proj.setting(:ruby_version, '2.7.7')
   proj.setting(:augeas_version, '1.11.0')
   # We need to explicitly define 1.1.1k here to avoid
   # build dep conflicts between openssl-1.1.1 needed by curl

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -1,7 +1,7 @@
 project 'pe-installer-runtime-main' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'pe-installer')
-  proj.setting(:ruby_version, '2.7.6')
+  proj.setting(:ruby_version, '2.7.7')
   proj.setting(:augeas_version, '1.11.0')
   # We need to explicitly define 1.1.1k here to avoid
   # build dep conflicts between openssl-1.1.1 needed by curl

--- a/resources/patches/ruby_27/transform_mjit_header.patch
+++ b/resources/patches/ruby_27/transform_mjit_header.patch
@@ -1,0 +1,19 @@
+diff --git a/tool/transform_mjit_header.rb b/tool/transform_mjit_header.rb
+index 5f89446c81..74bf2b759b 100644
+--- a/tool/transform_mjit_header.rb
++++ b/tool/transform_mjit_header.rb
+@@ -174,13 +174,7 @@ def self.supported_header?(code)
+   #    "error: redefinition of parameter 'restrict'"
+   # If it's true, this script regards platform as AIX or Solaris and adds -std=c99 as workaround.
+   def self.conflicting_types?(code, cc, cflags)
+-    with_code(code) do |path|
+-      cmd = "#{cc} #{cflags} #{path}"
+-      out = IO.popen(cmd, err: [:child, :out], &:read)
+-      !$?.success? &&
+-        (out.match?(/error: conflicting types for '[^']+'/) ||
+-         out.match?(/error: redefinition of parameter '[^']+'/))
+-    end
++    true
+   end
+ 
+   def self.with_code(code)


### PR DESCRIPTION
Add a patch for Solaris to get a `-std=c99` flag added