### PR TITLE
(PA-5640) Fix ruybgem-ffi runtime logic

### DIFF
--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -68,7 +68,7 @@ component "rubygem-ffi" do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
   elsif platform.is_solaris?
-    if settings[:runtime_project] == 'agent-runtime-main'
+    if settings[:ruby_version] =~ /3\.\d+\.\d+/
       pkg.environment "PATH", "/opt/csw/bin:/opt/pl-build-tools/bin:$(PATH)"
     else
       pkg.environment "PATH", "/opt/pl-build-tools/bin:/opt/csw/bin:$(PATH)"


### PR DESCRIPTION
Our logic is incorrect, previously we were looking at `settings[:runtime_project]`. In agent-runtime context that will always just return 'agent', not the full project name we were looking for.
This lead to having the PL build tools path added earlier then we want and an older GCC being used that breaks rubygem-ffi from building.