### PR TITLE
(PA-5594) Enable macOS 13 (ARM) puppet-runtime builds for agent-runtime-7.x

### DIFF
--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -54,14 +54,19 @@ component 'openssl' do |pkg, settings, platform|
     ldflags = "-R/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
     target = platform.architecture =~ /86/ ? 'solaris-x86-gcc' : 'solaris-sparcv9-gcc'
   elsif platform.is_macos?
-    pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
+    if platform.os_version.to_i >= 13 && platform.architecture == 'arm64'
+      pkg.environment 'PATH', '/opt/homebrew/bin:$(PATH):/usr/local/bin'
+    else
+      pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
+    end
 
     cflags = settings[:cflags]
-    target = if platform.is_cross_compiled?
-               'darwin64-arm64-cc'
-             else
-               'darwin64-x86_64-cc'
-             end
+
+    target =  if platform.architecture == 'arm64'
+                'darwin64-arm64-cc'
+              else
+                'darwin64-x86_64-cc'
+              end
   elsif platform.is_linux?
     pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
 

--- a/configs/components/ruby-2.7.8.rb
+++ b/configs/components/ruby-2.7.8.rb
@@ -111,6 +111,9 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
     # implementation instead of 'arm64', so specify 'amd64' explicitly
     # https://github.com/ruby/ruby/blob/c9c2245c0a25176072e02db9254f0e0c84c805cd/configure.ac#L2329-L2330
     special_flags += " --with-baseruby=#{host_ruby} --with-coroutine=arm64 "
+  elsif platform.is_macos? && platform.architecture == 'arm64' && platform.os_version.to_i >= 13
+    pkg.environment 'PATH', '/opt/homebrew/bin:$(PATH):/usr/local/bin'
+    special_flags += " --with-openssl-dir=#{settings[:prefix]} "
   elsif platform.is_solaris? && platform.architecture == "sparc"
     special_flags += " --with-baseruby=#{host_ruby} --enable-close-fds-by-recvmsg-with-peek "
   elsif platform.name =~ /el-6/
@@ -194,6 +197,7 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
     'x86_64-w64-mingw32' => 'x64-mingw32',
     'i686-w64-mingw32' => 'i386-mingw32'
   }
+
   if target_doubles.key?(settings[:platform_triple])
     rbconfig_topdir = File.join(ruby_dir, 'lib', 'ruby', '2.7.0', target_doubles[settings[:platform_triple]])
   else
@@ -225,6 +229,8 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
       # the ancient gcc version on sles-12-ppc64le does not understand -fstack-protector-strong, so remove the `strong` part
       rbconfig_changes["LDFLAGS"] = "-L. -Wl,-rpath=/opt/puppetlabs/puppet/lib -fstack-protector -rdynamic -Wl,-export-dynamic -L/opt/puppetlabs/puppet/lib"
     end
+  elsif platform.is_macos? && platform.architecture == 'arm64' && platform.os_version.to_i >= 13
+    rbconfig_changes["CC"] = 'clang'
   elsif platform.is_windows?
     rbconfig_changes["CC"] = "x86_64-w64-mingw32-gcc"
   end

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -28,7 +28,7 @@ component "yaml-cpp" do |pkg, settings, platform|
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
     elsif platform.architecture == 'arm64' && platform.os_version.to_i >= 13
       pkg.environment 'CXX', 'clang++'
-      cmake = "/opt/homebrew/bin/cmake" if platform.architecture == "arm64"
+      cmake = "/opt/homebrew/bin/cmake"
     end
 
   elsif platform.is_windows?

--- a/configs/platforms/osx-13-arm64.rb
+++ b/configs/platforms/osx-13-arm64.rb
@@ -1,9 +1,8 @@
 platform 'osx-13-arm64' do |plat|
-    plat.inherit_from_default
-  
-    packages = %w[automake cmake pkg-config yaml-cpp]
-    plat.provision_with "su test -c '/opt/homebrew/bin/brew install #{packages.join(' ')}'"
-  
-    plat.output_dir File.join('apple', '13', 'PC1', 'arm64')
-  end
-  
+  plat.inherit_from_default
+
+  packages = %w[automake cmake pkg-config yaml-cpp]
+  plat.provision_with "su test -c '/opt/homebrew/bin/brew install #{packages.join(' ')}'"
+
+  plat.output_dir File.join('apple', '13', 'PC1', 'arm64')
+end


### PR DESCRIPTION
Hello,
The result of component diff :

`
Platform name: osx-13-arm64
    Component 'openssl-1.1.1'
        Field: configure[0]
        --------------------
        - [" ./Configure --prefix=/opt/puppetlabs/puppet --libdir=lib --openssldir=/opt/puppetlabs/puppet/ssl shared no-asm darwin64-x86_64-cc  no-camellia no-ec2m no-md2 no-ssl3 no-dtls no-dtls1 no-idea no-seed no-weak-ssl-ciphers -DOPENSSL_NO_HEARTBEATS -I/opt/puppetlabs/puppet/include "]
        + [" ./Configure --prefix=/opt/puppetlabs/puppet --libdir=lib --openssldir=/opt/puppetlabs/puppet/ssl shared no-asm darwin64-arm64-cc  no-camellia no-ec2m no-md2 no-ssl3 no-dtls no-dtls1 no-idea no-seed no-weak-ssl-ciphers -DOPENSSL_NO_HEARTBEATS -I/opt/puppetlabs/puppet/include "]

        Field: environment
        --------------------
        - PATH=/opt/pl-build-tools/bin:$(PATH):/usr/local/bin
        + PATH=/opt/homebrew/bin:$(PATH):/usr/local/bin


    Component 'ruby-2.7.8'
        Field: configure[0]
        --------------------
        - ["bash configure         --enable-shared         --enable-bundled-libyaml         --disable-install-doc         --disable-install-rdoc                   --prefix=/opt/puppetlabs/puppet --with-opt-dir=/opt/puppetlabs/puppet  --enable-dtrace "]
        + ["bash configure         --enable-shared         --enable-bundled-libyaml         --disable-install-doc         --disable-install-rdoc                   --prefix=/opt/puppetlabs/puppet --with-opt-dir=/opt/puppetlabs/puppet  --with-openssl-dir=/opt/puppetlabs/puppet  --enable-dtrace "]

        Field: environment
        --------------------
        - optflags=-I/opt/puppetlabs/puppet/include CC=clang
        + optflags=-I/opt/puppetlabs/puppet/include CC=clang PATH=/opt/homebrew/bin:$(PATH):/usr/local/bin

        Field: install[12]
        --------------------
        + ["/opt/puppetlabs/puppet/bin/ruby ../rbconfig-update.rb \"{\\\"CC\\\"=>\\\"clang\\\"}\" $$(/opt/puppetlabs/puppet/bin/ruby -e \"puts RbConfig::CONFIG[\\\"topdir\\\"]\")", "cp original_rbconfig.rb /opt/puppetlabs/puppet/share/doc/rbconfig-2.7.8-orig.rb", "cp new_rbconfig.rb $$(/opt/puppetlabs/puppet/bin/ruby -e \"puts RbConfig::CONFIG[\\\"topdir\\\"]\")/rbconfig.rb"]

`

And [ vanagon generic pipeline](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1096/)

Also, [Artifacts](http://builds.delivery.puppetlabs.net/puppet-runtime/fb126f661ceba90ecacb689d75e5a1482182fad8/repos/?C=M&O=D)