### PR TITLE
(PA-5692) Build yaml-cpp and boost on Solaris 11 SPARC

### DIFF
--- a/configs/components/_base-ruby-augeas.rb
+++ b/configs/components/_base-ruby-augeas.rb
@@ -36,10 +36,18 @@ pkg.environment "CONFIGURE_ARGS", '--vendor'
 pkg.environment "PKG_CONFIG_PATH", "#{File.join(settings[:libdir], 'pkgconfig')}:/usr/lib/pkgconfig"
 
 if platform.is_solaris?
-  if platform.architecture == 'sparc'
+  if platform.is_cross_compiled?
     pkg.environment "RUBY", host_ruby
   end
-  ruby = "#{host_ruby} -r#{settings[:datadir]}/doc/rbconfig-#{ruby_version}-orig.rb"
+
+  if !platform.is_cross_compiled? && platform.architecture == 'sparc'
+    ruby = File.join(ruby_bindir, 'ruby')
+  else
+    # This should really only be done when cross compiling but
+    # to avoid breaking solaris x86_64 in 7.x continue preloading
+    # our hook.
+    ruby = "#{host_ruby} -r#{settings[:datadir]}/doc/rbconfig-#{ruby_version}-orig.rb"
+  end
 elsif platform.is_cross_compiled?
   if platform.is_linux? || platform.is_macos?
     pkg.environment "RUBY", host_ruby

--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -31,10 +31,15 @@ if platform.is_aix?
 elsif platform.is_solaris?
   # See PA-5639, if we decide to go without OpenCSW GCC then we can simplify this logic
   if ruby_version_y >= '3.0'
-    pkg.environment 'PATH', "#{settings[:bindir]}:/opt/csw/bin:/usr/ccs/bin:/usr/sfw/bin:$(PATH)"
-    pkg.environment 'CC', '/opt/csw/bin/gcc'
-    pkg.environment 'LD', '/opt/csw/bin/gld'
-    pkg.environment 'AR', '/opt/csw/bin/gar'
+    if !platform.is_cross_compiled? && platform.architecture == 'sparc'
+      pkg.environment 'PATH', "#{settings[:bindir]}:/opt/pl-build-tools/bin:/opt/csw/bin:/usr/ccs/bin:/usr/sfw/bin:$(PATH)"
+      pkg.environment 'CC', "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    else
+      pkg.environment 'PATH', "#{settings[:bindir]}:/opt/csw/bin:/usr/ccs/bin:/usr/sfw/bin:$(PATH)"
+      pkg.environment 'CC', '/opt/csw/bin/gcc'
+      pkg.environment 'LD', '/opt/csw/bin/gld'
+      pkg.environment 'AR', '/opt/csw/bin/gar'
+    end
   else
     pkg.environment 'PATH', "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$(PATH):/opt/csw/bin"
     pkg.environment 'CC', "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -98,6 +98,9 @@ component 'augeas' do |pkg, settings, platform|
     if platform.os_version == "10"
       pkg.environment "PKG_CONFIG_PATH", "/opt/csw/lib/pkgconfig"
       pkg.environment "PKG_CONFIG", "/opt/csw/bin/pkg-config"
+    elsif !platform.is_cross_compiled? && platform.architecture == 'sparc'
+      pkg.environment "PKG_CONFIG_PATH", "#{settings[:libdir]}/pkgconfig"
+      pkg.environment "PKG_CONFIG", "/usr/bin/pkg-config"
     else
       pkg.environment "PKG_CONFIG_PATH", "/usr/lib/pkgconfig"
       pkg.environment "PKG_CONFIG", "/opt/pl-build-tools/bin/pkg-config"

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -41,7 +41,7 @@ component 'curl' do |pkg, settings, platform|
     extra_cflags << '-mmacosx-version-min=12.0 -arch arm64' if platform.name =~ /osx-12/
   end
 
-  if (platform.is_solaris? && platform.os_version == "11") || platform.is_aix?
+  if (platform.is_solaris? && platform.os_version.start_with?("11")) || platform.is_aix?
     # Makefile generation with automatic dependency tracking fails on these platforms
     configure_options << "--disable-dependency-tracking"
   end

--- a/configs/components/libffi.rb
+++ b/configs/components/libffi.rb
@@ -16,7 +16,13 @@ component 'libffi' do |pkg, settings, platform|
     pkg.environment "LDFLAGS", settings[:ldflags]
   elsif platform.is_solaris?
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
-    pkg.environment "CFLAGS", "#{settings[:cflags]} -std=c99"
+    if !platform.is_cross_compiled? && platform.architecture == 'sparc'
+      # must use gnu99 due to `asm` keyword
+      # https://gcc.gnu.org/onlinedocs/gcc-7.2.0/gcc/Extended-Asm.html
+      pkg.environment "CFLAGS", "#{settings[:cflags]} -std=gnu99"
+    else
+      pkg.environment "CFLAGS", "#{settings[:cflags]} -std=c99"
+    end
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment 'MAKE', 'gmake'
   elsif platform.is_macos?

--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -61,10 +61,15 @@ component 'openssl' do |pkg, settings, platform|
     target = 'aix-gcc'
   elsif platform.is_solaris?
     pkg.environment 'PATH', '/opt/csw/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin'
-    pkg.environment 'CC', "/opt/csw/bin/gcc"
-
+    if !platform.is_cross_compiled? && platform.architecture == 'sparc'
+      pkg.environment 'CC', "/opt/pl-build-tools/bin/gcc"
+      gcc_lib = "/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
+    else
+      pkg.environment 'CC', "/opt/csw/bin/gcc"
+      gcc_lib = "/opt/csw/#{settings[:platform_triple]}/lib"
+    end
     cflags = "#{settings[:cflags]} -fPIC"
-    ldflags = "-R/opt/csw/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/csw/#{settings[:platform_triple]}/lib"
+    ldflags = "-R#{gcc_lib} -Wl,-rpath=#{settings[:libdir]} -L#{gcc_lib}"
     target = platform.architecture =~ /86/ ? 'solaris-x86-gcc' : 'solaris-sparcv9-gcc'
   elsif platform.is_macos?
 

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -29,8 +29,10 @@ component "ruby-shadow" do |pkg, settings, platform|
   end
 
   pkg.build do
-    ["#{ruby} extconf.rb",
-     "#{platform[:make]} -e -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+    [
+      "#{ruby} extconf.rb",
+      "#{platform[:make]} -e -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"
+    ]
   end
 
   pkg.install do

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -62,18 +62,22 @@ component "rubygem-ffi" do |pkg, settings, platform|
   end
 
   # due to contrib/make_sunver.pl missing on solaris 11 we cannot compile libffi, so we provide the opencsw library
-  pkg.environment "CPATH", "/opt/csw/lib/libffi-3.2.1/include" if platform.name =~ /solaris-11/
+  pkg.environment "CPATH", "/opt/csw/lib/libffi-3.2.1/include" if platform.name.start_with?('solaris-11-')
   pkg.environment "MAKE", platform[:make] if platform.is_solaris?
 
   if platform.is_cross_compiled_linux?
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
   elsif platform.is_solaris?
     if settings[:ruby_version] =~ /3\.\d+\.\d+/
-      pkg.environment "PATH", "/opt/csw/bin:/opt/pl-build-tools/bin:$(PATH)"
+      if !platform.is_cross_compiled? && platform.architecture == 'sparc'
+        pkg.environment "PATH", "#{settings[:ruby_bindir]}:$(PATH)"
+      else
+        pkg.environment "PATH", "/opt/csw/bin:/opt/pl-build-tools/bin:$(PATH)"
+      end
     else
       pkg.environment "PATH", "/opt/pl-build-tools/bin:/opt/csw/bin:$(PATH)"
-    end  
-  end  
+    end
+  end
 
   # With Ruby 3.2 on Solaris-11 we install OpenSCW's libffi, no need to copy over the system libffi
   if platform.name =~ /solaris-11-i386/ && rb_major_minor_version < 3.2

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -13,13 +13,18 @@ component "yaml-cpp" do |pkg, settings, platform|
     cmake = "/opt/pl-build-tools/bin/cmake"
     cmake_toolchain_file = "-DPL_TOOLS_ROOT=/opt/freeware -DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
   elsif platform.is_solaris?
-    if platform.os_version == "11"
+    if platform.os_version != '10'
       make = '/usr/bin/gmake'
     end
-    # We always use the i386 build of cmake, even on sparc
-    cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
-    cmake_toolchain_file = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
-    pkg.environment "PATH", "$(PATH):/opt/csw/bin"
+
+    if !platform.is_cross_compiled? && platform.architecture == 'sparc'
+      pkg.environment "PATH", "$(PATH):/opt/pl-build-tools/bin"
+    else
+      # We always use the i386 build of cmake, even when cross-compiling on sparc
+      cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
+      cmake_toolchain_file = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
+      pkg.environment "PATH", "$(PATH):/opt/csw/bin"
+    end
   elsif platform.is_macos?
     cmake_toolchain_file = ""
     cmake = "/usr/local/bin/cmake"

--- a/configs/platforms/solaris-113-sparc.rb
+++ b/configs/platforms/solaris-113-sparc.rb
@@ -1,0 +1,60 @@
+# This platform definition is used to build natively on SPARC, unlike
+# solaris-10/11-sparc, which are cross compiled. Therefore, this definition does
+# not inherit from vanagon defaults.
+platform "solaris-11-sparc" do |plat|
+  plat.servicedir "/lib/svc/manifest"
+  plat.defaultdir "/lib/svc/method"
+  plat.servicetype "smf"
+
+  plat.vmpooler_template "solaris-11-sparc"
+  plat.add_build_repository "http://solaris-11-reposync.delivery.puppetlabs.net:81", "puppetlabs.com"
+  plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
+
+  packages = [
+    "pl-gcc10",
+    "pl-libffi",
+    "pl-openssl",
+    "pl-yaml-cpp-sparc",
+
+    "autoconf",
+    "automake",
+    "cmake",
+    "gnu-make",
+    "libtool",
+    "pkg-config"
+  ]
+  plat.provision_with("pkg install #{packages.join(' ')}")
+
+  plat.provision_with %[echo "# Write the noask file to a temporary directory
+# please see man -s 4 admin for details about this file:
+# http://www.opensolarisforum.org/man/man4/admin.html
+#
+# The key thing we don\'t want to prompt for are conflicting files.
+# The other nocheck settings are mostly defensive to prevent prompts
+# We _do_ want to check for available free space and abort if there is
+# not enough
+mail=
+# Overwrite already installed instances
+instance=overwrite
+# Do not bother checking for partially installed packages
+partial=nocheck
+# Do not bother checking the runlevel
+runlevel=nocheck
+# Do not bother checking package dependencies (We take care of this)
+idepend=nocheck
+rdepend=nocheck
+# DO check for available free space and abort if there isn\'t enough
+space=quit
+# Do not check for setuid files.
+setuid=nocheck
+# Do not check if files conflict with other packages
+conflict=nocheck
+# We have no action scripts.  Do not check for them.
+action=nocheck
+# Install to the default base directory.
+basedir=default" > /var/tmp/vanagon-noask;
+  echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
+  pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
+  /opt/csw/bin/pkgutil -U && /opt/csw/bin/pkgutil -y -i bison || exit 1
+  ]
+end

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -79,6 +79,6 @@ project 'agent-runtime-main' do |proj|
   proj.component 'rubygem-erubi'
   proj.component 'rubygem-prime'
 
-  proj.component 'boost' if ENV['NO_PXP_AGENT'].to_s.empty?
-  proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty?
+  proj.component 'boost' if ENV['NO_PXP_AGENT'].to_s.empty? && platform.name != 'solaris-113-sparc'
+  proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty? && platform.name != 'solaris-113-sparc'
 end

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -79,6 +79,6 @@ project 'agent-runtime-main' do |proj|
   proj.component 'rubygem-erubi'
   proj.component 'rubygem-prime'
 
-  proj.component 'boost' if ENV['NO_PXP_AGENT'].to_s.empty? && platform.name != 'solaris-113-sparc'
-  proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty? && platform.name != 'solaris-113-sparc'
+  proj.component 'boost' if ENV['NO_PXP_AGENT'].to_s.empty?
+  proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty?
 end


### PR DESCRIPTION
boost: no changes are required to build, so add the component.

yaml-cpp: default to /usr/bin/gmake except for Solaris 10 and use /usr/bin/cmake
instead of pl-cmake.

Successfully built in https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2229/BUILD_TARGET=solaris-113-sparc,SLAVE_LABEL=k8s-worker/ and shipped to https://builds.delivery.puppetlabs.net/puppet-runtime/cd2f8ed54cff954306835f71942e2fe1dd10d6f6/artifacts/