### PR TITLE
(PA-4838) Update platform defaults for RHEL 8 ppc64le, RHEL 7 & 8 (x86-64)

### DIFF
--- a/configs/platforms/el-7-x86_64.rb
+++ b/configs/platforms/el-7-x86_64.rb
@@ -10,7 +10,8 @@ platform "el-7-x86_64" do |plat|
     pl-cmake
     pl-gcc
     readline-devel
-    rpm-build swig
+    rpm-build
+    swig
     zlib-devel
     systemtap-sdt-devel
   )

--- a/configs/platforms/el-8-ppc64le.rb
+++ b/configs/platforms/el-8-ppc64le.rb
@@ -1,14 +1,3 @@
 platform 'el-8-ppc64le' do |plat|
-  plat.servicedir '/usr/lib/systemd/system'
-  plat.defaultdir '/etc/sysconfig'
-  plat.servicetype 'systemd'
-
-  # Workaround for an issue with RedHat subscription metadata, see ITSYS-2543
-  plat.provision_with('subscription-manager repos --disable rhel-8-for-ppc64le-baseos-rpms && subscription-manager repos --enable rhel-8-for-ppc64le-baseos-rpms')
-
-  packages = %w[make cmake libarchive perl-Getopt-Long gcc-c++ java-1.8.0-openjdk-devel
-    patch swig libselinux-devel readline-devel zlib-devel systemtap-sdt-devel]
-  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
-  plat.install_build_dependencies_with 'dnf install -y --allowerasing'
-  plat.vmpooler_template 'redhat-8-power8'
+  plat.inherit_from_default
 end

--- a/configs/platforms/redhatfips-7-x86_64.rb
+++ b/configs/platforms/redhatfips-7-x86_64.rb
@@ -2,17 +2,8 @@ platform "redhatfips-7-x86_64" do |plat|
   plat.inherit_from_default
 
   packages = %w(
-    java-1.8.0-openjdk-devel
-    libsepol
-    libsepol-devel
-    libselinux-devel
-    openssl-devel
-    pkgconfig
     pl-cmake
     pl-gcc
-    readline-devel
-    rpm-build
-    swig zlib-devel
   )
   plat.provision_with "yum install --assumeyes #{packages.join(' ')}"
 end


### PR DESCRIPTION
el-8-ppc64le and redhatfips-7-x86_64 fail to build agent-runtime-main (Ruby 3.2) because they're missing autoconf. This pushes the platform definitions into vanagon. The autoconf, etc dependencies were added to vanagon.

~This is blocked until this commit is released: https://github.com/puppetlabs/vanagon/commit/768969f6bf7a02580e09c6dd99a64e3800bb1745~

Successfully built this PR with vanagon 0.33.0 in https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1882/

- [x] el-7-x86_64
- [x] el-8-ppc64le
- [x] redhatfips-7-x86_64
- [x] redhatfips-8-x86_64