### PR TITLE
(packaging) Experiment with building pe-bolt-server with ruby3/puppet8

### DIFF
--- a/configs/components/rubygem-addressable.rb
+++ b/configs/components/rubygem-addressable.rb
@@ -1,6 +1,6 @@
 component 'rubygem-addressable' do |pkg, _settings, _platform|
-  pkg.version '2.8.0'
-  pkg.md5sum '9cd03fc88dd69b3c3491ce73de27f2f7'
+  pkg.version '2.8.1'
+  pkg.md5sum '64cb545a6ddcfc93c68fe53ac594c5f7'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.616.0"
-  pkg.md5sum "91f875b15708a1d4abdfab97b5d948f3"
+  pkg.version "1.719.0"
+  pkg.md5sum "6afc4d3a69986cea5f6df5349a63331c"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.132.0"
-  pkg.md5sum "fc1e372ee8b41c01fd55eddc016ce900"
+  pkg.version "3.170.0"
+  pkg.md5sum "0c8b3c6bda23b265c2aa09b7212326bb"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.326.0"
-  pkg.md5sum "6a50657e534e0bd3dabe8829f8329320"
+  pkg.version "1.367.0"
+  pkg.md5sum "71b2517cb4d8c3c05a5597ba6424b7a2"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sigv4.rb
+++ b/configs/components/rubygem-aws-sigv4.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sigv4" do |pkg, settings, platform|
-  pkg.version "1.5.1"
-  pkg.md5sum "2d780098958551cf9ffa6f3e7f42efb4"
+  pkg.version "1.5.2"
+  pkg.md5sum "ade83c69138704ccf1a4f765f9926985"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-bindata.rb
+++ b/configs/components/rubygem-bindata.rb
@@ -1,6 +1,6 @@
 component 'rubygem-bindata' do |pkg, settings, platform|
-  pkg.version '2.4.10'
-  pkg.md5sum 'cf67b5b16c307139691d6cbec0c8c2ef'
+  pkg.version '2.4.15'
+  pkg.md5sum '55ccdea22d70273b136e573dba9b97cf'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-concurrent-ruby.rb
+++ b/configs/components/rubygem-concurrent-ruby.rb
@@ -1,6 +1,6 @@
 component 'rubygem-concurrent-ruby' do |pkg, settings, platform|
-  pkg.version '1.1.9'
-  pkg.md5sum '417a23cac840f6ea8bdd0841429c3c19'
+  pkg.version '1.1.10'
+  pkg.md5sum '4588a61d5af26e9ee12e9b8babc1b755'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-connection_pool.rb
+++ b/configs/components/rubygem-connection_pool.rb
@@ -1,6 +1,6 @@
 component 'rubygem-connection_pool' do |pkg, settings, platform|
-  pkg.version '2.2.5'
-  pkg.md5sum '498bdfe245ece1c2025fd3727a3dc7e3'
+  pkg.version '2.3.0'
+  pkg.md5sum 'bbbbc0e38de79db9f0cb2907c81204a4'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-ed25519.rb
+++ b/configs/components/rubygem-ed25519.rb
@@ -1,6 +1,6 @@
 component 'rubygem-ed25519' do |pkg, _settings, _platform|
-  pkg.version '1.2.4'
-  pkg.md5sum 'ba27e98736828152d900dd14b429fc27'
+  pkg.version '1.3.0'
+  pkg.md5sum 'd810e3aa82d0a0fb9b9d7ca6146121e4'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-erubi.rb
+++ b/configs/components/rubygem-erubi.rb
@@ -1,6 +1,6 @@
 component 'rubygem-erubi' do |pkg, settings, platform|
-  pkg.version '1.11.0'
-  pkg.md5sum '42f1f27ca9b70754f1eee09b761d5672'
+  pkg.version '1.12.0'
+  pkg.md5sum '92fa9ac9f48cce608153108e327d020d'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '4.2.11'
-  pkg.md5sum '5a387c10f5917d88b46cacd5da2de6f1'
+  pkg.version '4.3.0'
+  pkg.md5sum 'aef369eddbda0a53790b07ceea30449e'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-faraday.rb
+++ b/configs/components/rubygem-faraday.rb
@@ -1,6 +1,6 @@
 component 'rubygem-faraday' do |pkg, settings, platform|
-  pkg.version '1.10.1'
-  pkg.md5sum '4fe172f807c117441cc5d38d8b49a526'
+  pkg.version '1.10.3'
+  pkg.md5sum 'c7b56130721c0b055c071bec593e2446'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -1,10 +1,10 @@
 component "rubygem-fast_gettext" do |pkg, settings, platform|
-  version = settings[:rubygem_fast_gettext_version] || '2.2.0'
+  version = settings[:rubygem_fast_gettext_version] || '2.3.0'
   pkg.version version
 
   case version
-  when '2.2.0'
-    pkg.sha256sum '01804331afce7b7c918e7ebe1951a3507b24b3a0c0617429725dbd4a2f234ad8'
+  when '2.3.0'
+    pkg.sha256sum '0253e26423ccab68061c42387827e3b99243a1b15ad614df1c800ba870d64f84'
   when '1.1.2'
     pkg.sha256sum 'e868f02c24af746a137f3aaf898ca3660e6611aa7f1f96ce60e9a425130f2732'
   else

--- a/configs/components/rubygem-highline.rb
+++ b/configs/components/rubygem-highline.rb
@@ -1,6 +1,6 @@
 component 'rubygem-highline' do |pkg, settings, _platform|
-  pkg.version '2.0.3'
-  pkg.md5sum 'be63a46ed7eabcae9a4cf53032dba5bc'
+  pkg.version '2.1.0'
+  pkg.md5sum '4209083bda845d47dcc05b7ab23f25fd'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 

--- a/configs/components/rubygem-jmespath.rb
+++ b/configs/components/rubygem-jmespath.rb
@@ -1,6 +1,6 @@
 component "rubygem-jmespath" do |pkg, settings, platform|
-  pkg.version "1.6.1"
-  pkg.md5sum "3c84a5f234039163185a7ec31c628d0f"
+  pkg.version "1.6.2"
+  pkg.md5sum "fdd62edafbd40171f976a53ab349ae9e"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-multipart-post.rb
+++ b/configs/components/rubygem-multipart-post.rb
@@ -1,6 +1,6 @@
 component 'rubygem-multipart-post' do |pkg, settings, platform|
-  pkg.version '2.2.3'
-  pkg.md5sum 'ebcd6ee70446d58c85ceb926f664a883'
+  pkg.version '2.3.0'
+  pkg.md5sum '067cd7270a1f476ce71454d499213671'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -4,8 +4,8 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.version version
 
   case version
-  when "6.1.0"
-    pkg.md5sum "383afadb1bd66a458a5d8d2d60736b3d"
+  when "7.0.1"
+    pkg.md5sum "a97dcd90f88ec481fdf81b53cfc93285"
   when "5.2.0"
     pkg.md5sum "341114b3bf34257abd3b11bd16b0c99d"
   when "4.2.0"

--- a/configs/components/rubygem-public_suffix.rb
+++ b/configs/components/rubygem-public_suffix.rb
@@ -1,6 +1,6 @@
 component 'rubygem-public_suffix' do |pkg, _settings, _platform|
-  pkg.version '4.0.7'
-  pkg.md5sum '060e68307f51276ee6750c05c14d7c2d'
+  pkg.version '5.0.1'
+  pkg.md5sum '504e45c1f5f7b629e46e4deef7d0f46f'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet-strings.rb
+++ b/configs/components/rubygem-puppet-strings.rb
@@ -1,6 +1,6 @@
 component 'rubygem-puppet-strings' do |pkg, settings, platform|
-  pkg.version '2.9.0'
-  pkg.md5sum '3016a0b9cc1cc94a35e0c4869d8b13ec'
+  pkg.version '3.0.1'
+  pkg.md5sum '7c9a8936509a0434c39975a75197472c'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,6 +1,6 @@
 component 'rubygem-r10k' do |pkg, settings, platform|
-  pkg.version '3.15.3'
-  pkg.sha256sum '2b9cbdab2d52ae6572043978c71cc8b925d937253fa3e7c04613b914ee59d4b2'
+  pkg.version '3.15.4'
+  pkg.sha256sum '7d6f37c998f825f61fe34b42492d65f044b8e41fdb728b87892ede6373f4cd09'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-rgen.rb
+++ b/configs/components/rubygem-rgen.rb
@@ -1,6 +1,6 @@
 component 'rubygem-rgen' do |pkg, settings, platform|
-  pkg.version '0.9.0'
-  pkg.md5sum 'c0c6ae4351cf7d1deca2ab052e87d7ab'
+  pkg.version '0.9.1'
+  pkg.md5sum 'fafb97eeb3ea5385f70b2ff83af6d8b6'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-unicode-display_width.rb
+++ b/configs/components/rubygem-unicode-display_width.rb
@@ -1,6 +1,6 @@
 component 'rubygem-unicode-display_width' do |pkg, settings, platform|
-  pkg.version '2.2.0'
-  pkg.md5sum '970f312f0401b84b9ad16437892b3feb'
+  pkg.version '2.4.2'
+  pkg.md5sum 'b5167cb088feaf77be315e51e457b2d1'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-windows_error.rb
+++ b/configs/components/rubygem-windows_error.rb
@@ -1,6 +1,6 @@
 component 'rubygem-windows_error' do |pkg, settings, platform|
-  pkg.version '0.1.4'
-  pkg.md5sum '0e84bff54c220c09afd1706420ee439a'
+  pkg.version '0.1.5'
+  pkg.md5sum 'cb1faeaed0e3b1e4d4ad4e7d1aef76c7'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/runtime-pe-bolt-server.rb
+++ b/configs/components/runtime-pe-bolt-server.rb
@@ -11,7 +11,7 @@ component "runtime-pe-bolt-server" do |pkg, settings, platform|
   artifactory_url = 'https://artifactory.delivery.puppetlabs.net/artifactory'
 
   if platform.is_rpm?
-    platform.add_build_repository "#{artifactory_url}/rpm_enterprise__local/#{settings[:pe_version]}/repos/#{platform.name}/#{platform.name}.repo"
+    platform.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__local/development/puppet-agent/0ca106596dfb1bb1509e0a7b1c09e6e6907bd6fe/puppet-agent-8.0.0.203.g0ca106596-1.el7.x86_64.rpm"
   end
 
   if platform.is_deb?

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -36,7 +36,7 @@ proj.setting(:runtime_project, 'pe-bolt-server')
 # Set desired versions for gem components that offer multiple versions:
 # TODO: Can runtime projects use these updated versions?
 proj.setting(:rubygem_deep_merge_version, '1.2.2')
-proj.setting(:rubygem_net_ssh_version, '6.1.0')
+proj.setting(:rubygem_net_ssh_version, '7.0.1')
 
 # (pe-bolt-server does not run on Windows, so only the *nix path is here)
 proj.setting(:prefix, '/opt/puppetlabs/server/apps/bolt-server')


### PR DESCRIPTION
The bolt-server package contains the bolt code along with bolt library code that powers bolt-server, orchestrator, puppetserver and ace-server. Attempt to build a bolt-server that is able to run with the ruby 3.2 interpreter in puppet8.

TODO:
- Figure out how to get a puppet8 gem.
- Determine if el7 is the right primary platform OS to work with (no openssl3 yet)
- Firm up agent install used to build runtime artifact (native extensions are compiled with this version).