### PR TITLE
(PA-4769) Enable Ruby 3.2.0 on macOS on ARM

### DIFF
--- a/configs/components/pl-ruby-patch.rb
+++ b/configs/components/pl-ruby-patch.rb
@@ -48,7 +48,7 @@ component "pl-ruby-patch" do |pkg, settings, platform|
 
     # make rubygems use our target rbconfig when installing gems
     case base_ruby
-    when /2\.0|2\.1/
+    when /^(2\.0|2\.1)/
       sed_command = %(s|Gem.ruby|&, '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
     else
       sed_command = %(s|Gem.ruby.shellsplit|& << '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -77,6 +77,7 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
 
   if platform.is_macos?
     pkg.environment 'optflags', settings[:cflags]
+    pkg.environment 'PATH', '$(PATH):/usr/local/bin'
   elsif platform.is_windows?
     pkg.environment 'optflags', settings[:cflags] + ' -O3'
     pkg.environment 'MAKE', 'make'
@@ -172,7 +173,7 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
 
   target_doubles = {
     'powerpc-ibm-aix7.1.0.0' => 'powerpc-aix7.1.0.0',
-    'aarch64-apple-darwin' => 'aarch64-darwin',
+    'aarch64-apple-darwin' => 'arm64-darwin',
     'aarch64-redhat-linux' => 'aarch64-linux',
     'ppc64-redhat-linux' => 'powerpc64-linux',
     'ppc64le-redhat-linux' => 'powerpc64le-linux',

--- a/configs/platforms/osx-11-arm64.rb
+++ b/configs/platforms/osx-11-arm64.rb
@@ -5,6 +5,7 @@ platform 'osx-11-arm64' do |plat|
 
   plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
   plat.provision_with 'export HOMEBREW_VERBOSE=true'
+  plat.provision_with 'export HOMEBREW_NO_ANALYTICS=1'
 
   plat.provision_with 'sudo dscl . -create /Users/test'
   plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'

--- a/configs/platforms/osx-11-x86_64.rb
+++ b/configs/platforms/osx-11-x86_64.rb
@@ -5,6 +5,7 @@ platform 'osx-11-x86_64' do |plat|
 
     plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
     plat.provision_with 'export HOMEBREW_VERBOSE=true'
+    plat.provision_with 'export HOMEBREW_NO_ANALYTICS=1'
 
     plat.provision_with 'sudo dscl . -create /Users/test'
     plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -5,6 +5,7 @@ platform 'osx-12-arm64' do |plat|
 
     plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
     plat.provision_with 'export HOMEBREW_VERBOSE=true'
+    plat.provision_with 'export HOMEBREW_NO_ANALYTICS=1'
 
     plat.provision_with 'sudo dscl . -create /Users/test'
     plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -20,7 +20,7 @@ platform 'osx-12-arm64' do |plat|
     plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
     plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
 
-    packages = %w[cmake pkg-config yaml-cpp]
+    packages = %w[automake cmake pkg-config yaml-cpp]
 
     plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 

--- a/configs/platforms/osx-12-x86_64.rb
+++ b/configs/platforms/osx-12-x86_64.rb
@@ -5,6 +5,7 @@ platform 'osx-12-x86_64' do |plat|
 
     plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
     plat.provision_with 'export HOMEBREW_VERBOSE=true'
+    plat.provision_with 'export HOMEBREW_NO_ANALYTICS=1'
 
     plat.provision_with 'sudo dscl . -create /Users/test'
     plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'

--- a/resources/patches/ruby_32/ruby-shadow-rbconfig.patch
+++ b/resources/patches/ruby_32/ruby-shadow-rbconfig.patch
@@ -16,7 +16,7 @@ index ac54233..55dcff5 100644
  $CFLAGS = case RUBY_VERSION
            when /^1\.9/; '-DRUBY19'
            when /^2\./; '-DRUBY19'
-+          when /^3\./; '-DRUBY19'
++          when /^3\./; '-DRUBY19 -fms-extensions'
            else; ''
            end
  

--- a/resources/patches/ruby_32/ruby-shadow-rbconfig.patch
+++ b/resources/patches/ruby_32/ruby-shadow-rbconfig.patch
@@ -16,7 +16,7 @@ index ac54233..55dcff5 100644
  $CFLAGS = case RUBY_VERSION
            when /^1\.9/; '-DRUBY19'
            when /^2\./; '-DRUBY19'
-+          when /^3\./; '-DRUBY19 -fms-extensions'
++          when /^3\./; RUBY_PLATFORM =~ /darwin/ ? '-DRUBY19 -fms-extensions' : '-DRUBY19'
            else; ''
            end
  


### PR DESCRIPTION
Building in https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1894/

- [x] el-7-x86_64
- [x] el-8-x86_64
- [x] el-8-ppc64le
- [x] el-8-aarch64
- [x] el-9-x86_64
- [x] debian-10-amd64
- [x] debian-11-amd64
- [x] fedora-36-x86_64
- [x] redhatfips-7-x86_64
- [x] redhatfips-8-x86_64
- [x] sles-12-x86_64
- [x] sles-15-x86_64
- [x] ubuntu-18.04-amd64
- [x] ubuntu-18.04-aarch64
- [x] ubuntu-20.04-amd64
- [x] ubuntu-20.04-aarch64
- [x] ubuntu-22.04-amd64