### PR TITLE
(PA-4911) Ruby 3.2 performance patches for Windows

### DIFF
--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -67,6 +67,7 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
     pkg.apply_patch "#{base}/windows_mingw32_mkmf.patch"
     pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
     pkg.apply_patch "#{base}/ruby-faster-load_32.patch"
+    pkg.apply_patch "#{base}/revert-ruby-double-load-symlink.patch"
   end
 
   ####################

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -66,7 +66,7 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
   if platform.is_windows?
     pkg.apply_patch "#{base}/windows_mingw32_mkmf.patch"
     pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
- #   pkg.apply_patch "#{base}/ruby-faster-load_27.patch"
+    pkg.apply_patch "#{base}/ruby-faster-load_32.patch"
   end
 
   ####################

--- a/resources/patches/ruby_32/revert-ruby-double-load-symlink.patch
+++ b/resources/patches/ruby_32/revert-ruby-double-load-symlink.patch
@@ -1,0 +1,180 @@
+commit a6360cc115e2560b701ec746681113813ad9ab16
+Author: Josh Cooper <joshcooper@users.noreply.github.com>
+Date:   Wed Feb 22 11:53:00 2023 -0800
+
+    Revert "Do not load file with same realpath twice when requiring"
+    
+    Commit 79a4484a072e9769b603e7b4fbdb15b1d7eccb15 results in many more calls to
+    `rb_realpath` when trying to load a file. On RHEL 7, it cause `puppet --version`
+    to generate about 5x more file syscalls (before 11k vs after 60k). However, on
+    platforms that provide the `realpath` syscall (as indicated by HAVE_REALPATH),
+    then the difference is not so noticable.
+    
+    However, platforms like Windows don't HAVE_REALPATH. Instead ruby emulates it
+    by walking each ancestor directory. See the `rb_check_realpath_emulate`
+    function. This causes a significant performation issue, increasing Win32 API
+    calls from 48k to 366k, so nearly 10x.
+    
+    The problem is made worse due to Puppet's deeply nested installation directory:
+    
+        C:\Program Files\Puppet Labs\Puppet\puppet\lib\ruby\...
+    
+    I think the additional file IO occurs, because `require_internal` calls
+    `rb_realpath_internal` for each file it's about to require and checks if the
+    realpath has already been required or not. And `get_loaded_features_index` calls
+    `rb_check_realpath` when rebuilding the `loaded_features` hash.
+    
+    The bug the original commit fixes occurs when requiring files through a symlink,
+    which is very unlikely on Windows, so revert it.
+
+diff --git a/load.c b/load.c
+index 282bebdb62..636a124d03 100644
+--- a/load.c
++++ b/load.c
+@@ -157,12 +157,6 @@ get_loaded_features(rb_vm_t *vm)
+     return vm->loaded_features;
+ }
+ 
+-static VALUE
+-get_loaded_features_realpaths(rb_vm_t *vm)
+-{
+-    return vm->loaded_features_realpaths;
+-}
+-
+ static VALUE
+ get_LOADED_FEATURES(ID _x, VALUE *_y)
+ {
+@@ -360,8 +354,6 @@ get_loaded_features_index(rb_vm_t *vm)
+            modified loaded_features.  Rebuild the index. */
+         st_foreach(vm->loaded_features_index, loaded_features_index_clear_i, 0);
+ 
+-        VALUE realpaths = vm->loaded_features_realpaths;
+-        rb_hash_clear(realpaths);
+         features = vm->loaded_features;
+         for (i = 0; i < RARRAY_LEN(features); i++) {
+             VALUE entry, as_str;
+@@ -373,15 +365,6 @@ get_loaded_features_index(rb_vm_t *vm)
+             features_index_add(vm, as_str, INT2FIX(i));
+         }
+         reset_loaded_features_snapshot(vm);
+-
+-        features = rb_ary_dup(vm->loaded_features_snapshot);
+-        long j = RARRAY_LEN(features);
+-        for (i = 0; i < j; i++) {
+-            VALUE as_str = rb_ary_entry(features, i);
+-            VALUE realpath = rb_check_realpath(Qnil, as_str, NULL);
+-            if (NIL_P(realpath)) realpath = as_str;
+-            rb_hash_aset(realpaths, rb_fstring(realpath), Qtrue);
+-        }
+     }
+     return vm->loaded_features_index;
+ }
+@@ -1158,8 +1141,6 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception, bool wa
+     char *volatile ftptr = 0;
+     VALUE path;
+     volatile VALUE saved_path;
+-    volatile VALUE realpath = 0;
+-    VALUE realpaths = get_loaded_features_realpaths(th->vm);
+     volatile bool reset_ext_config = false;
+     struct rb_ext_config prev_ext_config;
+ 
+@@ -1192,10 +1173,6 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception, bool wa
+                 result = TAG_RETURN;
+             }
+ #endif
+-            else if (RTEST(rb_hash_aref(realpaths,
+-                                        realpath = rb_realpath_internal(Qnil, path, 1)))) {
+-                result = 0;
+-            }
+             else {
+                 switch (found) {
+                   case 'r':
+@@ -1249,10 +1226,6 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception, bool wa
+ 
+     if (result == TAG_RETURN) {
+         rb_provide_feature(th2->vm, path);
+-        VALUE real = realpath;
+-        if (real) {
+-            rb_hash_aset(realpaths, rb_fstring(real), Qtrue);
+-        }
+     }
+     ec->errinfo = saved.errinfo;
+ 
+@@ -1470,8 +1443,6 @@ Init_load(void)
+     vm->loaded_features = rb_ary_new();
+     vm->loaded_features_snapshot = rb_ary_hidden_new(0);
+     vm->loaded_features_index = st_init_numtable();
+-    vm->loaded_features_realpaths = rb_hash_new();
+-    rb_obj_hide(vm->loaded_features_realpaths);
+ 
+     rb_define_global_function("load", rb_f_load, -1);
+     rb_define_global_function("require", rb_f_require, 1);
+diff --git a/test/ruby/test_require.rb b/test/ruby/test_require.rb
+index 604ddf09d8..6ffa1eaa1f 100644
+--- a/test/ruby/test_require.rb
++++ b/test/ruby/test_require.rb
+@@ -466,32 +466,6 @@ def test_relative_symlink
+     }
+   end
+ 
+-  def test_relative_symlink_realpath
+-    Dir.mktmpdir {|tmp|
+-      Dir.chdir(tmp) {
+-        Dir.mkdir "a"
+-        File.open("a/a.rb", "w") {|f| f.puts 'require_relative "b"' }
+-        File.open("a/b.rb", "w") {|f| f.puts '$t += 1' }
+-        Dir.mkdir "b"
+-        File.binwrite("c.rb", <<~RUBY)
+-          $t = 0
+-          $:.unshift(File.expand_path('../b', __FILE__))
+-          require "b"
+-          require "a"
+-          print $t
+-        RUBY
+-        begin
+-          File.symlink("../a/a.rb", "b/a.rb")
+-          File.symlink("../a/b.rb", "b/b.rb")
+-          result = IO.popen([EnvUtil.rubybin, "c.rb"], &:read)
+-          assert_equal("1", result, "bug17885 [ruby-core:104010]")
+-        rescue NotImplementedError, Errno::EACCES
+-          omit "File.symlink is not implemented"
+-        end
+-      }
+-    }
+-  end
+-
+   def test_frozen_loaded_features
+     bug3756 = '[ruby-core:31913]'
+     assert_in_out_err(['-e', '$LOADED_FEATURES.freeze; require "ostruct"'], "",
+diff --git a/vm.c b/vm.c
+index 4c2ef9834e..4fa4ec2b54 100644
+--- a/vm.c
++++ b/vm.c
+@@ -2702,7 +2702,6 @@ rb_vm_update_references(void *ptr)
+         vm->expanded_load_path = rb_gc_location(vm->expanded_load_path);
+         vm->loaded_features = rb_gc_location(vm->loaded_features);
+         vm->loaded_features_snapshot = rb_gc_location(vm->loaded_features_snapshot);
+-        vm->loaded_features_realpaths = rb_gc_location(vm->loaded_features_realpaths);
+         vm->top_self = rb_gc_location(vm->top_self);
+         vm->orig_progname = rb_gc_location(vm->orig_progname);
+ 
+@@ -2793,7 +2792,6 @@ rb_vm_mark(void *ptr)
+         rb_gc_mark_movable(vm->expanded_load_path);
+         rb_gc_mark_movable(vm->loaded_features);
+         rb_gc_mark_movable(vm->loaded_features_snapshot);
+-        rb_gc_mark_movable(vm->loaded_features_realpaths);
+         rb_gc_mark_movable(vm->top_self);
+         rb_gc_mark_movable(vm->orig_progname);
+         RUBY_MARK_MOVABLE_UNLESS_NULL(vm->coverages);
+diff --git a/vm_core.h b/vm_core.h
+index 4f6e07d818..6b9cfca2cd 100644
+--- a/vm_core.h
++++ b/vm_core.h
+@@ -679,7 +679,6 @@ typedef struct rb_vm_struct {
+     VALUE expanded_load_path;
+     VALUE loaded_features;
+     VALUE loaded_features_snapshot;
+-    VALUE loaded_features_realpaths;
+     struct st_table *loaded_features_index;
+     struct st_table *loading_table;
+ #if EXTSTATIC

--- a/resources/patches/ruby_32/ruby-faster-load_32.patch
+++ b/resources/patches/ruby_32/ruby-faster-load_32.patch
@@ -1,0 +1,13 @@
+diff --git a/load.c b/load.c
+index 282bebdb62..f7b257508e 100644
+--- a/load.c
++++ b/load.c
+@@ -688,7 +688,7 @@ load_iseq_eval(rb_execution_context_t *ec, VALUE fname)
+         rb_parser_set_context(parser, NULL, FALSE);
+         ast = (rb_ast_t *)rb_parser_load_file(parser, fname);
+         iseq = rb_iseq_new_top(&ast->body, rb_fstring_lit("<top (required)>"),
+-                               fname, rb_realpath_internal(Qnil, fname, 1), NULL);
++                               fname, fname, NULL);
+         rb_ast_dispose(ast);
+         rb_vm_pop_frame(ec);
+         RB_GC_GUARD(v);


### PR DESCRIPTION
Applies the faster-load patch on Windows that we're using with Ruby 2.7

Revert an upstream commit (Windows only). The commit prevented a double load when a file is loaded through a symlink, but that situation is extremely rare for us, so revert until the upstream issue is resolved, see https://bugs.ruby-lang.org/issues/19378.

With both patches, `puppet apply -e 'notice($puppetversion)'` generates 36x fewer file IO calls than ruby 3.2.0 built via rubyinstaller.

Built agent-runtime-main and all tests passed for windows-2019 (64-bit) and windows 10 (32-bit) except for unrelated forge cert issue https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1081/

I confirmed the forge failures are unrelated to my changes.