### PR TITLE
(PA-4813) Refresh CA bundle and include FIPS version of puppet-cacerts

### DIFF
--- a/configs/components/puppet-ca-bundle.json
+++ b/configs/components/puppet-ca-bundle.json
@@ -1,4 +1,4 @@
 {
   "url": "https://github.com/puppetlabs/puppet-ca-bundle.git",
-  "ref": "refs/tags/1.0.11"
+  "ref": "refs/tags/1.0.12"
 }

--- a/configs/components/puppet-ca-bundle.rb
+++ b/configs/components/puppet-ca-bundle.rb
@@ -10,8 +10,14 @@ component "puppet-ca-bundle" do |pkg, settings, platform|
     openssl_cmd = "#{settings[:bindir]}/openssl"
   end
 
+  target = if platform.is_fips?
+             'install-fips'
+           else
+             'install'
+           end
+
   install_commands = [
-    "#{platform[:make]} install OPENSSL=#{openssl_cmd} USER=0 GROUP=0 DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
+    "#{platform[:make]} #{target} OPENSSL=#{openssl_cmd} USER=0 GROUP=0 DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
   ]
 
   pkg.install do


### PR DESCRIPTION
Refreshes CA bundles

Copies the `puppet-cacerts-fips` keystore when building on FIPS hosts. Otherwise uses the regular `puppet-cacerts` keystore.

Drops TrustCor CA

- [x] [agent-runtime-main](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2325/)
- [x] [agent-runtime-7.x](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2326/)

Example of [RHEL8 install](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2325/BUILD_TARGET=redhatfips-8-x86_64,SLAVE_LABEL=k8s-worker):

```
cp -f puppet-cacerts-fips /opt/puppetlabs/puppet/ssl/puppet-cacerts
chown 0:0 /opt/puppetlabs/puppet/ssl/puppet-cacerts
chmod 0644 /opt/puppetlabs/puppet/ssl/puppet-cacerts
```

And [Windows FIPS install](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2325/BUILD_TARGET=windowsfips-2012r2-x64,SLAVE_LABEL=k8s-worker):

```
cp -f puppet-cacerts-fips C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/ssl/puppet-cacerts
chown 0:0 C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/ssl/puppet-cacerts
chmod 0644 C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/ssl/puppet-cacerts
```