### PR TITLE
(PA-4869) Revert openssl 3 bump for OSes with older cmake

### DIFF
--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -22,6 +22,8 @@ project 'agent-runtime-main' do |proj|
   ########
 
   case platform.name
+  when /^el-7-x86_64/, /^sles-12-x86_64/, /^ubuntu-18\.04-amd64/
+    # need cmake 3.24.0 or greater in order to detect openssl3, revisit in PA-4870
   when /^el-/, /^redhat-/, /^fedora-/, /^debian-/, /^ubuntu-/, /^sles-/
     proj.setting(:openssl_version, '3.0')
   else


### PR DESCRIPTION
openssl 3 changed their versioning scheme, so pxp-agent-vanagon builds on systems with older cmake weren't finding openssl correctly, see

https://github.com/Kitware/CMake/commit/4a6caef9d57f823cf0cfa9087ebe072d263d1b18

For now revert the openssl bump and revisit in PA-4870.