### PR TITLE
(PA-4607) Remove redundant commands that are already being passed …

### DIFF
--- a/configs/platforms/debian-11-aarch64.rb
+++ b/configs/platforms/debian-11-aarch64.rb
@@ -1,16 +1,5 @@
 platform "debian-11-aarch64" do |plat|
-    # Delete the 6 lines below when a vanagon with Debian 11 support is released
-    plat.servicedir "/lib/systemd/system"
-    plat.defaultdir "/etc/default"
-    plat.servicetype "systemd"
-    plat.codename "bullseye"
-    plat.vmpooler_template "debian-11-arm64"
-    plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  
-    # Uncomment these when a vanagon with Debian 11 support is released
-    # plat.inherit_from_default
-    # plat.clear_provisioning
-  
+    plat.inherit_from_default
     packages = [
       'build-essential',
       'cmake',
@@ -29,7 +18,6 @@ platform "debian-11-aarch64" do |plat|
       'systemtap-sdt-dev',
       'zlib1g-dev'
     ]
-  
     plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   end
   


### PR DESCRIPTION
…by vanagon definition

The lines that have been removed here are already being added to the build steps in the debian-11-aarch definition file in vanagon.