### PR TITLE
(PA-5645) Install additional runtime dependencies

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -12,6 +12,7 @@ component 'curl' do |pkg, settings, platform|
   pkg.build_requires "openssl-#{settings[:openssl_version]}"
   pkg.build_requires "puppet-ca-bundle"
 
+  ldflags = settings[:ldflags]
   if platform.is_cross_compiled_linux?
     pkg.build_requires "runtime-#{settings[:runtime_project]}"
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
@@ -22,7 +23,10 @@ component 'curl' do |pkg, settings, platform|
     pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
     pkg.environment "CYGWIN", settings[:cygwin]
   elsif platform.is_aix? && platform.name != 'aix-7.1-ppc'
+    pkg.environment "PKG_CONFIG_PATH", "/opt/puppetlabs/puppet/lib/pkgconfig"
     pkg.environment 'PATH', "/opt/freeware/bin:$(PATH):#{settings[:bindir]}"
+    # exclude -Wl,-brtl
+    ldflags = "-L#{settings[:libdir]}"
   else
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
   end
@@ -43,7 +47,7 @@ component 'curl' do |pkg, settings, platform|
 
   pkg.configure do
     ["CPPFLAGS='#{settings[:cppflags]}' \
-      LDFLAGS='#{settings[:ldflags]}' \
+      LDFLAGS='#{ldflags}' \
      ./configure --prefix=#{settings[:prefix]} \
         #{configure_options.join(" ")} \
         --enable-threaded-resolver \

--- a/configs/components/ruby-3.2.2.rb
+++ b/configs/components/ruby-3.2.2.rb
@@ -48,6 +48,7 @@ component 'ruby-3.2.2' do |pkg, settings, platform|
   end
 
   if platform.is_aix?
+    pkg.apply_patch "#{base}/reline_disable_terminfo.patch"
     # TODO: Remove this patch once PA-1607 is resolved.
  #   pkg.apply_patch "#{base}/aix_configure.patch"
  #   pkg.apply_patch "#{base}/aix-fix-libpath-in-configure.patch"

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -29,6 +29,11 @@ component "runtime-agent" do |pkg, settings, platform|
     pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
     if platform.name != 'aix-7.1-ppc'
       pkg.install_file File.join(libdir, "libatomic.a"), "/opt/puppetlabs/puppet/lib/libatomic.a"
+      pkg.install_file "/opt/freeware/lib/libiconv.a", "/opt/puppetlabs/puppet/lib/libiconv.a"
+      pkg.install_file "/opt/freeware/lib/libncurses.so.6.3.0", "/opt/puppetlabs/puppet/lib/libncurses.so.6.3.0"
+      pkg.link         "libncurses.so.6.3.0", "/opt/puppetlabs/puppet/lib/libncurses.so"
+      pkg.install_file "/opt/freeware/lib/libreadline.a", "/opt/puppetlabs/puppet/lib/libreadline.a"
+      pkg.install_file "/opt/freeware/lib/libz.a", "/opt/puppetlabs/puppet/lib/libz.a"
     end
   elsif platform.is_windows?
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"

--- a/configs/platforms/aix-7.2-ppc.rb
+++ b/configs/platforms/aix-7.2-ppc.rb
@@ -6,24 +6,35 @@ platform "aix-7.2-ppc" do |plat|
   plat.servicetype "aix"
   plat.tar "/opt/freeware/bin/tar"
 
-  plat.provision_with %[
+  plat.provision_with %(
 curl -O https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/openssl-1.1.2.2000.tar.Z;
 uncompress openssl-1.1.2.2000.tar.Z;
 tar xvf openssl-1.1.2.2000.tar;
 cd openssl-1.1.2.2000 && /usr/sbin/installp -acgwXY -d $PWD openssl.base;
-curl --output yum.sh https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/aix-yum.sh && sh yum.sh]
+curl --output yum.sh https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/aix-yum.sh && sh yum.sh)
+
+  # Since we updated openssl.base, run updtvpkg so that RPM packages that we install
+  # later build against the new openssl.
+  # See https://www.ibm.com/support/pages/understanding-aix-virtual-rpm-package-rpmrte
+  plat.provision_with 'updtvpkg'
 
   # After installing yum, but before yum installing packages, point yum to artifactory
   # AIX sed doesn't support in-place replacement, so download GNU sed and use that
-  plat.provision_with %[
+  plat.provision_with %(
 rpm -Uvh https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/sed/sed-4.1.1-1.aix5.1.ppc.rpm;
-/opt/freeware/bin/sed -i 's|https://anonymous:anonymous@public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS|https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS|' /opt/freeware/etc/yum/yum.conf]
+/opt/freeware/bin/sed -i 's|https://anonymous:anonymous@public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS|https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS|' /opt/freeware/etc/yum/yum.conf)
+
+  # yum.sh downloads rpm.rte containing several base packages including curl
+  # 7.51. However, that version isn't compatible with cmake. If we update curl
+  # specifically, then yum/python/libcurl will be in an inconsistent state. So
+  # run `yum update` to update to newer versions while maintaining compatible
+  # versions.
+  plat.provision_with 'yum update --assumeyes --skip-broken'
 
   packages = %w(
     autoconf
     cmake
     coreutils
-    curl-7.86.0
     gawk
     gcc
     gcc-c++

--- a/resources/patches/ruby_32/reline_disable_terminfo.patch
+++ b/resources/patches/ruby_32/reline_disable_terminfo.patch
@@ -1,0 +1,23 @@
+commit e0e58e7f5ee53e14f7a87a7399ad977a1381861a
+Author: Josh Cooper <joshcooper@users.noreply.github.com>
+Date:   Mon Jul 10 22:34:25 2023 -0700
+
+    Disable terminfo
+    
+    If curses libraries can be loaded but terminfo isn't installed, then
+    reline raises, killing irb. Apply this patch to disable terminfo
+    integration.
+
+diff --git a/lib/reline/terminfo.rb b/lib/reline/terminfo.rb
+index f53642b919..e0633f802b 100644
+--- a/lib/reline/terminfo.rb
++++ b/lib/reline/terminfo.rb
+@@ -163,7 +163,7 @@ def self.tigetnum(capname)
+   end
+ 
+   def self.enabled?
+-    true
++    false
+   end
+ end if Reline::Terminfo.curses_dl
+ 


### PR DESCRIPTION
Whenver a fileset is installed via installp, e.g. openssl.base, IBM recommends
running updtvpkg so that RPM packages which depend on it, build correctly.

And after installing rpm.rte, yum prints that an update is required. This seems
to resolve package dependencies issues between yum/python/libcurl and cmake.

For reasons not entirely clear, if we provision an AIX host, install yum,
install build dependencies and then build curl within the same ssh session, then
the resulting curl executable will fail to run:

    # /opt/puppetlabs/puppet/bin/curl
    exec(): 0509-036 Cannot load program /opt/puppetlabs/puppet/bin/curl because of the following errors:
        0509-150   Dependent module libcurl.a(libcurl.so.4) could not be loaded.
        0509-022 Cannot load module libcurl.a(libcurl.so.4).
        0509-026 System error: A file or directory in the path name does not exist.

This occurs even though our libdir is first in the linker search path:

    # dumpbin -Hv /opt/puppetlabs/puppet/bin/curl
    ...
                      ***Import File Strings***
         INDEX  PATH                          BASE                MEMBER
         0      /opt/puppetlabs/puppet/lib:/opt/puppetlabs/puppet/lib:/opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/10:/opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/10/../../..:/opt/freeware/lib:/usr/lib:/lib

However, if you install yum and dependendencies in one ssh connection and then
try to build curl in a second, it works.

I think this has something to do with the way AIX caches shared libraries in
memory. For example, `yum install` loads `libcurl.a` and it's still in memory
when we build curl:

    # genkld | grep curl
    d15c9100    8a424 /opt/freeware/lib/libcurl.a[libcurl.so.4]

It's possible to clear shared libraries whose reference counts are 0, using
slibclean, but there's no guarantee that the library is unloaded.

Disabling runtime linking (removing -brtl from LDFLAGS) seems to reliably work.

Building https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2137/BUILD_TARGET=aix-7.2-ppc,SLAVE_LABEL=k8s-worker/