### PR TITLE
(PA-4717) Ruby 3.2 for Windows x64 and x86

### DIFF
--- a/configs/components/libffi.rb
+++ b/configs/components/libffi.rb
@@ -21,6 +21,10 @@ component 'libffi' do |pkg, settings, platform|
       pkg.environment 'CC', 'clang -target arm64-apple-macos11' if platform.name =~ /osx-11/
       pkg.environment 'CC', 'clang -target arm64-apple-macos12' if platform.name =~ /osx-12/
     end
+  elsif platform.is_windows?
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
   else
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", settings[:cflags]

--- a/configs/components/libffi.rb
+++ b/configs/components/libffi.rb
@@ -25,6 +25,10 @@ component 'libffi' do |pkg, settings, platform|
     pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", settings[:cflags]
+
+    if platform.architecture == "x86"
+      pkg.apply_patch "resources/patches/libffi/revert_clang_32bit.patch"
+    end
   else
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", settings[:cflags]

--- a/configs/components/libyaml.rb
+++ b/configs/components/libyaml.rb
@@ -21,6 +21,10 @@ component 'libyaml' do |pkg, settings, platform|
       pkg.environment 'CC', 'clang -target arm64-apple-macos11' if platform.name =~ /osx-11/
       pkg.environment 'CC', 'clang -target arm64-apple-macos12' if platform.name =~ /osx-12/
     end
+  elsif platform.is_windows?
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
   else
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", settings[:cflags]

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -64,7 +64,6 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
   end
 
   if platform.is_windows?
- #   pkg.apply_patch "#{base}/windows_ruby_2.5_fixup_generated_batch_files.patch"
  #   pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
  #   pkg.apply_patch "#{base}/win32_long_paths_support.patch"
  #   pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
@@ -159,13 +158,13 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
   #########
 
   if platform.is_windows?
-    # With ruby 2.5, ruby will generate cmd files instead of bat files; These
-    # cmd wrappers work fine in our environment if they're just renamed as batch
-    # files. Rake is omitted here on purpose - it retains the old batch wrapper.
+    # Ruby 3.2 copies bin/gem to $ruby_bindir/gem.cmd, but generates bat files for
+    # other gems like bundle.bat, irb.bat, etc. Just rename the cmd.cmd to cmd.bat
+    # as we used to in ruby 2.7 and earlier.
     #
     # Note that this step must happen after the install step above.
     pkg.install do
-      %w{erb gem irb rdoc ri}.map do |name|
+      %w{gem}.map do |name|
         "mv #{ruby_bindir}/#{name}.cmd #{ruby_bindir}/#{name}.bat"
       end
     end

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -66,7 +66,6 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
   if platform.is_windows?
     pkg.apply_patch "#{base}/windows_mingw32_mkmf.patch"
  #   pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
- #   pkg.apply_patch "#{base}/win32_long_paths_support.patch"
  #   pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
  #   pkg.apply_patch "#{base}/windows_configure.patch"
   end

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -65,7 +65,7 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
 
   if platform.is_windows?
     pkg.apply_patch "#{base}/windows_mingw32_mkmf.patch"
- #   pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
+    pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
  #   pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
  #   pkg.apply_patch "#{base}/windows_configure.patch"
   end

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -111,7 +111,13 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
     # cygwin opensshd & bash. So mkmf will convert compiler paths, e.g. -IC:/... to
     # cygwin paths, -I/cygdrive/c/..., which confuses mingw-w64. So specify the build
     # target explicitly.
-    special_flags += " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g --build x86_64-w64-mingw32 "
+    special_flags += " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g "
+
+    if platform.architecture == "x64"
+      special_flags += " --build x86_64-w64-mingw32 "
+    else
+      special_flags += " --build i686-w64-mingw32 "
+    end
   end
 
   without_dtrace = [
@@ -221,7 +227,11 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
       rbconfig_changes["LDFLAGS"] = "-L. -Wl,-rpath=/opt/puppetlabs/puppet/lib -fstack-protector -rdynamic -Wl,-export-dynamic -L/opt/puppetlabs/puppet/lib"
     end
   elsif platform.is_windows?
-    rbconfig_changes["CC"] = "x86_64-w64-mingw32-gcc"
+    if platform.architecture == "x64"
+      rbconfig_changes["CC"] = "x86_64-w64-mingw32-gcc"
+    else
+      rbconfig_changes["CC"] = "i686-w64-mingw32-gcc"
+    end
   end
 
   pkg.add_source("file://resources/files/ruby_vendor_gems/operating_system.rb")

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -171,6 +171,9 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
         "mv #{ruby_bindir}/#{name}.cmd #{ruby_bindir}/#{name}.bat"
       end
     end
+
+    # Required when using `stack-protection-strong` and older versions of mingw-w64-gcc
+    pkg.install_file File.join(settings[:gcc_bindir], "libssp-0.dll"), File.join(settings[:bindir], "libssp-0.dll")
   end
 
   target_doubles = {

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -67,7 +67,6 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
     pkg.apply_patch "#{base}/windows_mingw32_mkmf.patch"
     pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
  #   pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
- #   pkg.apply_patch "#{base}/windows_configure.patch"
   end
 
   ####################

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -64,6 +64,7 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
   end
 
   if platform.is_windows?
+    pkg.apply_patch "#{base}/windows_mingw32_mkmf.patch"
  #   pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
  #   pkg.apply_patch "#{base}/win32_long_paths_support.patch"
  #   pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
@@ -108,7 +109,11 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
   elsif platform.name =~ /el-6/
     special_flags += " --with-baseruby=no "
   elsif platform.is_windows?
-    special_flags = " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
+    # ruby's configure script guesses the build host is `cygwin`, because we're using
+    # cygwin opensshd & bash. So mkmf will convert compiler paths, e.g. -IC:/... to
+    # cygwin paths, -I/cygdrive/c/..., which confuses mingw-w64. So specify the build
+    # target explicitly.
+    special_flags += " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g --build x86_64-w64-mingw32 "
   end
 
   without_dtrace = [

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -20,8 +20,8 @@ component "rubygem-ffi" do |pkg, settings, platform|
   rb_major_minor_version = settings[:ruby_version].to_f
 
   # Windows versions of the FFI gem have custom filenames, so we overwite the
-  # defaults that _base-rubygem provides here, just for Windows.
-  if platform.is_windows?
+  # defaults that _base-rubygem provides here, just for Windows for Ruby < 3.2
+  if platform.is_windows? && rb_major_minor_version < 3.2
     # Pin this if lower than Ruby 2.7
     pkg.version '1.9.25' if rb_major_minor_version < 2.7
 

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -17,12 +17,14 @@ component "rubygem-ffi" do |pkg, settings, platform|
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 
+  rb_major_minor_version = settings[:ruby_version].to_f
+
   # Windows versions of the FFI gem have custom filenames, so we overwite the
   # defaults that _base-rubygem provides here, just for Windows.
   if platform.is_windows?
     # Pin this if lower than Ruby 2.7
-    rb_minor_version = settings[:ruby_version].split('.')[1].to_i
-    pkg.version '1.9.25' if rb_minor_version < 7
+    pkg.version '1.9.25' if rb_major_minor_version < 2.7
+
     # Vanagon's `pkg.mirror` is additive, and the _base_rubygem sets the
     # non-Windows gem as the first mirror, which is incorrect. We need to unset
     # the list of mirrors before adding the Windows-appropriate ones here:

--- a/resources/patches/libffi/revert_clang_32bit.patch
+++ b/resources/patches/libffi/revert_clang_32bit.patch
@@ -1,0 +1,23 @@
+commit a70ab2d397bfbdb10ab3ba1f98321763105bc017
+Author: Josh Cooper <joshcooper@users.noreply.github.com>
+Date:   Tue Feb 7 17:33:09 2023 -0800
+
+    Revert "Allow to build with mingw-clang (#579)"
+    
+    This reverts commit 8cc8f446f5aac13e107161dffbc15d1ee1a58878.
+
+diff --git a/src/x86/sysv.S b/src/x86/sysv.S
+index c7a0fb5..26e7fea 100644
+--- a/src/x86/sysv.S
++++ b/src/x86/sysv.S
+@@ -56,8 +56,8 @@
+ 
+ /* Handle win32 fastcall name mangling.  */
+ #ifdef X86_WIN32
+-# define ffi_call_i386		"@ffi_call_i386@8"
+-# define ffi_closure_inner	"@ffi_closure_inner@8"
++# define ffi_call_i386		@ffi_call_i386@8
++# define ffi_closure_inner	@ffi_closure_inner@8
+ #else
+ # define ffi_call_i386		C(ffi_call_i386)
+ # define ffi_closure_inner	C(ffi_closure_inner)

--- a/resources/patches/ruby_32/windows_mingw32_mkmf.patch
+++ b/resources/patches/ruby_32/windows_mingw32_mkmf.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/mkmf.rb b/lib/mkmf.rb
+index 245b0a44ce..1481ec89d7 100644
+--- a/lib/mkmf.rb
++++ b/lib/mkmf.rb
+@@ -1948,7 +1948,7 @@ def mkintpath(path)
+         path.tr!('\\', '/')
+         path.sub!(/\A([A-Za-z]):(?=\/)/, '/\1')
+         path
+-      end
++      end if CONFIG['build_vendor'] == "w32"
+     when 'cygwin', 'msys'
+       if CONFIG['target_os'] != 'cygwin'
+         def mkintpath(path)

--- a/resources/patches/ruby_32/windows_nocodepage_utf8_fallback_r2.5.patch
+++ b/resources/patches/ruby_32/windows_nocodepage_utf8_fallback_r2.5.patch
@@ -1,0 +1,27 @@
+2010/05/13 - John O'Connor, Puppet Inc.
+
+This patch to Ruby is necessary to handle languages/regions on windows
+where the codepage is not supported by Ruby such as Arabic which uses 
+codepage 720.
+If the codepage is not found, the Locale falls back to UTF8.
+This is a well known Ruby/Ruby on Rails issue which is described at
+https://stackoverflow.com/questions/22815542/rails4-unknown-encoding-name-cp720
+---
+
+diff --git a/ext/win32/lib/win32/registry.rb b/ext/win32/lib/win32/registry.rb
+index ea04bb34bf..87c8f87614 100644
+--- a/ext/win32/lib/win32/registry.rb
++++ b/ext/win32/lib/win32/registry.rb
+@@ -69,7 +69,11 @@ module Win32
+   WCHAR_NUL = "\0".encode(WCHAR).freeze
+   WCHAR_CR = "\r".encode(WCHAR).freeze
+   WCHAR_SIZE = WCHAR_NUL.bytesize
+-  LOCALE = Encoding.find(Encoding.locale_charmap)
++  begin
++    LOCALE = Encoding.find(Encoding.locale_charmap)
++  rescue ArgumentError
++    LOCALE = Encoding::UTF_8
++  end
+ 
+   class Registry
+ 


### PR DESCRIPTION
* Adds gcc bin directory to PATH for libffi and libyaml
* Drops unneeded patches: `configure.ac`, `win32_long_paths_support`, `windows_ruby_2.5_fixup_generated_batch_files`
* Patch mkmf.rb to build native extensions using [mingw-w64](https://www.mingw-w64.org/) (instead of mingw)
* Fix how ffi gem was pinned on < 2.7
* Use latest ffi gem (1.15.5) and compile native extension `ffi_c`
* Install libssp-0.dll needed for gcc's stack protection
* Patch libffi 3.4.3 on Windows x86

Built x64 and x86 packages in https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1922/

I created a separate ticket (PA-4913) to add this CI (along with pxp-agent-vanagon, etc)