### PR TITLE
(PA-5733) Enable puppet-runtime builds for rhel9

### DIFF
--- a/configs/platforms/el-9-aarch64.rb
+++ b/configs/platforms/el-9-aarch64.rb
@@ -1,0 +1,17 @@
+platform 'el-9-aarch64' do |plat|
+  plat.inherit_from_default
+
+  packages = %w(
+    perl-Getopt-Long 
+    java-1.8.0-openjdk-devel
+    patch 
+    swig 
+    libselinux-devel 
+    readline-devel 
+    zlib-devel 
+    systemtap-sdt-devel
+  )
+  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
+  plat.install_build_dependencies_with "dnf install -y --allowerasing "
+  plat.vmpooler_template "redhat-9-arm64"
+end

--- a/configs/platforms/el-9-aarch64.rb
+++ b/configs/platforms/el-9-aarch64.rb
@@ -2,6 +2,7 @@ platform 'el-9-aarch64' do |plat|
   plat.inherit_from_default
 
   packages = %w(
+    perl
     perl-Getopt-Long 
     java-1.8.0-openjdk-devel
     patch 


### PR DESCRIPTION
Added platform definition of redhat9 to enable puppet-runtime build.