### PR TITLE
(maint) Reenable bf and cast ciphers for pgcrypto

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -113,8 +113,8 @@ component 'openssl' do |pkg, settings, platform|
     'no-dtls1-method',
     'no-dtls1_2-method',
     'no-aria',
-    'no-bf',
-    'no-cast',
+    # 'no-bf', pgcrypto is requires this cipher in postgres for puppetdb
+    # 'no-cast', pgcrypto is requires this cipher in postgres for puppetdb
     'no-rc2',
     'no-rc5',
     # 'no-md4', puppet infra uses the agent's runtime and runs WinRM tasks using NTLM, so it needs DES & MD4


### PR DESCRIPTION
The openssl built for puppet-runtime is used to build postgres for puppetdb; when openssl is built with the `no-bf` and `no-cast` flags, the pgcrypto module for postgres errors out during the build process. This change puts the ciphers back in so postgres can build for puppetdb.