### PR TITLE
(PA-5023) Bump hocon to 1.4.0 in agent-runtime-main only

### DIFF
--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -1,6 +1,15 @@
 component "rubygem-hocon" do |pkg, settings, platform|
-  pkg.version "1.3.1"
-  pkg.md5sum "9182e012c0d48d0512a1b49179616709"
+  version = settings[:rubygem_hocon_version] || '1.3.1'
+  pkg.version version
+
+  case version
+  when '1.3.1'
+    pkg.md5sum "9182e012c0d48d0512a1b49179616709"
+  when '1.4.0'
+    pkg.sha256sum "e71023ed7c56ae780ec34c0ce7789a233bcead08c045d50bc7b3af40f5afcd80"
+  else
+    raise "rubygem-hocon version #{version} has not been configured; Cannot continue."
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -3,6 +3,7 @@ project 'agent-runtime-main' do |proj|
   # Set preferred component versions if they differ from defaults:
   proj.setting :ruby_version, '3.2.1'
   proj.setting :rubygem_deep_merge_version, '1.2.2'
+  proj.setting :rubygem_hocon_version, '1.4.0'
 
   # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0
   if platform.is_solaris? || platform.is_aix?


### PR DESCRIPTION
The latest version uses require_relative, so only doing this in the Puppet 8 stream.

Passed adhoc with these runtime changes: https://jenkins-platform.delivery.puppetlabs.net/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1097/