### PR TITLE
(maint) Fix AIX GCC options

### DIFF
--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -113,7 +113,7 @@ component "boost" do |pkg, settings, platform|
     install_only_flags = "boost.locale.iconv=off"
   elsif platform.is_aix?
     pkg.environment "NO_CXX11_CHECK", "1"
-    pkg.environment "CXX", "/opt/freeware/bin/g++"
+    pkg.environment "CXX", "/opt/freeware/bin/g++-8"
     pkg.environment "CXXFLAGS", "-pthread"
     pkg.environment "PATH", "/opt/freeware/bin:/opt/pl-build-tools/bin:$(PATH)"
     linkflags = "-Wl,-L#{settings[:libdir]},-L/opt/pl-build-tools/lib"

--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -41,7 +41,7 @@ uncompress openssl-1.0.2.1800.tar.Z;
 tar xvf openssl-1.0.2.1800.tar;
 cd openssl-1.0.2.1800 && /usr/sbin/installp -acgwXY -d $PWD openssl.base;
 curl -O http://ftp.software.ibm.com/aix/freeSoftware/aixtoolbox/ezinstall/ppc/yum.sh && sh yum.sh;
-yum install -y gcc-c++;
+yum install -y gcc8-c++;
 ln -sf /opt/freeware/lib/gcc/powerpc-ibm-aix7.1.0.0/8/libgcc_s.a /opt/freeware/lib/libgcc_s.a]
 
   # We use --force with rpm because the pl-gettext and pl-autoconf


### PR DESCRIPTION
Recently, the GCC package for AIX changed from linking to GCC 8 to GCC 10, breaking compilation for things like Ruby native extensions and C++ components like Boost.

This commit specifies GCC 8 to restore working behavior for building runtimes on AIX.