### PR TITLE
(PA-4945) Install default and bundled gems for macOS 12 ARM cross compiles

### DIFF
--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -42,7 +42,7 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
 #      pkg.apply_patch "#{base}/Replace-reference-to-RUBY-var-with-opt-pl-build-tool.patch"
     end
 
- #   pkg.apply_patch "#{base}/rbinstall_gem_path.patch"
+    pkg.apply_patch "#{base}/rbinstall_gem_path.patch"
  #   pkg.apply_patch "#{base}/revert_host_value_changes.patch"
   end
 

--- a/configs/components/ruby-3.2.0.rb
+++ b/configs/components/ruby-3.2.0.rb
@@ -39,14 +39,6 @@ component 'ruby-3.2.0' do |pkg, settings, platform|
 
   if platform.is_cross_compiled?
     unless platform.is_macos?
-#      pkg.apply_patch "#{base}/uri_generic_remove_safe_nav_operator_r2.5.patch"
-#      pkg.apply_patch "#{base}/lib_optparse_remove_safe_nav_operator.patch"
-#      pkg.apply_patch "#{base}/revert_delete_prefix.patch"
-#      pkg.apply_patch "#{base}/remove_squiggly_heredocs.patch"
-#      pkg.apply_patch "#{base}/remove_deprecate_constant_statements.patch"
-#      pkg.apply_patch "#{base}/ruby2_keywords_guard.patch"
-#      pkg.apply_patch "#{base}/ruby_version_extra_guards.patch"
-#      pkg.apply_patch "#{base}/ruby_20_guards.patch"
 #      pkg.apply_patch "#{base}/Replace-reference-to-RUBY-var-with-opt-pl-build-tool.patch"
     end
 

--- a/resources/patches/ruby_32/rbinstall_gem_path.patch
+++ b/resources/patches/ruby_32/rbinstall_gem_path.patch
@@ -1,0 +1,22 @@
+diff --git a/tool/rbinstall.rb b/tool/rbinstall.rb
+index f910fca57b..8eebd3f522 100755
+--- a/tool/rbinstall.rb
++++ b/tool/rbinstall.rb
+@@ -942,7 +942,7 @@ def load_gemspec(file, base = nil)
+ end
+ 
+ def install_default_gem(dir, srcdir, bindir)
+-  gem_dir = Gem.default_dir
++  gem_dir = "/opt/puppetlabs/puppet/lib/ruby/gems/3.2.0"
+   install_dir = with_destdir(gem_dir)
+   prepare "default gems from #{dir}", gem_dir
+   RbInstall.no_write do
+@@ -991,7 +991,7 @@ def install_default_gem(dir, srcdir, bindir)
+ end
+ 
+ install?(:ext, :comm, :gem, :'bundled-gems') do
+-  gem_dir = Gem.default_dir
++  gem_dir = "/opt/puppetlabs/puppet/lib/ruby/gems/3.2.0"
+   install_dir = with_destdir(gem_dir)
+   prepare "bundled gems", gem_dir
+   RbInstall.no_write do


### PR DESCRIPTION
`CFPropertyList` failed to load because `nokogiri` depended on `racc`, but the default `racc` gem was copied to the wrong gem dir when cross-compiling. With this change, on macOS 12 ARM:

```
# /opt/puppetlabs/puppet/bin/ruby -e 'puts require "CFPropertyList"'
true
# /opt/puppetlabs/puppet/bin/gem list

*** LOCAL GEMS ***

abbrev (default: 0.1.1)
base64 (default: 0.1.1)
benchmark (default: 0.2.1)
bigdecimal (default: 3.1.3)
bundler (default: 2.4.1)
CFPropertyList (2.3.6)
cgi (default: 0.3.6)
concurrent-ruby (1.1.9)
csv (default: 3.2.6)
date (default: 3.3.3)
debug (1.7.1)
deep_merge (1.2.2)
delegate (default: 0.3.0)
did_you_mean (default: 1.6.3)
digest (default: 3.1.1)
drb (default: 2.1.1)
english (default: 0.7.2)
erb (default: 4.0.2)
error_highlight (default: 0.5.1)
erubi (1.11.0)
etc (default: 1.4.2)
fast_gettext (2.2.0)
fcntl (default: 1.0.2)
ffi (1.15.5)
fiddle (default: 1.1.1)
fileutils (default: 1.7.0)
find (default: 0.1.1)
forwardable (default: 1.3.3)
getoptlong (default: 0.2.0)
gettext (3.4.3)
hiera-eyaml (3.3.0)
highline (2.0.3)
hocon (1.3.1)
io-console (default: 0.6.0)
io-nonblock (default: 0.2.0)
io-wait (default: 0.3.0)
ipaddr (default: 1.2.5)
irb (default: 1.6.2)
json (default: 2.6.3)
locale (2.1.3)
logger (default: 1.5.3)
matrix (0.4.2)
mini_portile2 (2.8.0)
minitest (5.16.3)
multi_json (1.15.0)
mutex_m (default: 0.1.2)
net-ftp (0.2.0)
net-http (default: 0.3.2)
net-imap (0.3.4)
net-pop (0.1.2)
net-protocol (default: 0.2.1)
net-smtp (0.3.3)
net-ssh (4.2.0)
nkf (default: 0.1.2)
nokogiri (1.13.10)
observer (default: 0.1.1)
open-uri (default: 0.3.0)
open3 (default: 0.1.2)
openssl (default: 3.1.0)
optimist (3.0.1)
optparse (default: 0.3.1)
ostruct (default: 0.5.5)
pathname (default: 0.2.1)
power_assert (2.0.3)
pp (default: 0.4.0)
prettyprint (default: 0.1.1)
prime (0.1.2)
pstore (default: 0.1.2)
psych (default: 5.0.1)
racc (default: 1.6.2)
rake (13.0.6)
rbs (2.8.2)
rdoc (default: 6.5.0)
readline (default: 0.0.3)
readline-ext (default: 0.1.5)
reline (default: 0.3.2)
resolv (default: 0.2.2)
resolv-replace (default: 0.1.1)
rexml (3.2.5)
rinda (default: 0.1.1)
rss (0.2.9)
ruby2_keywords (default: 0.0.5)
scanf (1.0.0)
securerandom (default: 0.2.2)
semantic_puppet (1.0.4)
set (default: 1.0.3)
shellwords (default: 0.1.0)
singleton (default: 0.1.1)
stringio (default: 3.0.4)
strscan (default: 3.0.5)
syntax_suggest (default: 1.0.2)
sys-filesystem (1.4.1)
syslog (default: 0.1.1)
tempfile (default: 0.1.3)
test-unit (3.5.7)
text (1.3.1)
thor (1.2.1)
time (default: 0.2.1)
timeout (default: 0.3.1)
tmpdir (default: 0.1.3)
tsort (default: 0.1.1)
typeprof (0.21.3)
un (default: 0.2.1)
uri (default: 0.12.0)
weakref (default: 0.1.2)
yaml (default: 0.2.1)
zlib (default: 3.0.0)
```