### PR TITLE
(PA-4817) Updates Nokogiri to 1.13.10

### DIFF
--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -1,6 +1,6 @@
 component 'rubygem-nokogiri' do |pkg, _settings, _platform|
-  pkg.version '1.13.9'
-  pkg.sha256sum '96f37c1baf0234d3ae54c2c89aef7220d4a8a1b03d2675ff7723565b0a095531'
+  pkg.version '1.13.10'
+  pkg.sha256sum 'd3ee00f26c151763da1691c7fc6871ddd03e532f74f85101f5acedc2d099e958'
   instance_eval File.read('configs/components/_base-rubygem.rb')
 
   pkg.build_requires 'rubygem-mini_portile2'


### PR DESCRIPTION
This commit updates the Nokogiri component used in puppet-agent- runtime on macOS from 1.13.9 to 1.13.10, which addresses CVE-2022-23476.