### PR TITLE
(maint) Bump libncurses

### DIFF
--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -30,8 +30,8 @@ component "runtime-agent" do |pkg, settings, platform|
     if platform.name != 'aix-7.1-ppc'
       pkg.install_file File.join(libdir, "libatomic.a"), "/opt/puppetlabs/puppet/lib/libatomic.a"
       pkg.install_file "/opt/freeware/lib/libiconv.a", "/opt/puppetlabs/puppet/lib/libiconv.a"
-      pkg.install_file "/opt/freeware/lib/libncurses.so.6.3.0", "/opt/puppetlabs/puppet/lib/libncurses.so.6.3.0"
-      pkg.link         "libncurses.so.6.3.0", "/opt/puppetlabs/puppet/lib/libncurses.so"
+      pkg.install_file "/opt/freeware/lib/libncurses.so.6.4.0", "/opt/puppetlabs/puppet/lib/libncurses.so.6.4.0"
+      pkg.link         "libncurses.so.6.4.0", "/opt/puppetlabs/puppet/lib/libncurses.so"
       pkg.install_file "/opt/freeware/lib/libreadline.a", "/opt/puppetlabs/puppet/lib/libreadline.a"
       pkg.install_file "/opt/freeware/lib/libz.a", "/opt/puppetlabs/puppet/lib/libz.a"
     end


### PR DESCRIPTION
AIX runtime-agent hard codes the ncurses library, looks like there was a recent update that we need to get.