### PR TITLE
(PA-4845) Delete extra file

### DIFF
--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -13,5 +13,13 @@ component "rubygem-gettext" do |pkg, settings, platform|
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 
-  pkg.environment "GEM_HOME", (settings[:puppet_gem_vendor_dir] || settings[:gem_home])
+  gem_home = settings[:puppet_gem_vendor_dir] || settings[:gem_home]
+  pkg.environment "GEM_HOME", gem_home
+
+  case version
+  when '3.4.3'
+    install do
+      "rm -f #{gem_home}/gems/gettext-3.4.3/test/fixtures/gtk_builder_ui_definitions.ui~"
+    end
+  end
 end


### PR DESCRIPTION
The file breaks debian packaging and isn't part of the repo.

```
touch rubygem-gettext-configure
touch rubygem-gettext-build
touch rubygem-gettext-check
export GEM_HOME="/opt/puppetlabs/puppet/lib/ruby/vendor_gems" && \
export RUBYLIB="/opt/puppetlabs/puppet/lib/ruby/vendor_ruby:" && \
cd ./ && \
/opt/puppetlabs/puppet/bin/gem install --no-document --local gettext-3.4.3.gem && \
rm -f /opt/puppetlabs/puppet/lib/ruby/vendor_gems/gems/gettext-3.4.3/test/fixtures/gtk_builder_ui_definitions.ui~
Successfully installed gettext-3.4.3
1 gem installed
```