### PR TITLE
(PA-4874) Re-enable OpenSSL 3 for Windows

### DIFF
--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -26,7 +26,7 @@ project 'agent-runtime-main' do |proj|
   if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb? || platform.is_macos? ||
      platform.is_windows?) && !platform.is_fips?
     case platform.name
-    when /^el-7-x86_64/, /^sles-12-x86_64/, /^ubuntu-18\.04-amd64/, /^windows-.*/
+    when /^el-7-x86_64/, /^sles-12-x86_64/, /^ubuntu-18\.04-amd64/
       # need cmake 3.24.0 or greater in order to detect openssl3, revisit in PA-4870
     else
       proj.setting(:openssl_version, '3.0')


### PR DESCRIPTION
Previously, OpenSSL 3 broke on pxp-agent for Windows because cmake could not resolve OpenSSL correctly (see PA-4970). However, this has been resolved. This commit re-enables OpenSSL 3 for Windows in agent-runtime-main.