### PR TITLE
(PA-5430) Patch augeas C extension

### DIFF
--- a/configs/components/_base-ruby-augeas.rb
+++ b/configs/components/_base-ruby-augeas.rb
@@ -3,6 +3,8 @@
 # load it with instance_eval. See ruby-x.y-augeas.rb configs.
 #
 
+pkg.add_source("file://resources/patches/augeas/ruby-augeas-0.5.0-patch_c_extension.patch")
+
 # These can be overridden by the including component.
 ruby_version ||= settings[:ruby_version]
 host_ruby ||= settings[:host_ruby]
@@ -72,6 +74,9 @@ end
 
 pkg.build do
   build_commands = []
+  if ruby_version =~ /^3/
+    build_commands << "#{platform.patch} --strip=2 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../ruby-augeas-0.5.0-patch_c_extension.patch"
+  end
   build_commands << "#{ruby} ext/augeas/extconf.rb"
   build_commands << "#{platform[:make]} -e -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"
 

--- a/resources/patches/augeas/ruby-augeas-0.5.0-patch_c_extension.patch
+++ b/resources/patches/augeas/ruby-augeas-0.5.0-patch_c_extension.patch
@@ -1,0 +1,12 @@
+diff --git a/ruby-augeas-0.5.0/ext/augeas/_augeas.c b/ruby-augeas-0.5.0/ext/augeas/_augeas.c
+index 95d9e05024..7aac0eb96d 100644
+--- a/ruby-augeas-0.5.0/ext/augeas/_augeas.c
++++ b/ruby-augeas-0.5.0/ext/augeas/_augeas.c
+@@ -489,6 +489,7 @@ void Init__augeas() {
+ 
+     /* Define the ruby class */
+     c_augeas = rb_define_class("Augeas", rb_cObject) ;
++        rb_undef_alloc_func(c_augeas);
+ 
+     /* Constants for enum aug_flags */
+ #define DEF_AUG_FLAG(name) \


### PR DESCRIPTION
This issue is very similar to PA-4844 (#620) except it affects augeas instead of selinux

When puppet is run with Ruby 3.2, this warning is generated:
`/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/augeas.rb:48: warning: undefining the allocator of T_DATA class Augeas`

This commit patches the autogenerated augeas C extension so there is no warning for augeas