### PR TITLE
(PA-4815) Updates fast_gettext gem to 2.2.0

### DIFF
--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -1,14 +1,14 @@
 component "rubygem-fast_gettext" do |pkg, settings, platform|
-  version = settings[:rubygem_fast_gettext_version] || '1.1.2'
+  version = settings[:rubygem_fast_gettext_version] || '2.2.0'
   pkg.version version
 
   case version
-    when '1.1.0'
-      pkg.md5sum "fc0597bd4d84b749c579cc39c7ceda0f"
-    when '1.1.2'
-      pkg.md5sum "df5a2462d0e1d2e5d49bb233b841f4d6"
-    else
-      raise "rubygem-fast_gettext version #{version} has not been configured; Cannot continue."
+  when '2.2.0'
+    pkg.sha256sum '01804331afce7b7c918e7ebe1951a3507b24b3a0c0617429725dbd4a2f234ad8'
+  when '1.1.2'
+    pkg.sha256sum 'e868f02c24af746a137f3aaf898ca3660e6611aa7f1f96ce60e9a425130f2732'
+  else
+    raise "rubygem-fast_gettext version #{version} has not been configured; Cannot continue."
   end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -1,6 +1,15 @@
 component "rubygem-gettext-setup" do |pkg, settings, platform|
-  pkg.version "0.34"
-  pkg.md5sum "72e511431d138a7c3e062d5e06989a40"
+  version = settings[:rubygem_gettext_setup_version] || '1.1.0'
+  pkg.version version
+
+  case version
+  when '1.1.0'
+    pkg.sha256sum '2ad4fa99575d869f18056941d98dc9cb2a656abc7b991f360fbd3e32d28fd4ec'
+  when '0.34'
+    pkg.sha256sum 'ea9d6f6be56908d54af8c7bb246f133fa9f8f634011df135c0a87520be57d6ed'
+  else
+    raise "rubygem-gettext-setup version #{version} has not been configured; Cannot continue."
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -1,13 +1,12 @@
 component "rubygem-gettext" do |pkg, settings, platform|
-  # Projects may define a :rubygem_gettext_version setting, or we use 3.2.2 by default:
-  version = settings[:rubygem_gettext_version] || '3.2.2'
+  version = settings[:rubygem_gettext_version] || '3.4.3'
   pkg.version version
 
   case version
-  when "3.2.2"
-    pkg.md5sum "4cbb125f8d8206e9a8f3a90f6488e4da"
-  when "3.2.9"
-    pkg.md5sum "09a755cd03ab617835e20a2e910581f4"
+  when '3.4.3'
+    pkg.sha256sum '1b98e1272d0f55a56f519ee86d24e0fcd114b94c9d10b26e72512d65f9174251'    
+  when '3.2.2'
+    pkg.sha256sum '9d250bb79273efb4a268977f219d2daca05cdc7473eff40288b8ab8ddd0f51b4'
   else
     raise "rubygem-gettext version #{version} has not been configured; Cannot continue."
   end

--- a/configs/components/rubygem-prime.rb
+++ b/configs/components/rubygem-prime.rb
@@ -1,0 +1,7 @@
+component 'rubygem-prime' do |pkg, settings, platform|
+    pkg.version '0.1.2'
+    pkg.sha256sum 'd4e956cadfaf04de036dc7dc74f95bf6a285a62cc509b28b7a66b245d19fe3a4'
+  
+    instance_eval File.read('configs/components/_base-rubygem.rb')
+  end
+  

--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,6 +1,6 @@
 component 'rubygem-r10k' do |pkg, settings, platform|
-  pkg.version '3.15.0'
-  pkg.md5sum 'e8ed305a7f2aa130c8be2e42a397a923'
+  pkg.version '3.15.3'
+  pkg.sha256sum '2b9cbdab2d52ae6572043978c71cc8b925d937253fa3e7c04613b914ee59d4b2'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -35,7 +35,6 @@ proj.setting(:runtime_project, 'pe-bolt-server')
 
 # Set desired versions for gem components that offer multiple versions:
 # TODO: Can runtime projects use these updated versions?
-proj.setting(:rubygem_gettext_version, '3.2.9')
 proj.setting(:rubygem_deep_merge_version, '1.2.2')
 proj.setting(:rubygem_net_ssh_version, '6.1.0')
 
@@ -81,6 +80,7 @@ proj.component 'rubygem-deep_merge'
 proj.component 'rubygem-text'
 proj.component 'rubygem-locale'
 proj.component 'rubygem-gettext'
+proj.component 'rubygem-prime'
 proj.component 'rubygem-fast_gettext'
 proj.component 'rubygem-semantic_puppet'
 

--- a/configs/projects/agent-runtime-6.x.rb
+++ b/configs/projects/agent-runtime-6.x.rb
@@ -2,6 +2,9 @@ project 'agent-runtime-6.x' do |proj|
   # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.5.9'
   proj.setting :augeas_version, '1.12.0'
+  proj.setting :rubygem_fast_gettext_version, '1.1.2'
+  proj.setting :rubygem_gettext_version, '3.2.2'
+  proj.setting :rubygem_gettext_setup_version, '0.34'
 
   ########
   # Load shared agent settings

--- a/configs/projects/agent-runtime-7.x.rb
+++ b/configs/projects/agent-runtime-7.x.rb
@@ -3,6 +3,10 @@ project 'agent-runtime-7.x' do |proj|
   # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.7.7'
   proj.setting :rubygem_deep_merge_version, '1.2.2'
+  proj.setting :rubygem_fast_gettext_version, '1.1.2'
+  proj.setting :rubygem_gettext_version, '3.2.2'
+  proj.setting :rubygem_gettext_setup_version, '0.34'
+
   # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0
   if platform.is_solaris? || platform.is_aix?
     proj.setting :augeas_version, '1.12.0'

--- a/configs/projects/agent-runtime-main_ruby_32.rb
+++ b/configs/projects/agent-runtime-main_ruby_32.rb
@@ -73,6 +73,10 @@ project 'agent-runtime-main_ruby_32' do |proj|
     proj.component 'rubygem-mini_portile2'
   end
 
+  # Dependencies for gettext for Ruby >= 3.2 (PA-4815)
+  proj.component 'rubygem-erubi'
+  proj.component 'rubygem-prime'
+
   proj.component 'boost' if ENV['NO_PXP_AGENT'].to_s.empty?
   proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty?
 end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -6,7 +6,6 @@ project 'bolt-runtime' do |proj|
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
   proj.setting(:augeas_version, '1.11.0')
   # TODO: Can runtime projects use these updated versions?
-  proj.setting(:rubygem_gettext_version, '3.2.9')
   proj.setting(:rubygem_deep_merge_version, '1.2.2')
   proj.setting(:rubygem_puppet_version, '7.18.0')
 
@@ -129,6 +128,7 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-text'
   proj.component 'rubygem-locale'
   proj.component 'rubygem-gettext'
+  proj.component 'rubygem-prime'
   proj.component 'rubygem-fast_gettext'
   proj.component 'rubygem-scanf'
   proj.component 'rubygem-semantic_puppet'

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -3,6 +3,10 @@ project 'pdk-runtime' do |proj|
   proj.setting(:runtime_project, "pdk")
   proj.setting(:openssl_version, '1.1.1')
   proj.setting(:augeas_version, '1.13.0')
+  proj.setting(:rubygem_fast_gettext_version, '1.1.2')
+  proj.setting(:rubygem_gettext_version, '3.2.2')
+  proj.setting(:rubygem_gettext_setup_version, '0.34')
+
   platform = proj.get_platform
 
   proj.version_from_git


### PR DESCRIPTION
Puppet projects will soon be using Ruby 3.2, which is not compatible with versions of fast_gettext earlier than 2.1 because of the deprecated taint checking features.

This commit also removes the conditional for multiple versions of fast_gettext, which was originally added in 29db591e55448931dabcc4803385c10b999ee1b7 for puppet-agent 1.10.x, which has long been deprecated.