### PR TITLE
(PA-5701) Generate tarballs with solaris-11-sparc in the name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place)
 end
 
 gem 'artifactory'
-gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.28')
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.39')
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.105')
 gem 'rake', '~> 13.0'
 

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -41,7 +41,7 @@ component 'curl' do |pkg, settings, platform|
     extra_cflags << '-mmacosx-version-min=12.0 -arch arm64' if platform.name =~ /osx-12/
   end
 
-  if (platform.is_solaris? && platform.os_version.start_with?("11")) || platform.is_aix?
+  if (platform.is_solaris? && platform.os_version == '11') || platform.is_aix?
     # Makefile generation with automatic dependency tracking fails on these platforms
     configure_options << "--disable-dependency-tracking"
   end

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -62,7 +62,7 @@ component "rubygem-ffi" do |pkg, settings, platform|
   end
 
   # due to contrib/make_sunver.pl missing on solaris 11 we cannot compile libffi, so we provide the opencsw library
-  pkg.environment "CPATH", "/opt/csw/lib/libffi-3.2.1/include" if platform.name.start_with?('solaris-11-')
+  pkg.environment "CPATH", "/opt/csw/lib/libffi-3.2.1/include" if platform.name =~ /solaris-11/ && (platform.is_cross_compiled? || platform.architecture != 'sparc')
   pkg.environment "MAKE", platform[:make] if platform.is_solaris?
 
   if platform.is_cross_compiled_linux?

--- a/configs/platforms/solaris-11-native-sparc.rb
+++ b/configs/platforms/solaris-11-native-sparc.rb
@@ -1,7 +1,7 @@
 # This platform definition is used to build natively on SPARC, unlike
 # solaris-10/11-sparc, which are cross compiled. Therefore, this definition does
 # not inherit from vanagon defaults.
-platform "solaris-11-sparc" do |plat|
+platform("solaris-11-sparc", override_name: true) do |plat|
   plat.servicedir "/lib/svc/manifest"
   plat.defaultdir "/lib/svc/method"
   plat.servicetype "smf"

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -120,11 +120,8 @@ elsif platform.is_cross_compiled? && platform.is_macos?
 elsif platform.is_solaris?
   if platform.architecture == 'i386'
     platform_triple = "#{platform.architecture}-pc-solaris2.#{platform.os_version}"
-  elsif platform.is_cross_compiled?
-    platform_triple = "#{platform.architecture}-sun-solaris2.#{platform.os_version}"
-    host = "--host #{platform_triple}"
   else
-    platform_triple = "#{platform.architecture}-sun-solaris2.11"
+    platform_triple = "#{platform.architecture}-sun-solaris2.#{platform.os_version}"
     host = "--host #{platform_triple}"
   end
 elsif platform.is_windows?


### PR DESCRIPTION
Since the puppet-runtime repo contains multiple projects and we need to build solaris 11 sparc differently for 7.x vs main, I was using solaris-113-sparc to fake out vanagon. However, the generated tarballs still had 113 in the name, which meant pxp-agent-vanagon couldn't find it when building solaris-11-sparc.

This leverages new functionality in vanagon that allows the platform name to be overridden based on the string passed to the `platform` DSL method instead of relying on the platform's filename.

It also undoes some hacks that were in place to differentiate between solaris 11 and 113.

This is blocked on:
- [x] https://github.com/puppetlabs/vanagon/pull/809 
- [x] vanagon gem release with ^
- [x] vanagon-generic-builder with this PR, both [solaris-11-i386 and solaris-11-native-sparc](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2247/)

Please merge https://github.com/puppetlabs/puppet-runtime/pull/712 after this.