### PR TITLE
(PE-36344) Enable md4 for winrm transport in bolt server for non fips

### DIFF
--- a/configs/projects/pe-bolt-server-runtime-main.rb
+++ b/configs/projects/pe-bolt-server-runtime-main.rb
@@ -10,6 +10,15 @@ project 'pe-bolt-server-runtime-main' do |proj|
   proj.setting(:ruby_version, '3.2.2')
   proj.setting(:openssl_version, '3.0')
 
+  # We enable legacy algorithms for winrm transport. Currently the winrm transport
+  # does not work on FIPS, so in order to stay compliant we do not enable legacy algorithms
+  # on fips builds.
+  if proj.get_platform.name =~ /^redhatfips/
+    proj.setting(:use_legacy_openssl_algos, false)
+  else 
+    proj.setting(:use_legacy_openssl_algos, true)
+  end
+
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server_with_ruby.rb'))
   proj.component 'rubygem-prime'
   proj.component 'rubygem-rexml'

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -36,8 +36,6 @@ project 'pe-installer-runtime-main' do |proj|
   ruby_base_version = proj.ruby_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2.0')
   proj.setting(:gem_home, File.join(proj.libdir, 'ruby', 'gems', ruby_base_version))
   proj.setting(:gem_install, "#{proj.host_gem} install --no-document --local --bindir=#{proj.ruby_bindir}")
-  # Enable legacy openssl agls for wirnm
-  proj.setting(:use_legacy_openssl_algos, true)
 
   proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
   proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")


### PR DESCRIPTION
This commit enables legacy openssl algorithms to support the winrm transport in bolt-server. Winrm does not work on FIPS currently so we continue to leave that unsupported.