### PR TITLE
(maint) update nokogiri for ruby 3.2 support

### DIFF
--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -1,6 +1,6 @@
 component 'rubygem-nokogiri' do |pkg, _settings, _platform|
-  pkg.version '1.13.10'
-  pkg.sha256sum 'd3ee00f26c151763da1691c7fc6871ddd03e532f74f85101f5acedc2d099e958'
+  pkg.version '1.14.2'
+  pkg.sha256sum 'c765a74aac6cf430a710bb0b6038b8ee11f177393cd6ae8dadc7a44a6e2658b6'
   instance_eval File.read('configs/components/_base-rubygem.rb')
 
   pkg.build_requires 'rubygem-mini_portile2'


### PR DESCRIPTION
The previous version of 1.13.10 only supported < 3.2.dev. The older 1.13.10 version also had a restriction of > 3.1, but the newer 1.14.2 supports ruby 2.7 through 3.2.