### PR TITLE
(PA-4265) Remove c_rehash binary

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -196,6 +196,8 @@ component 'openssl' do |pkg, settings, platform|
   #   install_commands << "rm -f #{settings[:prefix]}/bin/{openssl,c_rehash}"
   # end
 
+  install_commands << "rm -f #{settings[:prefix]}/bin/c_rehash"
+
   pkg.install do
     install_commands
   end


### PR DESCRIPTION
c_rehash binary has been replaced by an openssl subcommand 'rehash'. The binary is still packaged and that can lead to some confusion since we add that to puppet-agent, so this will just remove the c_rehash binary.