### PR TITLE
(PA-4769) Redo pl-ruby-patch for Solaris

### DIFF
--- a/configs/components/pl-ruby-patch.rb
+++ b/configs/components/pl-ruby-patch.rb
@@ -47,8 +47,8 @@ component "pl-ruby-patch" do |pkg, settings, platform|
     end
 
     # make rubygems use our target rbconfig when installing gems
-    case base_ruby
-    when /^(2\.0|2\.1)/
+    case File.basename(base_ruby)
+    when '2.0.0', '2.1.0'
       sed_command = %(s|Gem.ruby|&, '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
     else
       sed_command = %(s|Gem.ruby.shellsplit|& << '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)


### PR DESCRIPTION
Commit 0ee61dced fixed cross compiling for macOS 12 ARM, but broke Solaris 10 & 11 SPARC, because `base_ruby` is a file path, not a version string. Since "/opt/pl-build-tools/lib/ruby/2.1.0" doesn't start with "2.1.0" we applied the wrong sed command on Solaris cross compiling.

Since the last component of `base_ruby` defines the ruby API as x.y.0, then match that string directly.

Built `agent-runtime-7.x` on macOS ARM and Solaris SPARC in https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1902/

The `vanagon component_diff` output below is misleading, because we don't support many of those platforms in `agent-runtime-main`, but we do in `agent-runtime-6.x`. So I rebuilt the latter on the affected platforms:

https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1903/

All passed except for `el-7-ppc64` (big endian), which is a dead platform and isn't supported in any stream.

I also confirmed that this PR restores the `pl-ruby-patch` component behavior to what it was in puppet-agentt 6.28.0 (puppet-runtime#202207130) as can be seen from this output (since the `pl-ruby-patch` component is omitted)

```
❯ bx rake vanagon:component_diff -- -P agent-runtime-6.x -f 202207130 -t HEAD -p el-7-ppc64le | grep Component
    Component 'curl'
    Component 'libxml2'
    Component 'libxslt'
    Component 'ruby-selinux'
    Component 'rubygem-fast_gettext'
    Component 'rubygem-gettext'
    Component 'rubygem-hiera-eyaml'
    Component 'rubygem-thor'

❯ bx rake vanagon:component_diff -- -P agent-runtime-6.x -f 202207130 -t HEAD -p el-7-aarch64 | grep Component
    Component 'curl'
    Component 'libxml2'
    Component 'libxslt'
    Component 'ruby-selinux'
    Component 'rubygem-fast_gettext'
    Component 'rubygem-gettext'
    Component 'rubygem-hiera-eyaml'
    Component 'rubygem-thor'

❯ bx rake vanagon:component_diff -- -P agent-runtime-6.x -f 202207130 -t HEAD -p sles-12-ppc64le | grep Component
    Component 'curl'
    Component 'libxml2'
    Component 'libxslt'
    Component 'rubygem-fast_gettext'
    Component 'rubygem-gettext'
    Component 'rubygem-hiera-eyaml'
    Component 'rubygem-thor'
```