### PR TITLE
(PA-4875) Build OpenSSL 3 for macOS Intel & ARM

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -65,16 +65,16 @@ component 'openssl' do |pkg, settings, platform|
   #   cflags = "#{settings[:cflags]} -fPIC"
   #   ldflags = "-R/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
   #   target = platform.architecture =~ /86/ ? 'solaris-x86-gcc' : 'solaris-sparcv9-gcc'
-  # elsif platform.is_macos?
-  #   pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
+  if platform.is_macos?
+    pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
 
-  #   cflags = settings[:cflags]
-  #   target = if platform.is_cross_compiled?
-  #              'darwin64-arm64-cc'
-  #            else
-  #              'darwin64-x86_64-cc'
-  #            end
-  # elsif platform.is_linux?
+    cflags = settings[:cflags]
+    target = if platform.is_cross_compiled?
+               'darwin64-arm64'
+             else
+               'darwin64-x86_64'
+             end
+  elsif platform.is_linux?
     pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
 
     cflags = settings[:cflags]
@@ -91,7 +91,7 @@ component 'openssl' do |pkg, settings, platform|
     elsif platform.architecture == 'armhf'
       target = 'linux-armv4'
     end
-#  end
+  end
 
   ####################
   # BUILD REQUIREMENTS

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -23,7 +23,7 @@ project 'agent-runtime-main' do |proj|
 
   # Override OpenSSL version for select platforms. Eventually all platforms will support
   # it and we can remove the conditional
-  if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb?) && !platform.is_fips?
+  if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb? || platform.is_macos?) && !platform.is_fips?
     case platform.name
     when /^el-7-x86_64/, /^sles-12-x86_64/, /^ubuntu-18\.04-amd64/
       # need cmake 3.24.0 or greater in order to detect openssl3, revisit in PA-4870

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -21,13 +21,15 @@ project 'agent-runtime-main' do |proj|
   # Settings specific to this branch
   ########
 
-  case platform.name
-  when /^el-7-x86_64/, /^sles-12-x86_64/, /^ubuntu-18\.04-amd64/
-    # need cmake 3.24.0 or greater in order to detect openssl3, revisit in PA-4870
-  when /^el-/, /^redhat-/, /^fedora-/, /^debian-/, /^ubuntu-/, /^sles-/
-    proj.setting(:openssl_version, '3.0')
-  else
-    # inherit default
+  # Override OpenSSL version for select platforms. Eventually all platforms will support
+  # it and we can remove the conditional
+  if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb?) && !platform.is_fips?
+    case platform.name
+    when /^el-7-x86_64/, /^sles-12-x86_64/, /^ubuntu-18\.04-amd64/
+      # need cmake 3.24.0 or greater in order to detect openssl3, revisit in PA-4870
+    else
+      proj.setting(:openssl_version, '3.0')
+    end
   end
 
   # Directory for gems shared by puppet and puppetserver


### PR DESCRIPTION
- [x] osx-11-x86_64
- [x] osx-12-x86_64
- [x] osx-12-arm64

https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1906/

`osx-11-arm` and `osx-10.15-x86_64` are not supported in `agent-runtime-main` and can be ignored below.