### PR TITLE
(CONT-550) Reject dh-autoreconf RHEL 9

### DIFF
--- a/configs/components/git.rb
+++ b/configs/components/git.rb
@@ -48,7 +48,7 @@ component "git" do |pkg, settings, platform|
     ]
   end
 
-  if platform.name == 'el-8-x86_64'
+  if platform.name == 'el-8-x86_64' || platform.name == 'el-9-x86_64'
     build_deps.reject! { |r| r == 'dh-autoreconf' }
   end
 


### PR DESCRIPTION
dh-autoreconf is rejected for RHEL 8 so this commit rejects it in RHEL 9 to fix failing pdk Jenkins jobs.