### PR TITLE
(PE-36348) Enable legacy openssl algos in PE Installer runtime to support Bolt's WinRM transport

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -128,12 +128,15 @@ component 'openssl' do |pkg, settings, platform|
     # 'no-bf', pgcrypto is requires this cipher in postgres for puppetdb
     # 'no-cast', pgcrypto is requires this cipher in postgres for puppetdb
     'no-rc5',
-    # 'no-md4', puppet infra uses the agent's runtime and runs WinRM tasks using NTLM, so it needs DES & MD4
     'no-mdc2',
     # 'no-rmd160', this is causing failures with pxp, remove once pxp-agent does not need it
-    'no-whirlpool',
-    'no-legacy'
+    'no-whirlpool'
   ]
+
+  if !settings[:use_legacy_openssl_algos]
+    configure_flags << 'no-legacy' << 'no-md4' << 'no-des'
+  end
+
 
   # Individual projects may provide their own openssl configure flags:
   project_flags = settings[:openssl_extra_configure_flags] || []

--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -133,7 +133,9 @@ component 'openssl' do |pkg, settings, platform|
     'no-whirlpool'
   ]
 
-  if !settings[:use_legacy_openssl_algos]
+  if settings[:use_legacy_openssl_algos]
+    pkg.apply_patch 'resources/patches/openssl/openssl-3-activate-legacy-algos.patch'
+  else
     configure_flags << 'no-legacy' << 'no-md4' << 'no-des'
   end
 

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -3,10 +3,11 @@ project 'pe-installer-runtime-main' do |proj|
   proj.setting(:runtime_project, 'pe-installer')
   proj.setting(:ruby_version, '3.2.2')
   proj.setting(:augeas_version, '1.13.0')
-  # We need to explicitly define 1.1.1k here to avoid
-  # build dep conflicts between openssl-1.1.1 needed by curl
-  # and krb5-devel
   proj.setting(:openssl_version, '3.0')
+  # NLTM uses MD4 unconditionally in its protocol, so legacy algos must be
+  # enabled in OpenSSL >= 3.0 for Bolt's WinRM transport to work.
+  # We DO NOT WANT legacy algos enabled for the Puppet Agent runtime.
+  proj.setting(:use_legacy_openssl_algos, true)
   platform = proj.get_platform
 
   proj.version_from_git

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -97,10 +97,6 @@ project 'pe-installer-runtime-main' do |proj|
   proj.component 'rubygem-prime'
   proj.component 'rubygem-erubi'
 
-  #TODO: Once we solve PE-36078 stop using forked ntlm
-  proj.setting(:gem_build, "#{proj.host_gem} build")
-  proj.component('rubygem-rubyntlm-fork')
-
   # What to include in package?
   proj.directory proj.prefix
 

--- a/resources/patches/openssl/openssl-3-activate-legacy-algos.patch
+++ b/resources/patches/openssl/openssl-3-activate-legacy-algos.patch
@@ -1,0 +1,24 @@
+diff --git a/apps/openssl.cnf b/apps/openssl.cnf
+index 12bc408..8ab8aa7 100644
+--- a/apps/openssl.cnf
++++ b/apps/openssl.cnf
+@@ -56,6 +56,7 @@ providers = provider_sect
+ # List of providers to load
+ [provider_sect]
+ default = default_sect
++legacy = legacy_sect
+ # The fips section name should match the section name inside the
+ # included fipsmodule.cnf.
+ # fips = fips_sect
+@@ -69,7 +70,10 @@ default = default_sect
+ # OpenSSL may not work correctly which could lead to significant system
+ # problems including inability to remotely access the system.
+ [default_sect]
+-# activate = 1
++activate = 1
++
++[legacy_sect]
++activate = 1
+ 
+ 
+ ####################################################################


### PR DESCRIPTION
Implements the solution described in https://tickets.puppetlabs.com/browse/PE-36078

Still needs building & testing but putting this up so I can verify I understand the basics correctly.