### PR TITLE
(PA-4874) Revert building OpenSSL 3 for Windows

### DIFF
--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -26,7 +26,7 @@ project 'agent-runtime-main' do |proj|
   if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb? || platform.is_macos? ||
      platform.is_windows?) && !platform.is_fips?
     case platform.name
-    when /^el-7-x86_64/, /^sles-12-x86_64/, /^ubuntu-18\.04-amd64/
+    when /^el-7-x86_64/, /^sles-12-x86_64/, /^ubuntu-18\.04-amd64/, /^windows-.*/
       # need cmake 3.24.0 or greater in order to detect openssl3, revisit in PA-4870
     else
       proj.setting(:openssl_version, '3.0')


### PR DESCRIPTION
This commit has Windows build with OpenSSL 1.1.1 instead of OpenSSL 3. OpenSSL 3 breaks on pxp-agent for Windows because cmake cannot resolve OpenSSL correctly. See PA-4870 for more information.