### PR TITLE
(PA-5368) Bump Ruby 2.7 component to 2.7.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 gem 'artifactory'
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.28')
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.105')
-gem 'rake', '~> 12.0'
+gem 'rake', '~> 13.0'
 
 group(:development, optional: true) do
   gem 'highline', require: false

--- a/configs/components/ruby-2.7-augeas.rb
+++ b/configs/components/ruby-2.7-augeas.rb
@@ -1,5 +1,5 @@
 component 'ruby-2.7-augeas' do |pkg, settings, platform|
-  expected_ruby_version = '2.7.7'
+  expected_ruby_version = '2.7.8'
 
   unless settings[:ruby_version] == expected_ruby_version
     unless settings.key?(:additional_rubies) && settings[:additional_rubies].key?(expected_ruby_version)

--- a/configs/components/ruby-2.7-selinux.rb
+++ b/configs/components/ruby-2.7-selinux.rb
@@ -1,5 +1,5 @@
 component 'ruby-2.7-selinux' do |pkg, settings, platform|
-  expected_ruby_version = '2.7.7'
+  expected_ruby_version = '2.7.8'
 
   unless settings[:ruby_version] == expected_ruby_version
     unless settings.key?(:additional_rubies) && settings[:additional_rubies].key?(expected_ruby_version)

--- a/configs/components/ruby-2.7-stomp.rb
+++ b/configs/components/ruby-2.7-stomp.rb
@@ -1,5 +1,5 @@
 component 'ruby-2.7-stomp' do |pkg, settings, platform|
-  expected_ruby_version = '2.7.7'
+  expected_ruby_version = '2.7.8'
 
   unless settings[:ruby_version] == expected_ruby_version
     unless settings.key?(:additional_rubies) && settings[:additional_rubies].key?(expected_ruby_version)

--- a/configs/components/ruby-2.7.8.rb
+++ b/configs/components/ruby-2.7.8.rb
@@ -1,6 +1,6 @@
-component 'ruby-2.7.7' do |pkg, settings, platform|
-  pkg.version '2.7.7'
-  pkg.sha256sum 'e10127db691d7ff36402cfe88f418c8d025a3f1eea92044b162dd72f0b8c7b90'
+component 'ruby-2.7.8' do |pkg, settings, platform|
+  pkg.version '2.7.8'
+  pkg.sha256sum 'c2dab63cbc8f2a05526108ad419efa63a67ed4074dbbcf9fc2b1ca664cb45ba0'
 
   # rbconfig-update is used to munge rbconfigs after the fact.
   pkg.add_source("file://resources/files/ruby/rbconfig-update.rb")

--- a/configs/projects/agent-runtime-7.x.rb
+++ b/configs/projects/agent-runtime-7.x.rb
@@ -1,7 +1,7 @@
 project 'agent-runtime-7.x' do |proj|
 
   # Set preferred component versions if they differ from defaults:
-  proj.setting :ruby_version, '2.7.7'
+  proj.setting :ruby_version, '2.7.8'
   proj.setting :rubygem_deep_merge_version, '1.2.2'
   proj.setting :rubygem_fast_gettext_version, '1.1.2'
   proj.setting :rubygem_gettext_version, '3.2.2'

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -1,7 +1,7 @@
 project 'bolt-runtime' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'bolt')
-  proj.setting(:ruby_version, '2.7.7')
+  proj.setting(:ruby_version, '2.7.8')
   proj.setting(:openssl_version, '1.1.1')
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
   proj.setting(:augeas_version, '1.11.0')

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -52,7 +52,7 @@ project 'pdk-runtime' do |proj|
   proj.setting(:includedir, File.join(proj.prefix, "include"))
   proj.setting(:bindir, File.join(proj.prefix, "bin"))
 
-  proj.setting(:ruby_version, "2.7.7")
+  proj.setting(:ruby_version, "2.7.8")
   proj.setting(:ruby_api, "2.7.0")
 
   # this is the latest puppet that will be installed into the default ruby version above

--- a/configs/projects/pe-installer-runtime-2021.7.x.rb
+++ b/configs/projects/pe-installer-runtime-2021.7.x.rb
@@ -1,7 +1,7 @@
 project 'pe-installer-runtime-2021.7.x' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'pe-installer')
-  proj.setting(:ruby_version, '2.7.7')
+  proj.setting(:ruby_version, '2.7.8')
   proj.setting(:augeas_version, '1.11.0')
   # We need to explicitly define 1.1.1k here to avoid
   # build dep conflicts between openssl-1.1.1 needed by curl

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -1,7 +1,7 @@
 project 'pe-installer-runtime-main' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'pe-installer')
-  proj.setting(:ruby_version, '2.7.7')
+  proj.setting(:ruby_version, '2.7.8')
   proj.setting(:augeas_version, '1.11.0')
   # We need to explicitly define 1.1.1k here to avoid
   # build dep conflicts between openssl-1.1.1 needed by curl


### PR DESCRIPTION
Ruby 2.7.8 was released on March 30, 2023 to address two CVEs: CVE-2023-28755 and CVE-2023-28756.

This commit bumps the Ruby component from 2.7.7 to 2.7.8 and increments the ruby_version setting used by components and projects that use Ruby 2.7.