### PR TITLE
(maint) Remove deprecated OpenSSL functions

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -111,7 +111,6 @@ component 'openssl' do |pkg, settings, platform|
     target,
     sslflags,
     'no-camellia',
-    'no-ec2m',
     'no-md2',
     'no-ssl3',
     'no-ssl3-method',
@@ -120,7 +119,6 @@ component 'openssl' do |pkg, settings, platform|
     'no-aria',
     # 'no-bf', pgcrypto is requires this cipher in postgres for puppetdb
     # 'no-cast', pgcrypto is requires this cipher in postgres for puppetdb
-    'no-rc2',
     'no-rc5',
     # 'no-md4', puppet infra uses the agent's runtime and runs WinRM tasks using NTLM, so it needs DES & MD4
     'no-mdc2',


### PR DESCRIPTION
macOS x86 builds of agent-runtime-main recently started failing due to a combination of Homebrew updating all of its core Formulae from OpenSSL 1.1.1 to 3.0 and our build was configuring OpenSSL to use the `EC_GROUP_new` and `EVP_rc2_40_cbc` functions that were deprecated in OpenSSL 3[1]

This commit removes the configuration flags for OpenSSL 3 that invoke these deprecated functions.

[1] https://www.openssl.org/docs/man3.0/man7/migration_guide.html