### PR TITLE
(PA-5646) Pin to OpenSSL 1.1 Ruby 2.7

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -59,9 +59,10 @@ elsif platform.is_windows?
 elsif platform.is_macos?
   pkg.environment 'optflags', settings[:cflags]
   if platform.is_cross_compiled?
-    # Pin to an older version of ruby@2.5. This can be removed once we're no longer cross-compiling
-    if ruby_version_y == "2.5"
-      pkg.build_requires "puppetlabs/puppet/ruby@2.5"
+    # Pin to an older version of ruby@2.7 hosted by Puppet as Homebrew
+    # moved its Ruby 2.7 formula from OpenSSL 1.1 to 3.0
+    if ruby_version_y == "2.7"
+      pkg.build_requires "puppetlabs/puppet/ruby@2.7"
     else
       pkg.build_requires "ruby@#{ruby_version_y}"
     end


### PR DESCRIPTION
Homebrew recently updated its Ruby 2.7 formula to use OpenSSL 3.0 instead of 1.1:

https://github.com/Homebrew/homebrew-core/pull/134420/commits/fb4bb7656476000716e7d45bb595561789b2d18c

Ruby 2.7 does not support OpenSSL 3.0, so using Homebrew's updated formula causes test failures for puppet-agent.

This commit switches our Vanagon projects to use the last version of Homebrew's Ruby 2.7 formula prior to the switch over to OpenSSL 3.0.