### PR TITLE
(PA-5640) Fix up Solaris' ffi gem

### DIFF
--- a/configs/components/_base-rubygem.rb
+++ b/configs/components/_base-rubygem.rb
@@ -21,6 +21,9 @@ if platform.is_windows?
   pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:$(PATH)"
 end
 
+if name =~ /ffi/ && settings[:ruby_version].to_f >= 3.2 && platform.is_solaris?
+  extra_install_settings = ' -- --enable-system-libffi'
+end
 # When cross-compiling, we can't use the rubygems we just built.
 # Instead we use the host gem installation and override GEM_HOME. Yay?
 pkg.environment "GEM_HOME", settings[:gem_home]
@@ -38,5 +41,5 @@ pkg.url("https://rubygems.org/downloads/#{name}-#{version}.gem")
 pkg.mirror("#{settings[:buildsources_url]}/#{name}-#{version}.gem")
 
 pkg.install do
-  "#{settings[:gem_install]} #{name}-#{version}.gem"
+  "#{settings[:gem_install]} #{name}-#{version}.gem#{extra_install_settings}"
 end

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -75,7 +75,8 @@ component "rubygem-ffi" do |pkg, settings, platform|
     end  
   end  
 
-  if platform.name =~ /solaris-11-i386/
+  # With Ruby 3.2 on Solaris-11 we install OpenSCW's libffi, no need to copy over the system libffi
+  if platform.name =~ /solaris-11-i386/ && rb_major_minor_version < 3.2
     pkg.install_file "/usr/lib/libffi.so.5.0.10", "#{settings[:libdir]}/libffi.so"
   elsif platform.name =~ /solaris-10-i386/
     pkg.install_file "/opt/csw/lib/libffi.so.6", "#{settings[:libdir]}/libffi.so.6"


### PR DESCRIPTION
This PR cleans up a bit of the Solaris FFI gem work around Solaris. We no longer copy over the system libffi and rely on the OpenCSW libffi we install. Also when installing them ffi gem we use the OpenCSW libffi.