### PR TITLE
(PA-4844) Patch the autogenerated selinux C extension

### DIFF
--- a/resources/patches/ruby-selinux/selinuxswig_ruby_wrap.patch
+++ b/resources/patches/ruby-selinux/selinuxswig_ruby_wrap.patch
@@ -1,0 +1,10 @@
+--- selinuxswig_ruby_wrap.c.orig	2023-01-18 22:38:21.527547362 -0800
++++ selinuxswig_ruby_wrap.c	2023-01-18 22:38:26.887569066 -0800
+@@ -1724,6 +1724,7 @@
+ {
+   /* register a new class */
+   VALUE cl = rb_define_class("swig_runtime_data", rb_cObject);
++  rb_undef_alloc_func(cl);
+   /* create and store the structure pointer to a global variable */
+   swig_runtime_data_type_pointer = Data_Wrap_Struct(cl, 0, 0, pointer);
+   rb_define_readonly_variable("$swig_runtime_data_type_pointer" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME, &swig_runtime_data_type_pointer);


### PR DESCRIPTION
Calling into selinux from Ruby 3.2 generates a warning:

    selinux.so: warning: undefining the allocator of T_DATA class swig_runtime_data

This is because ruby 3.2 requires C extensions to "either use rb_define_alloc_func() to overwrite it or rb_undef_alloc_func() to delete it."[1] The selinux C extension selinuxswig_ruby_wrap.c is autogenerated by swig from the selinuxswig_i template.

swig 4.1.1 contains the fix for this[2] but we are using an older version on RHEL7. So patch the autogenerated C extension, which needs to happen after the code is generated and before it's compiled.

[1] https://github.com/ruby/ruby/blob/6963f8f743b42f9004a0879cd66c550f18987352/doc/extension.rdoc#label-Write+the+C+Code
[2] https://github.com/swig/swig/commit/962f0900018ecb10287b327d261e424fa5ccb755