### PR TITLE
(PA-5369) Bump Ruby 3.2 to 3.2.2

### DIFF
--- a/configs/components/ruby-3.2.2.rb
+++ b/configs/components/ruby-3.2.2.rb
@@ -1,7 +1,7 @@
 # The file name of the ruby component must match the ruby_version
-component 'ruby-3.2.1' do |pkg, settings, platform|
-  pkg.version '3.2.1'
-  pkg.sha256sum '13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd'
+component 'ruby-3.2.2' do |pkg, settings, platform|
+  pkg.version '3.2.2'
+  pkg.sha256sum '96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc'
 
   # rbconfig-update is used to munge rbconfigs after the fact.
   pkg.add_source("file://resources/files/ruby/rbconfig-update.rb")

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -1,7 +1,7 @@
 project 'agent-runtime-main' do |proj|
 
   # Set preferred component versions if they differ from defaults:
-  proj.setting :ruby_version, '3.2.1'
+  proj.setting :ruby_version, '3.2.2'
   proj.setting :rubygem_deep_merge_version, '1.2.2'
   proj.setting :rubygem_hocon_version, '1.4.0'
 


### PR DESCRIPTION
Ruby 3.2.2 was released on March 30, 2023 with fixes for two CVEs: CVE-2023-28755 and CVE-2023-28756.

This commit updates the Ruby 3.2 component from Ruby 3.2.1 to 3.2.2.