### PR TITLE
(PA-4871) Add our libdir to the runtime linker search path

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -53,8 +53,9 @@ component 'openssl' do |pkg, settings, platform|
     pkg.environment 'CC', '/opt/freeware/bin/gcc'
 
     cflags = "#{settings[:cflags]} -static-libgcc"
-    # see https://github.com/openssl/openssl/issues/18007
-    ldflags = "#{settings[:ldflags]} -latomic -lm"
+    # see https://github.com/openssl/openssl/issues/18007 about -latomic
+    # see https://www.ibm.com/docs/en/aix/7.2?topic=l-ld-command about -R<path>, which is equivalent to -rpath
+    ldflags = "#{settings[:ldflags]} -Wl,-R#{settings[:libdir]} -latomic -lm"
     target = 'aix-gcc'
   # elsif platform.is_solaris?
   #   pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin'


### PR DESCRIPTION
When the runtime linker loads executables, it uses a search path in the
executable to find library dependencies. On most platforms this is done
via -rpath, but on AIX it's -R. The search path is embedded in the
executable and can be seen using:

    # dump -H /opt/puppetlabs/puppet/bin/openssl
    ...
                               ***Import File Strings***
    INDEX  PATH                          BASE                MEMBER
    0      /opt/puppetlabs/puppet/lib:/usr/lib:/lib

Built in https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2110/BUILD_TARGET=aix-7.2-ppc,SLAVE_LABEL=k8s-worker/

## Project `agent-runtime-main`

### Platform name: `aix-7.2-ppc`
<details>
  <summary>Component 'openssl-3.0'</summary>

**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `environment`
```diff
- CC=/opt/freeware/bin/gcc CFLAGS=-I/opt/puppetlabs/puppet/include -I/opt/pl-build-tools/include -static-libgcc LDFLAGS=-Wl,-brtl -L/opt/puppetlabs/puppet/lib -latomic -lm
+ CC=/opt/freeware/bin/gcc CFLAGS=-I/opt/puppetlabs/puppet/include -I/opt/pl-build-tools/include -static-libgcc LDFLAGS=-Wl,-brtl -L/opt/puppetlabs/puppet/lib -Wl,-R/opt/puppetlabs/puppet/lib -latomic -lm
```
</details>

