### PR TITLE
(maint) Pin back concurrent ruby for agent 7 packages

### DIFF
--- a/configs/components/rubygem-concurrent-ruby.rb
+++ b/configs/components/rubygem-concurrent-ruby.rb
@@ -1,6 +1,15 @@
 component 'rubygem-concurrent-ruby' do |pkg, settings, platform|
-  pkg.version '1.1.10'
-  pkg.md5sum '4588a61d5af26e9ee12e9b8babc1b755'
+  # Projects may define a :rubygem_concurrent_ruby_version setting
+  version = settings[:rubygem_concurrent_ruby_version] || '1.1.10'
+
+  case version
+  when '1.1.9'
+    pkg.version '1.1.9'
+    pkg.md5sum '417a23cac840f6ea8bdd0841429c3c19'
+  when '1.1.10'
+    pkg.version '1.1.10'
+    pkg.md5sum '4588a61d5af26e9ee12e9b8babc1b755'
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/agent-runtime-7.x.rb
+++ b/configs/projects/agent-runtime-7.x.rb
@@ -6,6 +6,7 @@ project 'agent-runtime-7.x' do |proj|
   proj.setting :rubygem_fast_gettext_version, '1.1.2'
   proj.setting :rubygem_gettext_version, '3.2.2'
   proj.setting :rubygem_gettext_setup_version, '0.34'
+  proj.setting :rubygem_concurrent_ruby_version, '1.1.9'
 
   # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0
   if platform.is_solaris? || platform.is_aix?


### PR DESCRIPTION
Puppet agent 7 is compatable with 1.1.10 but some platforms (rhel7 aarch/arm) have a build step with a ruby version that is incompatable with concurrent-ruby 1.1.10. Given this will be deprecated soon and that concurrent ruby 1.1.9 is suitable on all platforms, pin it back for agent 7 series.