### PR TITLE
(maint) Don't copy facter dll dependencies

### DIFF
--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -28,9 +28,6 @@ component "runtime-agent" do |pkg, settings, platform|
     pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll", "#{settings[:bindir]}/libgcc_s_#{lib_type}-1.dll"
     pkg.install_file "#{settings[:gcc_bindir]}/libstdc++-6.dll", "#{settings[:bindir]}/libstdc++-6.dll"
     pkg.install_file "#{settings[:gcc_bindir]}/libwinpthread-1.dll", "#{settings[:bindir]}/libwinpthread-1.dll"
-    pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll", "#{settings[:facter_root]}/lib/libgcc_s_#{lib_type}-1.dll"
-    pkg.install_file "#{settings[:gcc_bindir]}/libstdc++-6.dll", "#{settings[:facter_root]}/lib/libstdc++-6.dll"
-    pkg.install_file "#{settings[:gcc_bindir]}/libwinpthread-1.dll", "#{settings[:facter_root]}/lib/libwinpthread-1.dll"
 
     # Curl is dynamically linking against zlib, so we need to include this file until we
     # update curl to statically link against zlib


### PR DESCRIPTION
We used to copy some gcc dlls into ruby and native facter's bin directory, see PA-2067. But we no longer define `facter_root` so we were copying the dlls into cygwin's `/lib` directory on the build host. If you tried to rebuild on the same host, it would fail because the destination file existed.