### PR TITLE
(PA-5017) Delete tmp nokogiri dir on macOS 11 ARM too

### DIFF
--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -8,9 +8,9 @@ component 'rubygem-nokogiri' do |pkg, _settings, _platform|
   gem_home = settings[:gem_home]
   pkg.environment "GEM_HOME", gem_home
 
-  # When building nokogiri native extensions on macOS 12 ARM, there is a 94M tmp
+  # When cross compiling nokogiri native extensions on macOS 11/12 ARM, there is a 94M tmp
   # directory that's not needed
-  if platform.name == 'osx-12-arm64'
+  if platform.is_macos? && platform.architecture == 'arm64'
     install do
       "rm -r #{gem_home}/gems/nokogiri-#{pkg.get_version}/ext/nokogiri/tmp"
     end


### PR DESCRIPTION
Built 11 and 12 ARM in https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1988/

Note technically we don't support macOS 11 ARM, but we build packages and ship them https://downloads.puppet.com/mac/puppet7/11/arm64 as "best effort"