### PR TITLE
(PA-4869) Move to OpenSSL 3.0 on base linux platforms

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -1,0 +1,205 @@
+component 'openssl' do |pkg, settings, platform|
+  pkg.version '3.0.7'
+  pkg.sha256sum '83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e'
+  pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/openssl-#{pkg.get_version}.tar.gz"
+
+  #############################
+  # ENVIRONMENT, FLAGS, TARGETS
+  #############################
+
+  # make sure openssl-lib compiles first, as we it only installs versioned libs and hopefully will not cause problems
+  # the other way around caused: # error "Inconsistency between crypto.h and cryptlib.c"
+  if settings[:provide_ssllib] && platform.is_linux?
+    pkg.build_requires 'openssl-lib'
+  end
+
+  if platform.name =~ /^(el-|redhat-|fedora-)/
+    pkg.build_requires 'perl-core'
+  else
+    pkg.build_requires 'perl'
+  end
+
+  target = cflags = ldflags = sslflags = ''
+
+  # if platform.is_windows?
+  #   pkg.environment 'PATH', "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
+  #   pkg.environment 'CYGWIN', settings[:cygwin]
+  #   pkg.environment 'CC', settings[:cc]
+  #   pkg.environment 'CXX', settings[:cxx]
+  #   pkg.environment 'MAKE', platform[:make]
+
+  #   target = platform.architecture == 'x64' ? 'mingw64' : 'mingw'
+  #   cflags = settings[:cflags]
+  #   ldflags = settings[:ldflags]
+  # elsif platform.is_cross_compiled_linux?
+  #   pkg.environment 'PATH', "/opt/pl-build-tools/bin:$(PATH)"
+  #   pkg.environment 'CC', "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+
+  #   cflags = "#{settings[:cflags]} -fPIC"
+  #   if platform.architecture =~ /aarch/
+  #     # OpenSSL fails to work on aarch unless we turn down the compiler optimization.
+  #     # See PA-2135 for details
+  #     cflags += " -O2"
+  #   end
+
+  #   ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
+  #   target = if platform.architecture == 'aarch64'
+  #               'linux-aarch64'
+  #             elsif platform.name =~ /debian-8-arm/
+  #               'linux-armv4'
+  #             elsif platform.architecture =~ /ppc64le|ppc64el/ # Little-endian
+  #               'linux-ppc64le'
+  #             elsif platform.architecture =~ /ppc64/ # Big-endian
+  #               'linux-ppc64'
+  #             end
+  # elsif platform.is_aix?
+  #   pkg.environment 'CC', '/opt/pl-build-tools/bin/gcc'
+
+  #   cflags = '$${CFLAGS} -static-libgcc'
+  #   target = 'aix-gcc'
+  # elsif platform.is_solaris?
+  #   pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin'
+  #   pkg.environment 'CC', "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+
+  #   cflags = "#{settings[:cflags]} -fPIC"
+  #   ldflags = "-R/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
+  #   target = platform.architecture =~ /86/ ? 'solaris-x86-gcc' : 'solaris-sparcv9-gcc'
+  # elsif platform.is_macos?
+  #   pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
+
+  #   cflags = settings[:cflags]
+  #   target = if platform.is_cross_compiled?
+  #              'darwin64-arm64-cc'
+  #            else
+  #              'darwin64-x86_64-cc'
+  #            end
+  # elsif platform.is_linux?
+    pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
+
+    cflags = settings[:cflags]
+    ldflags = "#{settings[:ldflags]} -Wl,-z,relro"
+    if platform.architecture =~ /86$/
+      target = 'linux-elf'
+      sslflags = '386'
+    elsif platform.architecture =~ /aarch64$/
+      target = 'linux-aarch64'
+    elsif platform.architecture =~ /ppc64le|ppc64el/ # Little-endian
+      target = 'linux-ppc64le'
+    elsif platform.architecture =~ /64$/
+      target = 'linux-x86_64'
+    elsif platform.architecture == 'armhf'
+      target = 'linux-armv4'
+    end
+#  end
+
+  ####################
+  # BUILD REQUIREMENTS
+  ####################
+
+  pkg.build_requires "runtime-#{settings[:runtime_project]}"
+
+  ###########
+  # CONFIGURE
+  ###########
+
+  # if platform.is_solaris? && platform.name =~ /10/
+  #   # We need to link the rt library on Solaris 10 in order to access the clock_gettime
+  #   # function.
+  #   cflags += " -lrt"
+
+  #   # Additionally when we're building on SPARC, we need to revert
+  #   # https://github.com/openssl/openssl/commit/7a061312 because for
+  #   # some reason, the linker fails to generate the .map files (like
+  #   # e.g. libcrypto.map). Strangely, this is not an issue for Solaris
+  #   # 11 SPARC despite it using an older version of ld (2.25 vs. 2.27).
+  #   if platform.is_cross_compiled?
+  #     pkg.apply_patch 'resources/patches/openssl/openssl-1.1.1a-revert-7a061312.patch'
+  #   else
+  #     # Work around gcc not conforming to Solaris 32-bit ABI by expecting 16-byte stack alignment
+  #     # https://github.com/openssl/openssl/issues/13666
+  #     cflags += " -mincoming-stack-boundary=2"
+  #   end
+  # end
+
+  # OpenSSL 1.1.1q has a bug with a test not including a required library that caueses
+  # packing failures on macos. Probably safe to look at the 1.1.1r release to see if
+  # this can be removed.
+  # if platform.is_macos?
+  #   pkg.apply_patch 'resources/patches/openssl/openssl_1.1.1q_fix_c_include.patch'
+  # end
+
+  # OpenSSL Configure doesn't honor CFLAGS or LDFLAGS as environment variables.
+  # Instead, those should be passed to Configure at the end of its options, as
+  # any unrecognized options are passed straight through to ${CC}. Defining
+  # --libdir ensures that we avoid the multilib (lib/ vs. lib64/) problem,
+  # since configure uses the existence of a lib64 directory to determine
+  # if it should install its own libs into a multilib dir. Yay OpenSSL!
+  configure_flags = [
+    "--prefix=#{settings[:prefix]}",
+    '--libdir=lib',
+    "--openssldir=#{settings[:prefix]}/ssl",
+    'shared',
+    'no-asm',
+    target,
+    sslflags,
+    'no-camellia',
+    'no-ec2m',
+    'no-md2',
+    'no-ssl3'
+  ]
+
+  # Individual projects may provide their own openssl configure flags:
+  project_flags = settings[:openssl_extra_configure_flags] || []
+  perl_exec = ''
+  # if platform.is_aix?
+  #   perl_exec = '/opt/freeware/bin/perl'
+  # elsif platform.is_solaris? && platform.os_version == '10'
+  #   perl_exec = '/opt/csw/bin/perl'
+  # end
+  configure_flags << project_flags << cflags << ldflags
+
+  pkg.configure do
+    ["#{perl_exec} ./Configure #{configure_flags.join(' ')}"]
+  end
+
+  #######
+  # BUILD
+  #######
+
+  pkg.build do
+    [
+      "#{platform[:make]} depend",
+      "#{platform[:make]}"
+    ]
+  end
+
+  #########
+  # INSTALL
+  #########
+
+  install_prefix = platform.is_windows? ? '' : 'INSTALL_PREFIX=/'
+  install_commands = []
+
+  # if platform.is_aix?
+  #   install_commands << "slibclean"
+  # end
+
+  # Don't build all the docs for armhf
+  if  platform.architecture == 'armhf'
+    install_commands << "#{platform[:make]} #{install_prefix} install_sw install_ssldirs"
+  else
+    install_commands << "#{platform[:make]} #{install_prefix} install"
+  end
+
+  # if settings[:runtime_project] == 'pdk'
+  #   install_commands << "rm -f #{settings[:prefix]}/bin/{openssl,c_rehash}"
+  # end
+
+  pkg.install do
+    install_commands
+  end
+
+  pkg.install_file 'LICENSE.txt', "#{settings[:prefix]}/share/doc/openssl-#{pkg.get_version}/LICENSE"
+end
+

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -18,8 +18,15 @@ project 'agent-runtime-main' do |proj|
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-settings.rb'))
 
   ########
-  # Settings specific to the next branch
+  # Settings specific to this branch
   ########
+
+  case platform.name
+  when /^el-/, /^redhat-/, /^fedora-/, /^debian-/, /^ubuntu-/, /^sles-/
+    proj.setting(:openssl_version, '3.0')
+  else
+    # inherit default
+  end
 
   # Directory for gems shared by puppet and puppetserver
   proj.setting(:puppet_gem_vendor_dir, File.join(proj.libdir, "ruby", "vendor_gems"))


### PR DESCRIPTION
Adds OpenSSL 3.0.7 component

Switches agent-runtime-main on redhat, fedora, debian, ubuntu and sles to use
that version. redhatfips is unchanged as are other agent runtime projects.

I verified agent-runtime-66.x and agent-runtime-7.x are unaffected:

```
❯ bx rake vanagon:component_diff -- -P agent-runtime-7.x -f upstream/master -t HEAD
...
Here is what your code changes would affect:

Project agent-runtime-7.x
Nothing is affected 😊

❯ bx rake vanagon:component_diff -- -P agent-runtime-6.x -f upstream/master -t HEAD
...
Here is what your code changes would affect:

Project agent-runtime-6.x
Nothing is affected 😊
```

While `agent-runtime-main` is:

```
❯ bx rake vanagon:component_diff -- -P agent-runtime-main -f upstream/master -t HEAD
...
Here is what your code changes would affect:

Project agent-runtime-main

Platform name: el-7-x86_64
    Component 'openssl-1.1.1' was removed, not showing diff for it

    Component 'openssl-3.0' was newly added, not showing diff for it

    Component 'curl'
        Field: build_requires[0]
        --------------------
        - openssl-1.1.1
        + openssl-3.0


    Component 'puppet-ca-bundle'
        Field: build_requires[0]
        --------------------
        - openssl-1.1.1
        + openssl-3.0


    Component 'ruby-3.2.0'
        Field: build_requires[0]
        --------------------
        - openssl-1.1.1
        + openssl-3.0
```

~Blocked on https://github.com/puppetlabs/puppet-runtime/pull/621~

Building packages: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1895/

- [x] el-7-x86_64
- [x] el-8-x86_64
- [x] el-8-ppc64le
- [x] el-8-aarch64
- [x] el-9-x86_64
- [x] debian-10-amd64
- [x] debian-11-amd64
- [x] fedora-36-x86_64
- [x] redhatfips-7-x86_64
- [x] redhatfips-8-x86_64
- [x] sles-12-x86_64
- [x] sles-15-x86_64
- [x] ubuntu-18.04-amd64
- [x] ubuntu-18.04-aarch64
- [x] ubuntu-20.04-amd64
- [x] ubuntu-20.04-aarch64
- [x] ubuntu-22.04-amd64