### PR TITLE
(PA-4607) Revert "Remove redundant commands that are already being pa…

### DIFF
--- a/configs/platforms/debian-11-aarch64.rb
+++ b/configs/platforms/debian-11-aarch64.rb
@@ -1,5 +1,16 @@
 platform "debian-11-aarch64" do |plat|
-    plat.inherit_from_default
+    # Delete the 6 lines below when a vanagon with Debian 11 support is released
+    plat.servicedir "/lib/systemd/system"
+    plat.defaultdir "/etc/default"
+    plat.servicetype "systemd"
+    plat.codename "bullseye"
+    plat.vmpooler_template "debian-11-arm64"
+    plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  
+    # Uncomment these when a vanagon with Debian 11 support is released
+    # plat.inherit_from_default
+    # plat.clear_provisioning
+  
     packages = [
       'build-essential',
       'cmake',
@@ -18,6 +29,7 @@ platform "debian-11-aarch64" do |plat|
       'systemtap-sdt-dev',
       'zlib1g-dev'
     ]
+  
     plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   end
   


### PR DESCRIPTION
…ssed by vanagon definition"

This reverts commit 17588a0517ad100fb86f5b0f7cfd83274cdb0940.

Reverting this commit since vanagon is not released yet with debian-11-aarch64 support which breaks CI.