### PR TITLE
(PA-5427) Enable dynamicbase on OpenSSL3 and Windows FIPS

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -20,10 +20,8 @@ component 'openssl' do |pkg, settings, platform|
 
  if platform.is_windows?
     pkg.environment 'PATH', "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
-  #   pkg.environment 'CYGWIN', settings[:cygwin]
-  #   pkg.environment 'CC', settings[:cc]
-  #   pkg.environment 'CXX', settings[:cxx]
-  #   pkg.environment 'MAKE', platform[:make]
+    pkg.environment 'CYGWIN', settings[:cygwin]
+    pkg.environment 'MAKE', platform[:make]
 
     target = platform.architecture == 'x64' ? 'mingw64' : 'mingw'
   #   cflags = settings[:cflags]

--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -99,32 +99,6 @@ component 'openssl' do |pkg, settings, platform|
   # CONFIGURE
   ###########
 
-  # if platform.is_solaris? && platform.name =~ /10/
-  #   # We need to link the rt library on Solaris 10 in order to access the clock_gettime
-  #   # function.
-  #   cflags += " -lrt"
-
-  #   # Additionally when we're building on SPARC, we need to revert
-  #   # https://github.com/openssl/openssl/commit/7a061312 because for
-  #   # some reason, the linker fails to generate the .map files (like
-  #   # e.g. libcrypto.map). Strangely, this is not an issue for Solaris
-  #   # 11 SPARC despite it using an older version of ld (2.25 vs. 2.27).
-  #   if platform.is_cross_compiled?
-  #     pkg.apply_patch 'resources/patches/openssl/openssl-1.1.1a-revert-7a061312.patch'
-  #   else
-  #     # Work around gcc not conforming to Solaris 32-bit ABI by expecting 16-byte stack alignment
-  #     # https://github.com/openssl/openssl/issues/13666
-  #     cflags += " -mincoming-stack-boundary=2"
-  #   end
-  # end
-
-  # OpenSSL 1.1.1q has a bug with a test not including a required library that caueses
-  # packing failures on macos. Probably safe to look at the 1.1.1r release to see if
-  # this can be removed.
-  # if platform.is_macos?
-  #   pkg.apply_patch 'resources/patches/openssl/openssl_1.1.1q_fix_c_include.patch'
-  # end
-
   # Defining --libdir ensures that we avoid the multilib (lib/ vs. lib64/) problem,
   # since configure uses the existence of a lib64 directory to determine
   # if it should install its own libs into a multilib dir. Yay OpenSSL!
@@ -160,8 +134,6 @@ component 'openssl' do |pkg, settings, platform|
   perl_exec = ''
   # if platform.is_aix?
   #   perl_exec = '/opt/freeware/bin/perl'
-  # elsif platform.is_solaris? && platform.os_version == '10'
-  #   perl_exec = '/opt/csw/bin/perl'
   # end
   configure_flags << project_flags
 

--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -16,16 +16,16 @@ component 'openssl' do |pkg, settings, platform|
     pkg.build_requires 'perl'
   end
 
-  target = cflags = ldflags = sslflags = ''
+  target = sslflags = ''
+  cflags = settings[:cflags]
+  ldflags = settings[:ldflags]
 
- if platform.is_windows?
+  if platform.is_windows?
     pkg.environment 'PATH', "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
     pkg.environment 'CYGWIN', settings[:cygwin]
     pkg.environment 'MAKE', platform[:make]
 
     target = platform.architecture == 'x64' ? 'mingw64' : 'mingw'
-  #   cflags = settings[:cflags]
-  #   ldflags = settings[:ldflags]
   # elsif platform.is_cross_compiled_linux?
   #   pkg.environment 'PATH', "/opt/pl-build-tools/bin:$(PATH)"
   #   pkg.environment 'CC', "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
@@ -35,8 +35,7 @@ component 'openssl' do |pkg, settings, platform|
   #     # OpenSSL fails to work on aarch unless we turn down the compiler optimization.
   #     # See PA-2135 for details
   #     cflags += " -O2"
-   end
-
+  #   end
   #   ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
   #   target = if platform.architecture == 'aarch64'
   #               'linux-aarch64'
@@ -59,10 +58,9 @@ component 'openssl' do |pkg, settings, platform|
   #   cflags = "#{settings[:cflags]} -fPIC"
   #   ldflags = "-R/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
   #   target = platform.architecture =~ /86/ ? 'solaris-x86-gcc' : 'solaris-sparcv9-gcc'
-  if platform.is_macos?
+  elsif platform.is_macos?
     pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
 
-    cflags = settings[:cflags]
     target = if platform.is_cross_compiled?
                'darwin64-arm64'
              else
@@ -71,7 +69,6 @@ component 'openssl' do |pkg, settings, platform|
   elsif platform.is_linux?
     pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
 
-    cflags = settings[:cflags]
     ldflags = "#{settings[:ldflags]} -Wl,-z,relro"
     if platform.architecture =~ /86$/
       target = 'linux-elf'

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -182,7 +182,9 @@ if platform.is_windows?
   proj.setting(:cflags, "#{proj.cppflags}")
 
   ldflags = "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir} -Wl,--nxcompat"
-  ldflags += ' -Wl,--dynamicbase' unless platform.name =~ /windowsfips-2012r2/
+  if platform.name !~ /windowsfips-2012r2/ || name != 'agent-runtime-7.x'
+    ldflags += ' -Wl,--dynamicbase'
+  end
   proj.setting(:ldflags, ldflags)
 
   proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")

--- a/resources/patches/windows/FORCEINLINE-i686-w64-mingw32-winnt.h
+++ b/resources/patches/windows/FORCEINLINE-i686-w64-mingw32-winnt.h
@@ -1,0 +1,70 @@
+From 8da1aae7a7ff5bf996878dc8fe30a0e01e210e5a Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <vinschen@redhat.com>
+Date: Tue, 25 Aug 2015 13:51:02 +0200
+Subject: [PATCH] winnt.h: FORCELINLINE inline-only definitions
+
+The following test application fails to build on i686 when building
+without optimization:
+
+  $ cat foo.c
+  #include <windows.h>
+
+  int
+  main ()
+  {
+    MEMORY_BASIC_INFORMATION m;
+    NT_TIB *tib = (NT_TIB *) NtCurrentTeb ();
+    VirtualQuery (tib, &m, sizeof m);
+  }
+  $ gcc -g -O foo.c -o foo
+  $ gcc -g foo.c -o foo
+  /tmp/ccnnAEl3.o: In function `main':
+  /home/corinna/foo.c:7: undefined reference to `NtCurrentTeb'
+  collect2: error: ld returned 1 exit status
+
+There's no way around that, except for building with optimization, which
+is often not prudent when debugging.
+
+In winnt.h, NtCurrentTeb is using __CRT_INLINE which, depending on C
+standard, expandes into
+
+  extern inline __attribute__((__gnu_inline__))
+
+or
+
+  extern __inline__
+
+However, that's not sufficient for NtCurrentTeb, nor for GetCurrentFiber,
+nor for GetFiberData, since these are inline-only functions not backed by
+non-inlined library versions.
+
+This patch fixes that by using FORCEINLINE in place of __CRT_INLINE.
+
+Signed-off-by: Corinna Vinschen <vinschen@redhat.com>
+---
+ mingw-w64-headers/include/winnt.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/mingw-w64-headers/include/winnt.h b/mingw-w64-headers/include/winnt.h
+index 8d8bd0d18..56d663df5 100644
+--- a/mingw-w64-headers/include/winnt.h
++++ b/mingw-w64-headers/include/winnt.h
+@@ -1995,15 +1995,15 @@ __buildmemorybarrier()
+ 
+ #define DbgRaiseAssertionFailure __int2c
+ 
+-  __CRT_INLINE struct _TEB *NtCurrentTeb(void)
++  FORCEINLINE struct _TEB *NtCurrentTeb(void)
+   {
+     return (struct _TEB *)__readfsdword(PcTeb);
+   }
+-  __CRT_INLINE PVOID GetCurrentFiber(void)
++  FORCEINLINE PVOID GetCurrentFiber(void)
+   {
+     return(PVOID)__readfsdword(0x10);
+   }
+-  __CRT_INLINE PVOID GetFiberData(void)
++  FORCEINLINE PVOID GetFiberData(void)
+   {
+       return *(PVOID *)GetCurrentFiber();
+   }


### PR DESCRIPTION
FIPS builds of openssl 2.x on Windows required libeay32.dll to be loaded at a fixed address 0x63000000. If it wasn't then FIPS_check_incore_fingerprint would generate an error. The openssl 3 fips provider doesn't have that issue so reenable dynamic base (ASLR).

- [x] [agent-runtime-main#1e2148d0f6c3cf13a2db6e9c1e9cc36a6c4047c3](https://builds.delivery.puppetlabs.net/puppet-runtime/1e2148d0f6c3cf13a2db6e9c1e9cc36a6c4047c3/artifacts)
- [x] [pxp-agent-vanagon#7fc114663c6ce804e6e23ed26bee41d97ad51884](https://builds.delivery.puppetlabs.net/pxp-agent/7fc114663c6ce804e6e23ed26bee41d97ad51884/artifacts)
- [x] [puppet-agent](https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1117/)