### PR TITLE
(PA-5637) Ensure mktemp is available without modifying PATH

### DIFF
--- a/configs/platforms/aix-7.2-ppc.rb
+++ b/configs/platforms/aix-7.2-ppc.rb
@@ -1,7 +1,6 @@
 platform "aix-7.2-ppc" do |plat|
   # os_version = 7.2
   plat.make "gmake"
-  plat.mktemp "/opt/freeware/bin/mktemp -d -p /var/tmp"
   plat.patch "/opt/freeware/bin/patch"
   plat.rpmbuild "/usr/bin/rpm"
   plat.servicetype "aix"
@@ -39,6 +38,9 @@ packages = %w(
 
   # No upstream rsync packages
   plat.provision_with "rpm -Uvh https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/rsync/rsync-3.0.6-1.aix5.3.ppc.rpm"
+
+  # lots of things expect mktemp to be installed in the usual place, so link it
+  plat.provision_with "ln -sf /opt/freeware/bin/mktemp /usr/bin/mktemp"
 
   plat.install_build_dependencies_with "yum install --assumeyes "
   plat.vmpooler_template "aix-7.2-power"


### PR DESCRIPTION
While a custom `mktemp` command can be specified in vanagon, we expect the command to be available in PATH, such as in CI. Just link it.

Passed in https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2109/BUILD_TARGET=aix-7.2-ppc,SLAVE_LABEL=k8s-worker

This should resolve the issue we ran into in CI, forcing us to disable [AIX 7.2](https://github.com/puppetlabs/ci-job-configs/pull/8988). When this is merged, please also merge https://github.com/puppetlabs/ci-job-configs/pull/8994