### PR TITLE
(PA-4718) Updates for Solaris and agent-runtime-main

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -29,8 +29,16 @@ if platform.is_aix?
   end
   pkg.environment 'LDFLAGS', "#{settings[:ldflags]} -Wl,-bmaxdata:0x80000000"
 elsif platform.is_solaris?
-  pkg.environment 'PATH', "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$(PATH):/opt/csw/bin"
-  pkg.environment 'CC', "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+  # See PA-5639, if we decide to go without OpenCSW GCC then we can simplify this logic
+  if ruby_version_y >= '3.0'
+    pkg.environment 'PATH', "#{settings[:bindir]}:/opt/csw/bin:/usr/ccs/bin:/usr/sfw/bin:$(PATH)"
+    pkg.environment 'CC', '/opt/csw/bin/gcc'
+    pkg.environment 'LD', '/opt/csw/bin/gld'
+    pkg.environment 'AR', '/opt/csw/bin/gar'
+  else
+    pkg.environment 'PATH', "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$(PATH):/opt/csw/bin"
+    pkg.environment 'CC', "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+  end
   pkg.environment 'CXX', "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-g++"
   pkg.environment 'LDFLAGS', "-Wl,-rpath=#{settings[:libdir]}"
   if platform.os_version == '10'

--- a/configs/components/libffi.rb
+++ b/configs/components/libffi.rb
@@ -18,6 +18,7 @@ component 'libffi' do |pkg, settings, platform|
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
     pkg.environment "CFLAGS", "#{settings[:cflags]} -std=c99"
     pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment 'MAKE', 'gmake'
   elsif platform.is_macos?
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", settings[:cflags]

--- a/configs/components/ruby-3.2.2.rb
+++ b/configs/components/ruby-3.2.2.rb
@@ -85,6 +85,8 @@ component 'ruby-3.2.2' do |pkg, settings, platform|
     #   collect2: error: ld returned 16 exit status
 
     pkg.environment 'optflags', "-O2 -fPIC -g0 "
+  elsif platform.is_solaris?
+    pkg.environment 'optflags', '-O1'
   else
     pkg.environment 'optflags', '-O2'
   end
@@ -223,7 +225,7 @@ component 'ruby-3.2.2' do |pkg, settings, platform|
     elsif platform.name =~ /osx-12/
       rbconfig_changes["CC"] = 'clang -target arm64-apple-macos12'
     else
-      rbconfig_changes["CC"] = "gcc"
+      rbconfig_changes["CC"] =  'gcc'
       rbconfig_changes["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wno-maybe-uninitialized"
     end
     if platform.name =~ /el-7-ppc64/

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -65,9 +65,15 @@ component "rubygem-ffi" do |pkg, settings, platform|
   pkg.environment "CPATH", "/opt/csw/lib/libffi-3.2.1/include" if platform.name =~ /solaris-11/
   pkg.environment "MAKE", platform[:make] if platform.is_solaris?
 
-  if platform.is_cross_compiled_linux? || platform.is_solaris?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:/opt/csw/bin:$(PATH)"
-  end
+  if platform.is_cross_compiled_linux?
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
+  elsif platform.is_solaris?
+    if settings[:runtime_project] == 'agent-runtime-main'
+      pkg.environment "PATH", "/opt/csw/bin:/opt/pl-build-tools/bin:$(PATH)"
+    else
+      pkg.environment "PATH", "/opt/pl-build-tools/bin:/opt/csw/bin:$(PATH)"
+    end  
+  end  
 
   if platform.name =~ /solaris-11-i386/
     pkg.install_file "/usr/lib/libffi.so.5.0.10", "#{settings[:libdir]}/libffi.so"

--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -40,7 +40,7 @@ action=nocheck
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
   pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev || exit 1;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev autoconf gcc4core || exit 1;
 
   ntpdate pool.ntp.org]
   plat.output_dir File.join("solaris", "11", "PC1")


### PR DESCRIPTION
This PR updates Solaris on agent-runtime-main to:

* Build libffi, with gmake
* Build Ruby 3.2.2 with OpenCSW gcc
* Configure rubygem-ffi, but still expected to fail. rubygem-ffi will be fixed at a later point
* Also installs a new GCC and autotools as part of the image.