### PR TITLE
(CONT-934) Prep for Puppet 8 and Ruby 3

### DIFF
--- a/configs/components/rubygem-addressable.rb
+++ b/configs/components/rubygem-addressable.rb
@@ -1,6 +1,6 @@
-component 'rubygem-addressable' do |pkg, _settings, _platform|
-  pkg.version '2.8.1'
-  pkg.md5sum '64cb545a6ddcfc93c68fe53ac594c5f7'
+component "rubygem-addressable" do |pkg, settings, platform|
+  pkg.version "2.8.1"
+  pkg.sha256sum "bc724a176ef02118c8a3ed6b5c04c39cf59209607ffcce77b91d0261dbadedfa"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-bundler.rb
+++ b/configs/components/rubygem-bundler.rb
@@ -1,0 +1,17 @@
+component "rubygem-bundler" do |pkg, settings, _platform|
+  pkg.version '2.3.26'
+  pkg.sha256sum '1ee53cdf61e728ad82c6dbff06cfcd8551d5422e88e86203f0e2dbe9ae999e09'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+
+  pkg.install do
+    install_commands = []
+    install_commands << "#{settings[:gem_install]} bundler-#{pkg.get_version}.gem"
+
+    settings[:additional_rubies].each do |_rubyver, local_settings|
+      install_commands << "#{local_settings[:gem_install]} bundler-#{pkg.get_version}.gem"
+    end
+
+    install_commands
+  end
+end

--- a/configs/components/rubygem-childprocess.rb
+++ b/configs/components/rubygem-childprocess.rb
@@ -1,0 +1,6 @@
+component "rubygem-childprocess" do |pkg, settings, platform|
+  pkg.version "4.1.0"
+  pkg.sha256sum '3616ce99ccb242361ce7f2b19bf9ff3e6bc1d98b927c7edc29af8ca617ba6cd3'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-cri.rb
+++ b/configs/components/rubygem-cri.rb
@@ -1,6 +1,6 @@
-component 'rubygem-cri' do |pkg, settings, platform|
-  pkg.version '2.15.11'
-  pkg.md5sum '98e0ce55d289f9aed97ee11c5ba83010'
+component "rubygem-cri" do |pkg, settings, platform|
+  pkg.version "2.15.11"
+  pkg.sha256sum "254320ef42198cf2670b36dbdd67aa8f8c177e7f058ce176f995a4ada47d1aae"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-diff-lcs.rb
+++ b/configs/components/rubygem-diff-lcs.rb
@@ -1,0 +1,6 @@
+component "rubygem-diff-lcs" do |pkg, settings, platform|
+  pkg.version "1.5.0"
+  pkg.sha256sum "49b934001c8c6aedb37ba19daec5c634da27b318a7a3c654ae979d6ba1929b67"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-hitimes.rb
+++ b/configs/components/rubygem-hitimes.rb
@@ -1,0 +1,6 @@
+component "rubygem-hitimes" do |pkg, settings, platform|
+  pkg.version "2.0.0"
+  pkg.sha256sum "0e8bc5829251bb43be3a44e5510dfd4d5cc4fae5112bf1d1b091679dd3cda947"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+ end

--- a/configs/components/rubygem-json-schema.rb
+++ b/configs/components/rubygem-json-schema.rb
@@ -1,0 +1,6 @@
+component "rubygem-json-schema" do |pkg, settings, platform|
+  pkg.version "4.0.0"
+  pkg.sha256sum "a3bfe5fa1ad9771f0637a7c339a598b8b258343c49a1110988288e04f4f3b994"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-json_pure.rb
+++ b/configs/components/rubygem-json_pure.rb
@@ -1,0 +1,6 @@
+component "rubygem-json_pure" do |pkg, settings, platform|
+  pkg.version "2.6.3"
+  pkg.sha256sum 'c39185aa41c04a1933b8d66d1294224743262ee6881adc7b5a488ab2ae19c74e'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-pastel.rb
+++ b/configs/components/rubygem-pastel.rb
@@ -1,0 +1,6 @@
+component "rubygem-pastel" do |pkg, settings, platform|
+  pkg.version "0.8.0"
+  pkg.sha256sum '481da9fb7d2f6e6b1a08faf11fa10363172dc40fd47848f096ae21209f805a75'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-pathspec.rb
+++ b/configs/components/rubygem-pathspec.rb
@@ -1,0 +1,6 @@
+component "rubygem-pathspec" do |pkg, settings, platform|
+  pkg.version "1.1.3"
+  pkg.sha256sum "c4e7ff4c4019499488874e21c37a1e2473d5123cfce6f13ecb07f42c0f8c5d23"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-public_suffix.rb
+++ b/configs/components/rubygem-public_suffix.rb
@@ -3,4 +3,4 @@ component 'rubygem-public_suffix' do |pkg, _settings, _platform|
   pkg.md5sum '504e45c1f5f7b629e46e4deef7d0f46f'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
-end
+ end

--- a/configs/components/rubygem-tty-color.rb
+++ b/configs/components/rubygem-tty-color.rb
@@ -1,0 +1,6 @@
+component "rubygem-tty-color" do |pkg, settings, platform|
+  pkg.version "0.6.0"
+  pkg.sha256sum '6f9c37ca3a4e2367fb2e6d09722762647d6f455c111f05b59f35730eeb24332a'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-tty-cursor.rb
+++ b/configs/components/rubygem-tty-cursor.rb
@@ -1,0 +1,6 @@
+component "rubygem-tty-cursor" do |pkg, settings, platform|
+  pkg.version "0.7.1"
+  pkg.sha256sum "79534185e6a777888d88628b14b6a1fdf5154a603f285f80b1753e1908e0bf48"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-tty-prompt.rb
+++ b/configs/components/rubygem-tty-prompt.rb
@@ -1,0 +1,6 @@
+component "rubygem-tty-prompt" do |pkg, settings, platform|
+  pkg.version "0.23.1"
+  pkg.sha256sum "fcdbce905238993f27eecfdf67597a636bc839d92192f6a0eef22b8166449ec8"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-tty-reader.rb
+++ b/configs/components/rubygem-tty-reader.rb
@@ -1,0 +1,6 @@
+component "rubygem-tty-reader" do |pkg, settings, platform|
+  pkg.version "0.9.0"
+  pkg.sha256sum 'c62972c985c0b1566f0e56743b6a7882f979d3dc32ff491ed490a076f899c2b1'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-tty-screen.rb
+++ b/configs/components/rubygem-tty-screen.rb
@@ -1,0 +1,6 @@
+component "rubygem-tty-screen" do |pkg, settings, platform|
+  pkg.version "0.8.1"
+  pkg.sha256sum '6508657c38f32bdca64880abe201ce237d80c94146e1f9b911cba3c7823659a2'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-tty-spinner.rb
+++ b/configs/components/rubygem-tty-spinner.rb
@@ -1,0 +1,6 @@
+component "rubygem-tty-spinner" do |pkg, settings, platform|
+  pkg.version "0.9.3"
+  pkg.sha256sum "0e036f047b4ffb61f2aa45f5a770ec00b4d04130531558a94bfc5b192b570542"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-tty-which.rb
+++ b/configs/components/rubygem-tty-which.rb
@@ -1,0 +1,6 @@
+component "rubygem-tty-which" do |pkg, settings, platform|
+  pkg.version "0.5.0"
+  pkg.sha256sum "5824055f0d6744c97e7c4426544f01d519c40d1806ef2ef47d9854477993f466"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-wisper.rb
+++ b/configs/components/rubygem-wisper.rb
@@ -1,0 +1,6 @@
+component "rubygem-wisper" do |pkg, settings, platform|
+  pkg.version "2.0.1"
+  pkg.sha256sum "ce17bc5c3a166f241a2e6613848b025c8146fce2defba505920c1d1f3f88fae6"
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/runtime-pdk.rb
+++ b/configs/components/runtime-pdk.rb
@@ -1,5 +1,8 @@
 # This component exists to link in the gcc and stdc++ runtime libraries.
 component "runtime-pdk" do |pkg, settings, platform|
+  pkg.build_requires "libffi"
+  pkg.build_requires "libyaml"
+
   if platform.is_windows?
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"
     ["libgcc_s_#{lib_type}-1.dll", 'libstdc++-6.dll', 'libwinpthread-1.dll'].each do |dll|
@@ -18,6 +21,11 @@ component "runtime-pdk" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
 
+    if settings[:ruby_major_version] >= 3
+      pkg.install_file "#{settings[:bindir]}/libyaml-0-2.dll", "#{settings[:ruby_bindir]}/libyaml-0-2.dll"
+      pkg.install_file "#{settings[:bindir]}/libffi-8.dll", "#{settings[:ruby_bindir]}/libffi-8.dll"
+    end
+
     # Copy the DLLs into additional ruby install bindirs as well.
     if settings.has_key?(:additional_rubies)
       settings[:additional_rubies].each do |rubyver, local_settings|
@@ -28,6 +36,7 @@ component "runtime-pdk" do |pkg, settings, platform|
         pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{local_settings[:ruby_bindir]}/libffi-6.dll"
       end
     end
+
   elsif platform.is_macos?
 
     # Do nothing

--- a/configs/platforms/windows-2019-x64.rb
+++ b/configs/platforms/windows-2019-x64.rb
@@ -6,14 +6,13 @@ platform "windows-2019-x64" do |plat|
   visual_studio_sdk_version = 'win8.1'
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
-  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey.ps1"
+  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey-1.4.0.ps1"
   plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/nuget"
 
   # C:\tools is likely added by mingw, however because we also want to use that
   # dir for vsdevcmd.bat we create it for safety
   plat.provision_with "mkdir C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   packages = [

--- a/configs/projects/_pdk-components.rb
+++ b/configs/projects/_pdk-components.rb
@@ -1,0 +1,114 @@
+# This file is used to define the components that make up the PDK runtime package.
+
+matchdata = platform.settings[:ruby_version].match /(\d+)\.\d+\.\d+/
+ruby_major_version = matchdata[1].to_i
+
+if ruby_major_version >= 3
+
+  openssl3_platform = [
+    platform.is_el?,
+    platform.is_fedora?,
+    platform.is_sles?,
+    platform.is_deb?,
+    platform.is_macos?,
+    platform.is_windows?
+  ].any?
+
+  openssl_version = proj.openssl_version
+  openssl_version = '3.0' if openssl3_platform
+
+  # Ruby 3.2 does not package these two libraries so we need to add them as a component
+  proj.component 'libffi'
+  proj.component 'libyaml'
+  proj.component "openssl-#{openssl_version}"
+end
+
+# Always build the default openssl version
+proj.component "openssl-#{proj.openssl_version}"
+
+# Common deps
+proj.component 'curl'
+
+# Git and deps
+proj.component 'git'
+
+# Ruby and deps
+proj.component 'runtime-pdk'
+proj.component 'puppet-ca-bundle'
+
+proj.component 'readline' if platform.is_macos?
+proj.component 'augeas' unless platform.is_windows?
+proj.component 'libxml2' unless platform.is_windows?
+proj.component 'libxslt' unless platform.is_windows?
+
+proj.component "ruby-#{proj.ruby_version}"
+proj.component 'ruby-augeas' unless platform.is_windows?
+proj.component 'ruby-selinux' if platform.is_el? || platform.is_fedora?
+proj.component 'ruby-stomp'
+
+# Additional Rubies
+if proj.respond_to?(:additional_rubies)
+  proj.additional_rubies.each_key do |rubyver|
+    proj.component "ruby-#{rubyver}"
+
+    ruby_minor = rubyver.split('.')[0, 2].join('.')
+
+    proj.component "ruby-#{ruby_minor}-augeas" unless platform.is_windows?
+    proj.component "ruby-#{ruby_minor}-selinux" if platform.is_el? || platform.is_fedora?
+    proj.component "ruby-#{ruby_minor}-stomp"
+  end
+end
+
+# PDK Rubygems
+proj.component 'rubygem-ffi'
+proj.component 'rubygem-locale'
+proj.component 'rubygem-text'
+proj.component 'rubygem-gettext'
+proj.component 'rubygem-fast_gettext'
+proj.component 'rubygem-gettext-setup'
+proj.component 'rubygem-minitar'
+
+# Bundler
+proj.component 'rubygem-bundler'
+
+# Cri and deps
+proj.component 'rubygem-cri'
+
+# Childprocess and deps
+proj.component 'rubygem-childprocess'
+proj.component 'rubygem-hitimes'
+
+## tty-reader and deps
+proj.component 'rubygem-tty-screen'
+proj.component 'rubygem-tty-cursor'
+proj.component 'rubygem-wisper'
+proj.component 'rubygem-tty-reader'
+
+## pastel and deps
+proj.component 'rubygem-tty-color'
+proj.component 'rubygem-pastel'
+
+## root tty gems
+proj.component 'rubygem-tty-prompt'
+proj.component 'rubygem-tty-spinner'
+proj.component 'rubygem-tty-which'
+
+# json-schema and deps
+proj.component 'rubygem-public_suffix'
+proj.component 'rubygem-addressable'
+proj.component 'rubygem-json-schema'
+
+# Analytics deps
+proj.component 'rubygem-concurrent-ruby'
+proj.component 'rubygem-thor'
+proj.component 'rubygem-hocon'
+proj.component 'rubygem-facter'
+proj.component 'rubygem-httpclient'
+
+# Other deps
+proj.component 'rubygem-deep_merge'
+proj.component 'rubygem-json_pure'
+proj.component 'rubygem-diff-lcs'
+proj.component 'rubygem-pathspec'
+
+proj.component 'ansicon' if platform.is_windows?

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -52,12 +52,12 @@ project 'pdk-runtime' do |proj|
   proj.setting(:includedir, File.join(proj.prefix, "include"))
   proj.setting(:bindir, File.join(proj.prefix, "bin"))
 
-  proj.setting(:ruby_version, "2.7.8")
-  proj.setting(:ruby_api, "2.7.0")
-
+  proj.setting(:ruby_version, "3.2.2")
+  proj.setting(:ruby_api, "3.2.0")
+ 
   # this is the latest puppet that will be installed into the default ruby version above
   # newer versions of puppet will be installed into the Ruby 2.7 runtime
-  proj.setting(:latest_puppet, "~> 7")
+  proj.setting(:latest_puppet, "~> 8")
 
   proj.setting(:privatedir, File.join(proj.prefix, "private"))
   proj.setting(:ruby_dir, File.join(proj.privatedir, "ruby", proj.ruby_version))
@@ -80,10 +80,10 @@ project 'pdk-runtime' do |proj|
 
   # TODO: build this with a helper method?
   additional_rubies = {
-    "2.5.9" => {
-      ruby_version: "2.5.9",
-      ruby_api: "2.5.0",
-      ruby_dir: File.join(proj.privatedir, "ruby", "2.5.9"),
+    "2.7.8" => {
+      ruby_version: "2.7.8",
+      ruby_api: "2.7.0",
+      ruby_dir: File.join(proj.privatedir, "ruby", "2.7.8"),
     },
   }
 
@@ -151,8 +151,25 @@ project 'pdk-runtime' do |proj|
   # What to build?
   # --------------
 
-  # Common deps
+  matchdata = platform.settings[:ruby_version].match /(\d+)\.\d+\.\d+/
+  ruby_major_version = matchdata[1].to_i
+
+  if ruby_major_version >= 3
+    openssl_version = proj.openssl_version
+    if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb? || platform.is_macos? || platform.is_windows?)
+      openssl_version = '3.0'
+    end
+
+    # Ruby 3.2 does not package these two libraries so we need to add them as a component
+    proj.component 'libffi'
+    proj.component 'libyaml'
+    proj.component "openssl-#{openssl_version}"
+  end
+
+  # Always build the default openssl version
   proj.component "openssl-#{proj.openssl_version}"
+
+  # Common deps
   proj.component "curl"
 
   # Git and deps

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -1,6 +1,5 @@
 project 'pdk-runtime' do |proj|
-  # Used in component configurations to conditionally include dependencies
-  proj.setting(:runtime_project, "pdk")
+  proj.setting(:runtime_project, 'pdk')
   proj.setting(:openssl_version, '1.1.1')
   proj.setting(:augeas_version, '1.13.0')
   proj.setting(:rubygem_fast_gettext_version, '1.1.2')
@@ -13,92 +12,87 @@ project 'pdk-runtime' do |proj|
   proj.generate_archives true
   proj.generate_packages false
 
-  proj.description "The PDK runtime contains third-party components needed for the puppet developer kit"
-  proj.license "See components"
-  proj.vendor "Puppet, Inc.  <info@puppet.com>"
-  proj.homepage "https://puppet.com"
-
-  if platform.is_macos?
-    proj.identifier "com.puppetlabs"
-  end
-
-  # These flags are applied in addition to the defaults in configs/component/openssl.rb.
   proj.setting(:openssl_extra_configure_flags, [
-    'enable-cms',
-    'enable-seed',
-    'no-gost',
-    'no-rc5',
-    'no-srp',
-  ])
+    'no-dtls',
+    'no-dtls1',
+    'no-idea',
+    'no-seed',
+    'no-weak-ssl-ciphers',
+    '-DOPENSSL_NO_HEARTBEATS'
+    ])
 
-  proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
+  proj.setting(:artifactory_url, 'https://artifactory.delivery.puppetlabs.net/artifactory')
   proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
 
+  proj.description 'The PDK runtime contains third-party components needed for the puppet developer kit'
+  proj.license 'See components'
+  proj.vendor 'Puppet, Inc.  <info@puppet.com>'
+  proj.homepage 'https://puppet.com'
+  proj.identifier 'com.puppetlabs' if platform.is_macos?
+
   if platform.is_windows?
-    proj.setting(:base_dir, "ProgramFiles64Folder")
-    proj.setting(:company_id, "PuppetLabs")
-    proj.setting(:product_id, "DevelopmentKit")
-    proj.setting(:install_root, File.join("C:", proj.base_dir, proj.company_id, proj.product_id))
+    proj.setting(:base_dir, 'ProgramFiles64Folder')
+    proj.setting(:company_id, 'PuppetLabs')
+    proj.setting(:product_id, 'DevelopmentKit')
+    proj.setting(:install_root, File.join('C:', proj.base_dir, proj.company_id, proj.product_id))
     proj.setting(:prefix, proj.install_root)
-    proj.setting(:windows_tools, File.join(proj.install_root, "private/tools/bin"))
+    proj.setting(:windows_tools, File.join(proj.install_root, 'private/tools/bin'))
   else
-    proj.setting(:install_root, "/opt/puppetlabs")
-    proj.setting(:prefix, File.join(proj.install_root, "pdk"))
-    proj.setting(:link_bindir, File.join(proj.prefix, "bin"))
+    proj.setting(:install_root, '/opt/puppetlabs')
+    proj.setting(:prefix, File.join(proj.install_root, 'pdk'))
+    proj.setting(:link_bindir, File.join(proj.prefix, 'bin'))
   end
 
-  proj.setting(:libdir, File.join(proj.prefix, "lib"))
-  proj.setting(:datadir, File.join(proj.prefix, "share"))
-  proj.setting(:includedir, File.join(proj.prefix, "include"))
-  proj.setting(:bindir, File.join(proj.prefix, "bin"))
+  proj.setting(:libdir, File.join(proj.prefix, 'lib'))
+  proj.setting(:datadir, File.join(proj.prefix, 'share'))
+  proj.setting(:includedir, File.join(proj.prefix, 'include'))
+  proj.setting(:bindir, File.join(proj.prefix, 'bin'))
 
-  proj.setting(:ruby_version, "3.2.2")
-  proj.setting(:ruby_api, "3.2.0")
- 
+  proj.setting(:ruby_version, '3.2.2')
+  proj.setting(:ruby_api, '3.2.0')
+
   # this is the latest puppet that will be installed into the default ruby version above
-  # newer versions of puppet will be installed into the Ruby 2.7 runtime
-  proj.setting(:latest_puppet, "~> 8")
+  proj.setting(:latest_puppet, '~> 8')
 
-  proj.setting(:privatedir, File.join(proj.prefix, "private"))
-  proj.setting(:ruby_dir, File.join(proj.privatedir, "ruby", proj.ruby_version))
-  proj.setting(:ruby_bindir, File.join(proj.ruby_dir, "bin"))
-  proj.setting(:gem_home, File.join(proj.ruby_dir, "lib", "ruby", "gems", proj.ruby_api))
+  proj.setting(:privatedir, File.join(proj.prefix, 'private'))
+  proj.setting(:ruby_dir, File.join(proj.privatedir, 'ruby', proj.ruby_version))
+  proj.setting(:ruby_bindir, File.join(proj.ruby_dir, 'bin'))
+  proj.setting(:gem_home, File.join(proj.ruby_dir, 'lib', 'ruby', 'gems', proj.ruby_api))
 
   if platform.is_windows?
-    proj.setting(:host_ruby, File.join(proj.ruby_bindir, "ruby.exe"))
-    proj.setting(:host_gem, File.join(proj.ruby_bindir, "gem.bat"))
-    proj.setting(:host_bundle, File.join(proj.ruby_bindir, "bundle.bat"))
+    proj.setting(:host_ruby, File.join(proj.ruby_bindir, 'ruby.exe'))
+    proj.setting(:host_gem, File.join(proj.ruby_bindir, 'gem.bat'))
+    proj.setting(:host_bundle, File.join(proj.ruby_bindir, 'bundle.bat'))
   else
-    proj.setting(:host_ruby, File.join(proj.ruby_bindir, "ruby"))
-    proj.setting(:host_gem, File.join(proj.ruby_bindir, "gem"))
-    proj.setting(:host_bundle, File.join(proj.ruby_bindir, "bundle"))
+    proj.setting(:host_ruby, File.join(proj.ruby_bindir, 'ruby'))
+    proj.setting(:host_gem, File.join(proj.ruby_bindir, 'gem'))
+    proj.setting(:host_bundle, File.join(proj.ruby_bindir, 'bundle'))
   end
 
   gem_install = "#{proj.host_gem} install --no-document --local "
   gem_install += "--bindir #{proj.ruby_bindir} " if platform.is_windows? # Add --bindir option for Windows...
   proj.setting(:gem_install, gem_install)
 
-  # TODO: build this with a helper method?
   additional_rubies = {
-    "2.7.8" => {
-      ruby_version: "2.7.8",
-      ruby_api: "2.7.0",
-      ruby_dir: File.join(proj.privatedir, "ruby", "2.7.8"),
-    },
+    '2.7.8' => {
+      ruby_version: '2.7.8',
+      ruby_api: '2.7.0',
+      ruby_dir: File.join(proj.privatedir, 'ruby', '2.7.8')
+    }
   }
 
-  additional_rubies.each do |rubyver, local_settings|
-    local_settings[:ruby_bindir] = File.join(local_settings[:ruby_dir], "bin")
-    local_settings[:gem_home] = File.join(local_settings[:ruby_dir], "lib", "ruby", "gems", local_settings[:ruby_api])
+  additional_rubies.each do |_rubyver, local_settings|
+    local_settings[:ruby_bindir] = File.join(local_settings[:ruby_dir], 'bin')
+    local_settings[:gem_home] = File.join(local_settings[:ruby_dir], 'lib', 'ruby', 'gems', local_settings[:ruby_api])
 
     if platform.is_windows?
-      local_settings[:host_ruby] = File.join(local_settings[:ruby_bindir], "ruby.exe")
-      local_settings[:host_gem] = File.join(local_settings[:ruby_bindir], "gem.bat")
-      local_settings[:host_bundle] = File.join(local_settings[:ruby_bindir], "bundle.bat")
+      local_settings[:host_ruby] = File.join(local_settings[:ruby_bindir], 'ruby.exe')
+      local_settings[:host_gem] = File.join(local_settings[:ruby_bindir], 'gem.bat')
+      local_settings[:host_bundle] = File.join(local_settings[:ruby_bindir], 'bundle.bat')
     else
-      local_settings[:host_ruby] = File.join(local_settings[:ruby_bindir], "ruby")
-      local_settings[:host_gem] = File.join(local_settings[:ruby_bindir], "gem")
-      local_settings[:host_bundle] = File.join(local_settings[:ruby_bindir], "bundle")
+      local_settings[:host_ruby] = File.join(local_settings[:ruby_bindir], 'ruby')
+      local_settings[:host_gem] = File.join(local_settings[:ruby_bindir], 'gem')
+      local_settings[:host_bundle] = File.join(local_settings[:ruby_bindir], 'bundle')
     end
 
     local_gem_install = "#{local_settings[:host_gem]} install --no-document --local "
@@ -119,17 +113,17 @@ project 'pdk-runtime' do |proj|
   # Define default CFLAGS and LDFLAGS for most platforms, and then
   # tweak or adjust them as needed.
   proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-  proj.setting(:cflags, "#{proj.cppflags}")
+  proj.setting(:cflags, proj.cppflags.to_s)
   proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
 
   if platform.is_windows?
-    proj.setting(:gcc_root, "C:/tools/mingw64")
+    proj.setting(:gcc_root, 'C:/tools/mingw64')
     proj.setting(:gcc_bindir, "#{proj.gcc_root}/bin")
-    proj.setting(:tools_root, "C:/tools/pl-build-tools")
-    proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
+    proj.setting(:tools_root, 'C:/tools/pl-build-tools')
+    proj.setting(:cygwin, 'nodosfilewarning winsymlinks:native')
 
     proj.setting(:cppflags, "-I#{proj.tools_root}/include -I#{proj.gcc_root}/include -I#{proj.includedir}")
-    proj.setting(:cflags, "#{proj.cppflags}")
+    proj.setting(:cflags, proj.cppflags.to_s)
     proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir}")
   elsif platform.is_macos?
     proj.setting(:cppflags, "-I#{proj.includedir}")
@@ -146,120 +140,12 @@ project 'pdk-runtime' do |proj|
   end
 
   # We want PDK's vendored Git binary to use system-wide gitconfig.
-  proj.setting(:git_sysconfdir, "/etc")
+  proj.setting(:git_sysconfdir, '/etc')
 
-  # What to build?
-  # --------------
-
-  matchdata = platform.settings[:ruby_version].match /(\d+)\.\d+\.\d+/
-  ruby_major_version = matchdata[1].to_i
-
-  if ruby_major_version >= 3
-    openssl_version = proj.openssl_version
-    if (platform.is_el? || platform.is_fedora? || platform.is_sles? || platform.is_deb? || platform.is_macos? || platform.is_windows?)
-      openssl_version = '3.0'
-    end
-
-    # Ruby 3.2 does not package these two libraries so we need to add them as a component
-    proj.component 'libffi'
-    proj.component 'libyaml'
-    proj.component "openssl-#{openssl_version}"
-  end
-
-  # Always build the default openssl version
-  proj.component "openssl-#{proj.openssl_version}"
-
-  # Common deps
-  proj.component 'curl'
-
-  # Git and deps
-  proj.component 'git'
-
-  # Ruby and deps
-  proj.component 'puppet-ca-bundle'
-
-  proj.component 'readline' if platform.is_macos?
-  proj.component 'augeas' unless platform.is_windows?
-  proj.component 'libxml2' unless platform.is_windows?
-  proj.component 'libxslt' unless platform.is_windows?
-
-  proj.component "ruby-#{proj.ruby_version}"
-
-  proj.component 'ruby-augeas' unless platform.is_windows?
-
-  # We only build ruby-selinux for EL 5-7
-  proj.component 'ruby-selinux' if platform.is_el? || platform.is_fedora?
-
-  proj.component 'ruby-stomp'
-
-  # PDK Rubygems
-  proj.component 'rubygem-ffi'
-  proj.component 'rubygem-locale'
-  proj.component 'rubygem-text'
-  proj.component 'rubygem-gettext'
-  proj.component 'rubygem-fast_gettext'
-  proj.component 'rubygem-gettext-setup'
-  proj.component 'rubygem-minitar'
-
-  # Bundler
-  proj.component 'rubygem-bundler'
-
-  # Cri and deps
-  proj.component 'rubygem-cri'
-
-  # Childprocess and deps
-  proj.component 'rubygem-childprocess'
-
-  proj.component 'rubygem-hitimes'
-
-  ## tty-reader and deps
-  proj.component 'rubygem-tty-screen'
-  proj.component 'rubygem-tty-cursor'
-  proj.component 'rubygem-wisper'
-  proj.component 'rubygem-tty-reader'
-
-  ## pastel and deps
-  proj.component 'rubygem-tty-color'
-  proj.component 'rubygem-pastel'
-
-  ## root tty gems
-  proj.component 'rubygem-tty-prompt'
-  proj.component 'rubygem-tty-spinner'
-  proj.component 'rubygem-tty-which'
-
-  # json-schema and deps
-  proj.component 'rubygem-public_suffix'
-  proj.component 'rubygem-addressable'
-  proj.component 'rubygem-json-schema'
-
-  # Analytics deps
-  proj.component 'rubygem-concurrent-ruby'
-  proj.component 'rubygem-thor'
-  proj.component 'rubygem-hocon'
-  proj.component 'rubygem-facter'
-  proj.component 'rubygem-httpclient'
-
-  # Other deps
-  proj.component 'rubygem-deep_merge'
-  proj.component 'rubygem-json_pure'
-  proj.component 'rubygem-diff-lcs'
-  proj.component 'rubygem-pathspec'
-
-  # Additional Rubies
-  if proj.respond_to?(:additional_rubies)
-    proj.additional_rubies.each_key do |rubyver|
-      proj.component "ruby-#{rubyver}"
-
-      ruby_minor = rubyver.split('.')[0, 2].join('.')
-
-      proj.component "ruby-#{ruby_minor}-augeas" unless platform.is_windows?
-      proj.component "ruby-#{ruby_minor}-selinux" if platform.is_el? || platform.is_fedora?
-      proj.component "ruby-#{ruby_minor}-stomp"
-    end
-  end
-
-  # Platform specific deps
-  proj.component 'ansicon' if platform.is_windows?
+  # Load PDK component definitions
+  proj.setting(:rubygem_concurrent_ruby_version, '1.1.10')
+  proj.setting(:rubygem_deep_merge_version, '1.2.2')
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_pdk-components.rb'))
 
   # What to include in package?
   proj.directory proj.install_root
@@ -275,5 +161,5 @@ project 'pdk-runtime' do |proj|
   # Something like https://www.openssl.org/source/openssl-1.0.0r.tar.gz gets
   # rewritten as
   # https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/openssl-1.0.0r.tar.gz
-  proj.register_rewrite_rule 'http', proj.buildsources_url
+  # proj.register_rewrite_rule 'http', proj.buildsources_url
 end

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -170,46 +170,87 @@ project 'pdk-runtime' do |proj|
   proj.component "openssl-#{proj.openssl_version}"
 
   # Common deps
-  proj.component "curl"
+  proj.component 'curl'
 
   # Git and deps
-  proj.component "git"
+  proj.component 'git'
 
   # Ruby and deps
-  proj.component "runtime-pdk"
-  proj.component "puppet-ca-bundle"
+  proj.component 'puppet-ca-bundle'
 
-  proj.component "readline" if platform.is_macos?
-  proj.component "augeas" unless platform.is_windows?
-  proj.component "libxml2" unless platform.is_windows?
-  proj.component "libxslt" unless platform.is_windows?
+  proj.component 'readline' if platform.is_macos?
+  proj.component 'augeas' unless platform.is_windows?
+  proj.component 'libxml2' unless platform.is_windows?
+  proj.component 'libxslt' unless platform.is_windows?
 
   proj.component "ruby-#{proj.ruby_version}"
 
-  proj.component "ruby-augeas" unless platform.is_windows?
+  proj.component 'ruby-augeas' unless platform.is_windows?
 
   # We only build ruby-selinux for EL 5-7
-  if platform.is_el? || platform.is_fedora?
-    proj.component "ruby-selinux"
-  end
+  proj.component 'ruby-selinux' if platform.is_el? || platform.is_fedora?
 
-  proj.component "ruby-stomp"
+  proj.component 'ruby-stomp'
 
   # PDK Rubygems
-  proj.component "rubygem-ffi"
-  proj.component "rubygem-locale"
-  proj.component "rubygem-text"
-  proj.component "rubygem-gettext"
-  proj.component "rubygem-fast_gettext"
-  proj.component "rubygem-gettext-setup"
-  proj.component "rubygem-minitar"
+  proj.component 'rubygem-ffi'
+  proj.component 'rubygem-locale'
+  proj.component 'rubygem-text'
+  proj.component 'rubygem-gettext'
+  proj.component 'rubygem-fast_gettext'
+  proj.component 'rubygem-gettext-setup'
+  proj.component 'rubygem-minitar'
+
+  # Bundler
+  proj.component 'rubygem-bundler'
+
+  # Cri and deps
+  proj.component 'rubygem-cri'
+
+  # Childprocess and deps
+  proj.component 'rubygem-childprocess'
+
+  proj.component 'rubygem-hitimes'
+
+  ## tty-reader and deps
+  proj.component 'rubygem-tty-screen'
+  proj.component 'rubygem-tty-cursor'
+  proj.component 'rubygem-wisper'
+  proj.component 'rubygem-tty-reader'
+
+  ## pastel and deps
+  proj.component 'rubygem-tty-color'
+  proj.component 'rubygem-pastel'
+
+  ## root tty gems
+  proj.component 'rubygem-tty-prompt'
+  proj.component 'rubygem-tty-spinner'
+  proj.component 'rubygem-tty-which'
+
+  # json-schema and deps
+  proj.component 'rubygem-public_suffix'
+  proj.component 'rubygem-addressable'
+  proj.component 'rubygem-json-schema'
+
+  # Analytics deps
+  proj.component 'rubygem-concurrent-ruby'
+  proj.component 'rubygem-thor'
+  proj.component 'rubygem-hocon'
+  proj.component 'rubygem-facter'
+  proj.component 'rubygem-httpclient'
+
+  # Other deps
+  proj.component 'rubygem-deep_merge'
+  proj.component 'rubygem-json_pure'
+  proj.component 'rubygem-diff-lcs'
+  proj.component 'rubygem-pathspec'
 
   # Additional Rubies
   if proj.respond_to?(:additional_rubies)
-    proj.additional_rubies.keys.each do |rubyver|
+    proj.additional_rubies.each_key do |rubyver|
       proj.component "ruby-#{rubyver}"
 
-      ruby_minor = rubyver.split('.')[0,2].join('.')
+      ruby_minor = rubyver.split('.')[0, 2].join('.')
 
       proj.component "ruby-#{ruby_minor}-augeas" unless platform.is_windows?
       proj.component "ruby-#{ruby_minor}-selinux" if platform.is_el? || platform.is_fedora?
@@ -218,7 +259,7 @@ project 'pdk-runtime' do |proj|
   end
 
   # Platform specific deps
-  proj.component "ansicon" if platform.is_windows?
+  proj.component 'ansicon' if platform.is_windows?
 
   # What to include in package?
   proj.directory proj.install_root

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -49,6 +49,7 @@ project 'pdk-runtime' do |proj|
   proj.setting(:bindir, File.join(proj.prefix, 'bin'))
 
   proj.setting(:ruby_version, '3.2.2')
+  proj.setting(:ruby_major_version, 3)
   proj.setting(:ruby_api, '3.2.0')
 
   # this is the latest puppet that will be installed into the default ruby version above


### PR DESCRIPTION
This change updates the default Ruby to 3.2.2 and latest puppet to v8.

The secondary Ruby is now 2.7.8.