### PR TITLE
(PA-5638) Update Ruby URI gem

### DIFF
--- a/configs/components/ruby-2.7.8.rb
+++ b/configs/components/ruby-2.7.8.rb
@@ -39,6 +39,8 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
   # Patch for https://bugs.ruby-lang.org/issues/14972
   pkg.apply_patch "#{base}/net_http_eof_14972_r2.5.patch"
 
+  pkg.apply_patch "#{base}/uri-redos-cve-2023-36617.patch"
+
   if platform.is_cross_compiled?
     unless platform.is_macos?
       pkg.apply_patch "#{base}/uri_generic_remove_safe_nav_operator_r2.5.patch"

--- a/configs/components/ruby-3.2.2.rb
+++ b/configs/components/ruby-3.2.2.rb
@@ -38,6 +38,8 @@ component 'ruby-3.2.2' do |pkg, settings, platform|
 
   base = 'resources/patches/ruby_32'
 
+  pkg.apply_patch "#{base}/uri-redos-cve-2023-36617.patch"
+
   if platform.is_cross_compiled?
     unless platform.is_macos?
 #      pkg.apply_patch "#{base}/Replace-reference-to-RUBY-var-with-opt-pl-build-tool.patch"

--- a/resources/patches/ruby_27/uri-redos-cve-2023-36617.patch
+++ b/resources/patches/ruby_27/uri-redos-cve-2023-36617.patch
@@ -1,0 +1,59 @@
+diff --git a/lib/uri/rfc2396_parser.rb b/lib/uri/rfc2396_parser.rb
+index 76a8f99fd4..00c66cf042 100644
+--- a/lib/uri/rfc2396_parser.rb
++++ b/lib/uri/rfc2396_parser.rb
+@@ -497,8 +497,8 @@ def initialize_regexp(pattern)
+       ret = {}
+
+       # for URI::split
+-      ret[:ABS_URI] = Regexp.new('\A\s*' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
+-      ret[:REL_URI] = Regexp.new('\A\s*' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:ABS_URI] = Regexp.new('\A\s*+' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:REL_URI] = Regexp.new('\A\s*+' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
+
+       # for URI::extract
+       ret[:URI_REF]     = Regexp.new(pattern[:URI_REF])
+diff --git a/lib/uri/rfc3986_parser.rb b/lib/uri/rfc3986_parser.rb
+index dd24a409ea..9b1663dbb6 100644
+--- a/lib/uri/rfc3986_parser.rb
++++ b/lib/uri/rfc3986_parser.rb
+@@ -100,7 +100,7 @@ def default_regexp # :nodoc:
+         QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         OPAQUE: /\A(?:[^\/].*)?\z/,
+-        PORT: /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/,
++        PORT: /\A[\x09\x0a\x0c\x0d ]*+\d*[\x09\x0a\x0c\x0d ]*\z/,
+       }
+     end
+
+diff --git a/test/uri/test_parser.rb b/test/uri/test_parser.rb
+index 72fb5901d9..cee0acb4b5 100644
+--- a/test/uri/test_parser.rb
++++ b/test/uri/test_parser.rb
+@@ -79,4 +79,26 @@ def test_split
+     assert_equal([nil, nil, "example.com", nil, nil, "", nil, nil, nil], URI.split("//example.com"))
+     assert_equal([nil, nil, "[0::0]", nil, nil, "", nil, nil, nil], URI.split("//[0::0]"))
+   end
++
++  def test_rfc2822_parse_relative_uri
++    pre = ->(length) {
++      " " * length + "\0"
++    }
++    parser = URI::RFC2396_Parser.new
++    assert_linear_performance((1..5).map {|i| 10**i}, pre: pre) do |uri|
++      assert_raise(URI::InvalidURIError) do
++        parser.split(uri)
++      end
++    end
++  end
++
++  def test_rfc3986_port_check
++    pre = ->(length) {"\t" * length + "a"}
++    uri = URI.parse("http://my.example.com")
++    assert_linear_performance((1..5).map {|i| 10**i}, pre: pre) do |port|
++      assert_raise(URI::InvalidComponentError) do
++        uri.port = port
++      end
++    end
++  end
+ end

--- a/resources/patches/ruby_32/uri-redos-cve-2023-36617.patch
+++ b/resources/patches/ruby_32/uri-redos-cve-2023-36617.patch
@@ -1,0 +1,83 @@
+From dd73fe077cae077808e820f4765a12b1f4660521 Mon Sep 17 00:00:00 2001
+From: Hiroshi SHIBATA <hsbt@ruby-lang.org>
+Date: Wed, 21 Jun 2023 13:20:54 +0900
+Subject: [PATCH] Merge URI-0.12.2
+
+---
+ lib/uri/rfc2396_parser.rb |  4 ++--
+ lib/uri/rfc3986_parser.rb |  2 +-
+ lib/uri/version.rb        |  2 +-
+ test/uri/test_parser.rb   | 22 ++++++++++++++++++++++
+ 4 files changed, 26 insertions(+), 4 deletions(-)
+
+diff --git a/lib/uri/rfc2396_parser.rb b/lib/uri/rfc2396_parser.rb
+index 76a8f99fd4..00c66cf042 100644
+--- a/lib/uri/rfc2396_parser.rb
++++ b/lib/uri/rfc2396_parser.rb
+@@ -497,8 +497,8 @@ def initialize_regexp(pattern)
+       ret = {}
+
+       # for URI::split
+-      ret[:ABS_URI] = Regexp.new('\A\s*' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
+-      ret[:REL_URI] = Regexp.new('\A\s*' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:ABS_URI] = Regexp.new('\A\s*+' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:REL_URI] = Regexp.new('\A\s*+' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
+
+       # for URI::extract
+       ret[:URI_REF]     = Regexp.new(pattern[:URI_REF])
+diff --git a/lib/uri/rfc3986_parser.rb b/lib/uri/rfc3986_parser.rb
+index dd24a409ea..9b1663dbb6 100644
+--- a/lib/uri/rfc3986_parser.rb
++++ b/lib/uri/rfc3986_parser.rb
+@@ -100,7 +100,7 @@ def default_regexp # :nodoc:
+         QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         OPAQUE: /\A(?:[^\/].*)?\z/,
+-        PORT: /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/,
++        PORT: /\A[\x09\x0a\x0c\x0d ]*+\d*[\x09\x0a\x0c\x0d ]*\z/,
+       }
+     end
+
+diff --git a/lib/uri/version.rb b/lib/uri/version.rb
+index 7497a7d31a..f0aca586ac 100644
+--- a/lib/uri/version.rb
++++ b/lib/uri/version.rb
+@@ -1,6 +1,6 @@
+ module URI
+   # :stopdoc:
+-  VERSION_CODE = '001201'.freeze
++  VERSION_CODE = '001202'.freeze
+   VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
+   # :startdoc:
+ end
+diff --git a/test/uri/test_parser.rb b/test/uri/test_parser.rb
+index 72fb5901d9..cee0acb4b5 100644
+--- a/test/uri/test_parser.rb
++++ b/test/uri/test_parser.rb
+@@ -79,4 +79,26 @@ def test_split
+     assert_equal([nil, nil, "example.com", nil, nil, "", nil, nil, nil], URI.split("//example.com"))
+     assert_equal([nil, nil, "[0::0]", nil, nil, "", nil, nil, nil], URI.split("//[0::0]"))
+   end
++
++  def test_rfc2822_parse_relative_uri
++    pre = ->(length) {
++      " " * length + "\0"
++    }
++    parser = URI::RFC2396_Parser.new
++    assert_linear_performance((1..5).map {|i| 10**i}, pre: pre) do |uri|
++      assert_raise(URI::InvalidURIError) do
++        parser.split(uri)
++      end
++    end
++  end
++
++  def test_rfc3986_port_check
++    pre = ->(length) {"\t" * length + "a"}
++    uri = URI.parse("http://my.example.com")
++    assert_linear_performance((1..5).map {|i| 10**i}, pre: pre) do |port|
++      assert_raise(URI::InvalidComponentError) do
++        uri.port = port
++      end
++    end
++  end
+ end


### PR DESCRIPTION
This commit patches the Ruby URI gem to handle vulnerability CVE-2023-36617. This vulnerability is addressed in URI 0.12.2, which can be updated in the Ruby 3.2 stream.

We will likely not need this patch in Ruby > 3.2.2, as future releases will presumably include URI >= 0.12.2.

We also apply this patch to Ruby 2.7 but because it is end-of-life, there is no corresponding URI release.

ruby/uri#master commits: https://github.com/ruby/uri/commit/9010ee2536adda10a0555ae1ed6fe2f5808e6bf1 https://github.com/ruby/uri/commit/9d7bcef1e6ad23c9c6e4932f297fb737888144c8 ruby/ruby commit: https://github.com/ruby/ruby/commit/dd73fe077cae077808e820f4765a12b1f4660521 GitHub Advisory DB: https://github.com/advisories/GHSA-hww2-5g85-429m