### PR TITLE
(PA-4815) Update installer runtime to support gettext versions

### DIFF
--- a/configs/projects/pe-installer-runtime-2019.8.x.rb
+++ b/configs/projects/pe-installer-runtime-2019.8.x.rb
@@ -70,6 +70,11 @@ project 'pe-installer-runtime-2019.8.x' do |proj|
   # puppet to have the same gems as the default puppet agent install.
   ########
 
+  # Pin back the gettext gems only in the 2019.8.x series to remain compatable with old ruby version
+  proj.setting :rubygem_fast_gettext_version, '1.1.2'
+  proj.setting :rubygem_gettext_version, '3.2.2'
+  proj.setting :rubygem_gettext_setup_version, '0.34'
+
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-components.rb'))
 
   # pl-build-tools

--- a/configs/projects/pe-installer-runtime-2021.7.x.rb
+++ b/configs/projects/pe-installer-runtime-2021.7.x.rb
@@ -97,6 +97,8 @@ project 'pe-installer-runtime-2021.7.x' do |proj|
   proj.component 'rubygem-httpclient'
   proj.component 'rubygem-thor'
   proj.component 'rubygem-sys-filesystem'
+  proj.component 'rubygem-prime'
+  proj.component 'rubygem-erubi'
 
   # What to include in package?
   proj.directory proj.prefix

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -97,6 +97,8 @@ project 'pe-installer-runtime-main' do |proj|
   proj.component 'rubygem-httpclient'
   proj.component 'rubygem-thor'
   proj.component 'rubygem-sys-filesystem'
+  proj.component 'rubygem-prime'
+  proj.component 'rubygem-erubi'
 
   # What to include in package?
   proj.directory proj.prefix


### PR DESCRIPTION
The 2019.8.x stream is pinned back to an older version of gettext and its dependencies to support the version of ruby shipped in the puppet 6 stream. Newer PE streams support running with the unpinned version. In order to support the newer configuration the `prime` rubygem is required. This commit adds the prime gem to installer runtime artifacts to support the new gettext version.