### PR TITLE
(PA-4877) Use Ruby 3 with Puppet 8 on Windows FIPS

### DIFF
--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -157,7 +157,7 @@ if platform.name =~ /sles-15|el-8|debian-10/ || platform.is_fedora?
   proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
 end
 
-if ruby_version_x == "3" && !platform.is_aix? && !platform.is_solaris? && !(platform.is_windows? && platform.is_fips?)
+if ruby_version_x == "3" && !platform.is_aix? && !platform.is_solaris?
   proj.setting(:openssl_version, '3.0')
 elsif platform.name =~ /^redhatfips-/
   proj.setting(:openssl_version, '1.1.1-fips')


### PR DESCRIPTION
The resulting Makefile contains:

```
openssl-3.0-configure: openssl-3.0-patch runtime-agent
        [ -d openssl-3.0.8 ] || mkdir -p openssl-3.0.8
        export PATH="$(shell cygpath -u C:/tools/mingw64/bin):$(PATH)" && \
        cd openssl-3.0.8 && \
         ./Configure --prefix=C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet --libdir=lib --openssldir=C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/ssl shared no-asm mingw64 no-camellia no-ec2m no-md2 no-ssl3 no-dtls no-dtls1 no-idea no-seed no-weak-ssl-ciphers -DOPENSSL_NO_HEARTBEATS 
        touch openssl-3.0-configure

openssl-3.0-build: openssl-3.0-configure
        export PATH="$(shell cygpath -u C:/tools/mingw64/bin):$(PATH)" && \
        cd openssl-3.0.8 && \
        /usr/bin/make depend && \
        /usr/bin/make
        touch openssl-3.0-build

openssl-3.0-check: openssl-3.0-build
        touch openssl-3.0-check

openssl-3.0-install: openssl-3.0-check
        export PATH="$(shell cygpath -u C:/tools/mingw64/bin):$(PATH)" && \
        cd openssl-3.0.8 && \
        /usr/bin/make install_sw install_ssldirs && \
        rm -f C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/bin/c_rehash && \
        /usr/bin/install -d 'C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/share/doc/openssl-3.0.8' && \
        /usr/bin/cp -p 'LICENSE.txt' 'C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/share/doc/openssl-3.0.8/LICENSE'
        touch openssl-3.0-install
```

Building agent-runtime-main in https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2041/BUILD_TARGET=windowsfips-2012r2-x64,SLAVE_LABEL=k8s-worker/

