### PR TITLE
(PA-4908) Drop openssl man and html docs

### DIFF
--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -179,12 +179,8 @@ component 'openssl' do |pkg, settings, platform|
     install_commands << "slibclean"
   end
 
-  # Don't build all the docs for armhf
-  if  platform.architecture == 'armhf'
-    install_commands << "#{platform[:make]} #{install_prefix} install_sw install_ssldirs"
-  else
-    install_commands << "#{platform[:make]} #{install_prefix} install"
-  end
+  # Skip man and html docs
+  install_commands << "#{platform[:make]} #{install_prefix} install_sw install_ssldirs"
 
   if settings[:runtime_project] == 'pdk'
     install_commands << "rm -f #{settings[:prefix]}/bin/{openssl,c_rehash}"

--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -185,12 +185,8 @@ component 'openssl' do |pkg, settings, platform|
   #   install_commands << "slibclean"
   # end
 
-  # Don't build all the docs for armhf
-  if  platform.architecture == 'armhf'
-    install_commands << "#{platform[:make]} #{install_prefix} install_sw install_ssldirs"
-  else
-    install_commands << "#{platform[:make]} #{install_prefix} install"
-  end
+  # Skip man and html docs
+  install_commands << "#{platform[:make]} #{install_prefix} install_sw install_ssldirs"
 
   # if settings[:runtime_project] == 'pdk'
   #   install_commands << "rm -f #{settings[:prefix]}/bin/{openssl,c_rehash}"


### PR DESCRIPTION
man and html docs accounted for 13MB uncompressed and a surprising amount of
build time because the build runs pod2man and perl twice for each doc. OpenSSL
doesn't have a `--no-docs` option, so follow what other projects do to avoid
building/installing docs, like ruby-setup.

This change affects all runtime projects and platforms except those using
openssl-1.1-fips, because the fips version doesn't have the `install_ssldir`
Makefile target.

I built agent-runtime-main in https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1961/ except for redhatfips-* so I removed them from this PR.

RHEL9 build times dropped from 26 to 19 mins.