### PR TITLE
(CONT-550) Prep PDK for RHEL9

### DIFF
--- a/configs/components/git.rb
+++ b/configs/components/git.rb
@@ -48,7 +48,7 @@ component "git" do |pkg, settings, platform|
     ]
   end
 
-  if platform.name == 'el-8-x86_64'
+  if platform.name == 'el-8-x86_64' || platform.name == 'el-9-x86_64'
     build_deps.reject! { |r| r == 'dh-autoreconf' }
   end
 

--- a/configs/platforms/el-9-x86_64.rb
+++ b/configs/platforms/el-9-x86_64.rb
@@ -15,4 +15,5 @@ platform "el-9-x86_64" do |plat|
     zlib-devel
   )
   plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
+  plat.provision_with("sed -i 's/beta-x86_64\/baseos\/x86_64/base/' /etc/yum.repos.d/localmirror-baseos.repo; sed -i 's/beta-x86_64\/appstream\/x86_64/appstream/' /etc/yum.repos.d/localmirror-appstream.repo")
 end

--- a/configs/platforms/el-9-x86_64.rb
+++ b/configs/platforms/el-9-x86_64.rb
@@ -1,12 +1,30 @@
 platform "el-9-x86_64" do |plat|
-  plat.inherit_from_default
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  # Temporary fix until new rhel 9 image is built
+  plat.provision_with("sed -i 's/beta-x86_64\\/baseos\\/x86_64/base/' /etc/yum.repos.d/localmirror-baseos.repo; sed -i 's/beta-x86_64\\/appstream\\/x86_64/appstream/' /etc/yum.repos.d/localmirror-appstream.repo")
 
   packages = %w(
+    gcc
+    gcc-c++
+    autoconf
+    automake
+    createrepo
+    rsync
+    cmake
+    make
+    rpm-libs
+    rpm-build
+    rpm-sign
+    libtool
+    libarchive
     java-1.8.0-openjdk-devel
     libsepol
     libsepol-devel
     libselinux-devel
-    pkgconfig 
+    pkgconfig
     readline-devel
     rpmdevtools
     swig
@@ -14,6 +32,9 @@ platform "el-9-x86_64" do |plat|
     yum-utils
     zlib-devel
   )
-  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
-  plat.provision_with("sed -i 's/beta-x86_64\/baseos\/x86_64/base/' /etc/yum.repos.d/localmirror-baseos.repo; sed -i 's/beta-x86_64\/appstream\/x86_64/appstream/' /etc/yum.repos.d/localmirror-appstream.repo")
+
+  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
+  plat.install_build_dependencies_with "dnf install -y --allowerasing "
+  plat.vmpooler_template "redhat-9-x86_64"
 end
+


### PR DESCRIPTION
Prior to this change, puppet-runtime would fail to build due package installation failures.

Specifically, the expat-devel package failed to install because it did not exist on our mirror. 

This change makes use of a newly created repo with all of the packages needed to build puppet-runtime.

Additionally dh-autoreconf is also removed as a dependency as per RHEL8