### PR TITLE
(PE-36344) Disable curl's ntlm if OpenSSL excludes it

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -34,6 +34,12 @@ component 'curl' do |pkg, settings, platform|
   configure_options = []
   configure_options << "--with-ssl=#{settings[:prefix]}"
 
+  # OpenSSL version 3.0 & up no longer ships by default the insecure algorithms
+  # that curl's ntlm module depends on (md4 & des).
+  if !settings[:use_legacy_openssl_algos] && settings[:openssl_version] =~ /^3\./
+    configure_options << "--disable-ntlm"
+  end
+
   extra_cflags = []
   if platform.is_cross_compiled? && platform.is_macos?
     extra_cflags << '-mmacosx-version-min=11.0 -arch arm64' if platform.name =~ /osx-11/


### PR DESCRIPTION
OpenSSL 3.0 by default disables some legacy algorithms that are required for ntlm. We previously kept them enabled for Bolt's WinRM transport but in b85bf0fda made the inclusion of these legacy algorithms optional so that the agent and company no longer have to include insecure crypto on account of Bolt.

However, removing the NTLM algorithms from OpenSSL caused downstream failures in the compilation of curl, which this patch addresses by disabling curl's support for NTLM.