### PR TITLE
(PA-5409) Keep md4 for NTLM

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -117,7 +117,7 @@ component 'openssl' do |pkg, settings, platform|
     'no-cast',
     'no-rc2',
     'no-rc5',
-    'no-md4',
+    # 'no-md4', puppet infra uses the agent's runtime and runs WinRM tasks using NTLM, so it needs DES & MD4
     'no-mdc2',
     # 'no-rmd160', this is causing failures with pxp, remove once pxp-agent does not need it
     'no-whirlpool',


### PR DESCRIPTION
The 'puppet infra' command uses the agent's runtime when executing bolt tasks & plans. When a task uses the WinRM transport, it will authenticate to the Windows host using NTLM. The NTLMv1 protocol relies on MD4 to compute the NT-Hash[1] so we need to re-enable it here.

[1] https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/464551a8-9fc4-428e-b3d3-bc5bfb2e73a5