### PR TITLE
(PA-4874) Build OpenSSL 3 for Windows x64 & x86

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -16,20 +16,22 @@ component 'openssl' do |pkg, settings, platform|
 
   if platform.name =~ /^(el-|redhat-|fedora-)/
     pkg.build_requires 'perl-core'
+  elsif platform.is_windows?
+    pkg.build_requires 'strawberryperl'
   else
     pkg.build_requires 'perl'
   end
 
   target = cflags = ldflags = sslflags = ''
 
-  # if platform.is_windows?
-  #   pkg.environment 'PATH', "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
+ if platform.is_windows?
+    pkg.environment 'PATH', "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
   #   pkg.environment 'CYGWIN', settings[:cygwin]
   #   pkg.environment 'CC', settings[:cc]
   #   pkg.environment 'CXX', settings[:cxx]
   #   pkg.environment 'MAKE', platform[:make]
 
-  #   target = platform.architecture == 'x64' ? 'mingw64' : 'mingw'
+    target = platform.architecture == 'x64' ? 'mingw64' : 'mingw'
   #   cflags = settings[:cflags]
   #   ldflags = settings[:ldflags]
   # elsif platform.is_cross_compiled_linux?
@@ -41,7 +43,7 @@ component 'openssl' do |pkg, settings, platform|
   #     # OpenSSL fails to work on aarch unless we turn down the compiler optimization.
   #     # See PA-2135 for details
   #     cflags += " -O2"
-  #   end
+   end
 
   #   ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
   #   target = if platform.architecture == 'aarch64'

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -23,7 +23,8 @@ project 'agent-runtime-main' do |proj|
 
   # Override OpenSSL version for select platforms. Eventually all platforms will support
   # it and we can remove the conditional
-  if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb? || platform.is_macos?) && !platform.is_fips?
+  if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb? || platform.is_macos? ||
+     platform.is_windows?) && !platform.is_fips?
     case platform.name
     when /^el-7-x86_64/, /^sles-12-x86_64/, /^ubuntu-18\.04-amd64/
       # need cmake 3.24.0 or greater in order to detect openssl3, revisit in PA-4870


### PR DESCRIPTION
Currently, there are runtime builds for Windows x86 and x64. This commit enables openssl 3 for Windows.