### PR TITLE
(PA-4815) Fix order of rubygem-prime include for pe-bolt-server

### DIFF
--- a/configs/projects/pe-bolt-server-runtime-2021.7.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2021.7.x.rb
@@ -6,6 +6,6 @@ project 'pe-bolt-server-runtime-2021.7.x' do |proj|
   # Once we are no longer using ruby 2.5 we can update.
   proj.setting(:no_doc, true)
 
-  proj.component 'rubygem-prime'
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server.rb'))
+  proj.component 'rubygem-prime'
 end

--- a/configs/projects/pe-bolt-server-runtime-main.rb
+++ b/configs/projects/pe-bolt-server-runtime-main.rb
@@ -6,6 +6,6 @@ project 'pe-bolt-server-runtime-main' do |proj|
   # Once we are no longer using ruby 2.5 we can update.
   proj.setting(:no_doc, true)
 
-  proj.component 'rubygem-prime'
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server.rb'))
+  proj.component 'rubygem-prime'
 end


### PR DESCRIPTION
The component needs to be added after the eval of
_shared-pe-bolt-server.rb which adds settings the component method relies on.