### PR TITLE
(PE-36907) Ensure the version of concurrent-ruby matches puppet-agent 7.y

### DIFF
--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -4,6 +4,7 @@ project 'bolt-runtime' do |proj|
   proj.setting(:ruby_version, '2.7.8')
   proj.setting(:openssl_version, '1.1.1')
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
+  proj.setting :rubygem_concurrent_ruby_version, '1.1.9'
   proj.setting(:augeas_version, '1.11.0')
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_deep_merge_version, '1.2.2')


### PR DESCRIPTION
The puppet 8 puppet packages contain the 1.1.10 version of concurrent ruby. Bolt 3.x is still puppet 7 based. In the case where an apply is used over the local transport where the bundled-ruby options is not set it is important that the concurrent ruby versions match. This commit ensures bolt-packages have the same version as puppet 7 packages. As we figure out the bolt 4 / puppet 8 story we can update accordingly.