### PR TITLE
(PE-36078) Use fork of ntlm with md4 ruby algo

### DIFF
--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -96,6 +96,10 @@ project 'pe-installer-runtime-main' do |proj|
   proj.component 'rubygem-prime'
   proj.component 'rubygem-erubi'
 
+  #TODO: Once we solve PE-36078 stop using forked ntlm
+  proj.setting(:gem_build, "#{proj.host_gem} build")
+  proj.component('rubygem-rubyntlm-fork')
+
   # What to include in package?
   proj.directory proj.prefix
 


### PR DESCRIPTION
While we figure out what we want to do for PE-36078, ship the gem build from the fork of ntlm that implements an md4 algorithm in ruby.