### PR TITLE
(PA-4870) Build OpenSSL 3 on older linux

### DIFF
--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -23,14 +23,8 @@ project 'agent-runtime-main' do |proj|
 
   # Override OpenSSL version for select platforms. Eventually all platforms will support
   # it and we can remove the conditional
-  if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb? || platform.is_macos? ||
-     platform.is_windows?) && !platform.is_fips?
-    case platform.name
-    when /^el-7-x86_64/, /^sles-12-x86_64/, /^ubuntu-18\.04-amd64/
-      # need cmake 3.24.0 or greater in order to detect openssl3, revisit in PA-4870
-    else
-      proj.setting(:openssl_version, '3.0')
-    end
+  if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb? || platform.is_macos? || platform.is_windows?) && !platform.is_fips?
+    proj.setting(:openssl_version, '3.0')
   end
 
   # Directory for gems shared by puppet and puppetserver


### PR DESCRIPTION
We use pl-cmake on older linux which patch CMake for OpenSSL 3 support.

Only AIX, Solaris and FIPS remain.

Built [puppet-runtime#6da945a1803cd648b76e72475fda80e44efb625f](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1985/)

Built [pxp-agent-vanagon#main with agent-runtime-main from above](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1986/)

[adhoc puppet-agent el-7, sles-12, ubuntu 18.04 passed](https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1096/)

```
20:14:13 -- Found OpenSSL: /opt/puppetlabs/puppet/lib/libssl.so;/opt/puppetlabs/puppet/lib/libcrypto.so (found version "3.0.8") 
...
20:14:14 -- The following REQUIRED packages have been found:
20:14:14 
20:14:14  * CURL
20:14:14  * Leatherman
20:14:14  * Boost (required version >= 1.54)
20:14:14  * OpenSSL
```