### PR TITLE
(PA-5618) Build curl on AIX 7.2

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -41,6 +41,17 @@ component 'curl' do |pkg, settings, platform|
     configure_options << "--disable-dependency-tracking"
   end
 
+  if platform.name == 'aix-7.2-ppc'
+    # yum on aix installs an old version of libcurl.a that /opt/freeware/bin/gcc seems
+    # to use no matter what -L search path I use, so use the same workaround as bbf248fb6
+    pkg.configure do
+      [
+        'mkdir -p /opt/freeware/lib/hide',
+        'mv /opt/freeware/lib/libcurl.a /opt/freeware/lib/hide/libcurl.a'
+      ]
+    end
+  end
+
   pkg.configure do
     ["CPPFLAGS='#{settings[:cppflags]}' \
       LDFLAGS='#{settings[:ldflags]}' \
@@ -57,6 +68,12 @@ component 'curl' do |pkg, settings, platform|
 
   pkg.build do
     ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  if platform.name == 'aix-7.2-ppc'
+    pkg.build do
+      ['mv /opt/freeware/lib/hide/libcurl.a /opt/freeware/lib/libcurl.a']
+    end
   end
 
   install_steps = [

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -30,7 +30,7 @@ else
   proj.component "openssl-#{proj.openssl_version}"
 end
 
-proj.component 'curl' if platform.name != 'aix-7.2-ppc' # PA-5618
+proj.component 'curl'
 proj.component 'puppet-ca-bundle'
 proj.component "ruby-#{proj.ruby_version}"
 proj.component "readline" if platform.is_macos?


### PR DESCRIPTION
Hide and restore /opt/freeware/lib/libcurl.a while building curl

PR https://github.com/puppetlabs/puppet-runtime/pull/690 should be merged first

## Project `agent-runtime-main`

### Platform name: `aix-7.2-ppc`
&nbsp;&nbsp;&nbsp;&nbsp;Component 'curl' was newly added, not showing diff for it :white_check_mark:

## Project `agent-runtime-7.x`

### Platform name: `aix-7.2-ppc`
&nbsp;&nbsp;&nbsp;&nbsp;Component 'curl' was newly added, not showing diff for it :white_check_mark: