### PR TITLE
(PA-4815) Pins gettext versions for runtime-main

### DIFF
--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -3,6 +3,13 @@ project 'agent-runtime-main' do |proj|
   # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '2.7.7'
   proj.setting :rubygem_deep_merge_version, '1.2.2'
+
+  # Temporarily pinning back gettext-related component versions until Ruby 3.2 is part
+  # of the runtime.
+  proj.setting :rubygem_fast_gettext_version, '1.1.2'
+  proj.setting :rubygem_gettext_version, '3.2.2'
+  proj.setting :rubygem_gettext_setup_version, '0.34'
+
   # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0
   if platform.is_solaris? || platform.is_aix?
     proj.setting :augeas_version, '1.12.0'


### PR DESCRIPTION
gettext and related components have been updated by default in preparation for Ruby 3.2, but agent-runtime-main is still running Ruby 2.7. This commit pins gettext, fast_gettex, and gettext-setup to older versions in the runtime.