### PR TITLE
(PA-4845) Use full path to rm on Windows

### DIFF
--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -16,10 +16,12 @@ component "rubygem-gettext" do |pkg, settings, platform|
   gem_home = settings[:puppet_gem_vendor_dir] || settings[:gem_home]
   pkg.environment "GEM_HOME", gem_home
 
+  remove_file_command = platform.is_windows? ? '/usr/bin/rm' : 'rm'
+
   case version
   when '3.4.3'
     install do
-      "rm -f #{gem_home}/gems/gettext-3.4.3/test/fixtures/gtk_builder_ui_definitions.ui~"
+      "#{remove_file_command} -f #{gem_home}/gems/gettext-3.4.3/test/fixtures/gtk_builder_ui_definitions.ui~"
     end
   end
 end


### PR DESCRIPTION
Our Cygwin setup is a bit hacky, and the 'rm' command isn't found when vanagon is running it for some odd reason. This PR will use the full path if the platform is windows.