### PR TITLE
(PE-4815) Remove prime gem from pe-bolt-server 2019.8.x

### DIFF
--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -80,7 +80,6 @@ proj.component 'rubygem-deep_merge'
 proj.component 'rubygem-text'
 proj.component 'rubygem-locale'
 proj.component 'rubygem-gettext'
-proj.component 'rubygem-prime'
 proj.component 'rubygem-fast_gettext'
 proj.component 'rubygem-semantic_puppet'
 

--- a/configs/projects/pe-bolt-server-runtime-2021.7.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2021.7.x.rb
@@ -5,5 +5,7 @@ project 'pe-bolt-server-runtime-2021.7.x' do |proj|
   # for gem installs instead of --no-ri --no-rdoc. This setting allows us to use this while we support both ruby 2.5 and 2.7
   # Once we are no longer using ruby 2.5 we can update.
   proj.setting(:no_doc, true)
+
+  proj.component 'rubygem-prime'
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server.rb'))
 end

--- a/configs/projects/pe-bolt-server-runtime-main.rb
+++ b/configs/projects/pe-bolt-server-runtime-main.rb
@@ -5,5 +5,7 @@ project 'pe-bolt-server-runtime-main' do |proj|
   # for gem installs instead of --no-ri --no-rdoc. This setting allows us to use this while we support both ruby 2.5 and 2.7
   # Once we are no longer using ruby 2.5 we can update.
   proj.setting(:no_doc, true)
+
+  proj.component 'rubygem-prime'
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server.rb'))
 end


### PR DESCRIPTION
Similar to previous commit, inclusion of the prime gem was failing to find forwardable in the pe-bolt-server 2019.8.x pipeline, so this removes it from _shared-pe-bolt-server.rb and includes it specifically for 2021.7.x and main that use the later gettext defaults.