### PR TITLE
(PE-36966) Use puppet-strings 3.x sereies for LTS bolt-server

### DIFF
--- a/configs/components/rubygem-puppet-strings.rb
+++ b/configs/components/rubygem-puppet-strings.rb
@@ -1,7 +1,18 @@
 component 'rubygem-puppet-strings' do |pkg, settings, platform|
-  pkg.version '4.1.0'
-  pkg.md5sum 'd8259d8a9144757f4e78f118b59e2681'
+  # 2021.7.x LTS has a jruby that does not work with puppet-strings
+  # version 4.y. The 4 series requires ruby >= 2.7
+  # Default to 4.x sereies but allow it to be configuratble by project.
+  version = settings[:rubygem_puppet_strings_version] || '4.1.0'
+  pkg.version(version)
 
+  case version
+  when '3.0.1'
+    pkg.md5sum '7c9a8936509a0434c39975a75197472c'
+  when '4.1.0'
+    pkg.md5sum 'd8259d8a9144757f4e78f118b59e2681'
+  else
+    raise "Invalid version #{version} for rubygem-puppet-strings; Cannot continue."
+  end
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end
 

--- a/configs/projects/pe-bolt-server-runtime-2021.7.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2021.7.x.rb
@@ -1,6 +1,7 @@
 project 'pe-bolt-server-runtime-2021.7.x' do |proj|
   proj.setting(:pe_version, '2021.7')
   proj.setting(:rubygem_puppet_version, '7.26.0')
+  proj.setting(:rubygem_puppet_strings_version, '3.0.1')
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.7 we need to use a --no-document flag
   # for gem installs instead of --no-ri --no-rdoc. This setting allows us to use this while we support both ruby 2.5 and 2.7


### PR DESCRIPTION
The puppet-strings 4 series requires ruby 2.7. While the agent version ships with 2.7 the Jruby in the LTS is more akin to the ruby 2.6 spec. This makes the puppet-strings version break when run under Jruby. For the LTS we pin back to the 3 series.