### PR TITLE
(PA-5617) Build yaml-cpp on AIX 7.2

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -41,17 +41,6 @@ component 'curl' do |pkg, settings, platform|
     configure_options << "--disable-dependency-tracking"
   end
 
-  if platform.name == 'aix-7.2-ppc'
-    # yum on aix installs an old version of libcurl.a that /opt/freeware/bin/gcc seems
-    # to use no matter what -L search path I use, so use the same workaround as bbf248fb6
-    pkg.configure do
-      [
-        'mkdir -p /opt/freeware/lib/hide',
-        'mv /opt/freeware/lib/libcurl.a /opt/freeware/lib/hide/libcurl.a'
-      ]
-    end
-  end
-
   pkg.configure do
     ["CPPFLAGS='#{settings[:cppflags]}' \
       LDFLAGS='#{settings[:ldflags]}' \
@@ -68,12 +57,6 @@ component 'curl' do |pkg, settings, platform|
 
   pkg.build do
     ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
-  end
-
-  if platform.name == 'aix-7.2-ppc'
-    pkg.build do
-      ['mv /opt/freeware/lib/hide/libcurl.a /opt/freeware/lib/libcurl.a']
-    end
   end
 
   install_steps = [

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -39,7 +39,8 @@ component "yaml-cpp" do |pkg, settings, platform|
     cmake_toolchain_file = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
   else
     if platform.is_aix?
-      pkg.environment "PATH", "$PATH:/opt/freeware/bin"
+      pkg.environment "PATH", "$(PATH):/opt/freeware/bin"
+      cmake = "/opt/freeware/bin/cmake"
     end
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment 'CFLAGS', settings[:cflags]

--- a/configs/platforms/aix-7.2-ppc.rb
+++ b/configs/platforms/aix-7.2-ppc.rb
@@ -7,10 +7,10 @@ platform "aix-7.2-ppc" do |plat|
   plat.tar "/opt/freeware/bin/tar"
 
   plat.provision_with %[
-curl -O https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/openssl-1.0.2.1800.tar.Z;
-uncompress openssl-1.0.2.1800.tar.Z;
-tar xvf openssl-1.0.2.1800.tar;
-cd openssl-1.0.2.1800 && /usr/sbin/installp -acgwXY -d $PWD openssl.base;
+curl -O https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/openssl-1.1.2.2000.tar.Z;
+uncompress openssl-1.1.2.2000.tar.Z;
+tar xvf openssl-1.1.2.2000.tar;
+cd openssl-1.1.2.2000 && /usr/sbin/installp -acgwXY -d $PWD openssl.base;
 curl --output yum.sh https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/aix-yum.sh && sh yum.sh]
 
   # After installing yum, but before yum installing packages, point yum to artifactory
@@ -19,10 +19,11 @@ curl --output yum.sh https://artifactory.delivery.puppetlabs.net/artifactory/gen
 rpm -Uvh https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/sed/sed-4.1.1-1.aix5.1.ppc.rpm;
 /opt/freeware/bin/sed -i 's|https://anonymous:anonymous@public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS|https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS|' /opt/freeware/etc/yum/yum.conf]
 
-packages = %w(
+  packages = %w(
     autoconf
     cmake
     coreutils
+    curl-7.86.0
     gawk
     gcc
     gcc-c++

--- a/configs/platforms/aix-7.2-ppc.rb
+++ b/configs/platforms/aix-7.2-ppc.rb
@@ -44,7 +44,7 @@ rpm -Uvh https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix
   plat.provision_with "yum install --assumeyes #{packages.join(' ')}"
 
   # No upstream rsync packages
-  plat.provision_with "rpm -Uvh https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/rsync/rsync-3.0.6-1.aix5.3.ppc.rpm"
+  plat.provision_with "rpm -Uvh --replacepkgs https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/rsync/rsync-3.0.6-1.aix5.3.ppc.rpm"
 
   # lots of things expect mktemp to be installed in the usual place, so link it
   plat.provision_with "ln -sf /opt/freeware/bin/mktemp /usr/bin/mktemp"

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -80,5 +80,5 @@ project 'agent-runtime-main' do |proj|
   proj.component 'rubygem-prime'
 
   proj.component 'boost' if ENV['NO_PXP_AGENT'].to_s.empty?
-  proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty? && platform.name != 'aix-7.2-ppc' # PA-5617
+  proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty?
 end


### PR DESCRIPTION
Previous attempts to build yaml-cpp failed when trying to run
/opt/freeware/bin/cmake, because it linked to libcurl.a and generated:

    0509-150 Dependent module /opt/freeware/lib/libcurl.a(libcurl.so.4) could not be loaded.
    0509-103 The module has an invalid magic number.

That library is preinstalled on our AIX 7.2 hosts and is version 7.52.1. The
library is also used by yum/python in order to download AIX toolbox packages.

As mentioned in https://github.com/eclipse-openj9/openj9/issues/4245 upgrading
the curl version resolves the issue. And in order to do that we need to bootstrap
a newer openssl 1.1.x version.

Installing newer curl also means we can remove the hack that was added when
building curl.

Note the typo `$PATH` vs `$(PATH)`. The latter is necessary so that PATH is
resolved at runtime when make executes. Sometimes it's also written as `$$PATH`.

Built in https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=aix-7.2-ppc,SLAVE_LABEL=k8s-worker/2115/