### PR TITLE
(PA-5016) Bump CFPropertyList to 3.0.6 for Ruby 3.2

### DIFF
--- a/configs/components/rubygem-CFPropertyList.rb
+++ b/configs/components/rubygem-CFPropertyList.rb
@@ -1,6 +1,11 @@
 component 'rubygem-CFPropertyList' do |pkg, settings, platform|
-  pkg.version '2.3.6'
-  pkg.md5sum 'ae4086185992f293ffab1641b83286a5'
+  if settings[:ruby_version].to_f >= 3.2
+    pkg.version '3.0.6'
+    pkg.md5sum 'a10c1a40d093160f7264c0985b89881d'
+  else
+    pkg.version '2.3.6'
+    pkg.md5sum 'ae4086185992f293ffab1641b83286a5'
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
   pkg.environment "GEM_HOME", (settings[:puppet_gem_vendor_dir] || settings[:gem_home])


### PR DESCRIPTION
`CFPropertyList` versions < 3.0.6 have a `File.exists?` [call](https://github.com/ckruse/CFPropertyList/commit/6afb06fbc11b225477846197e5bfd3d582e204b0) but `File.exists?` was deprecated and removed in Ruby 3.2. Since Ruby 3.2 is used for Puppet 8, this causes issues for macOS 11 and 12 which use the CFPropertyList gem. This commit bumps `CFPropertyList` to 3.0.6 for the agent-runtime-main project which uses Ruby 3.2.