### PR TITLE
(PA-5632) Update SELinux on Red Hat 9 to 3.3

### DIFF
--- a/configs/platforms/el-9-aarch64.rb
+++ b/configs/platforms/el-9-aarch64.rb
@@ -7,7 +7,6 @@ platform 'el-9-aarch64' do |plat|
     java-1.8.0-openjdk-devel
     patch 
     swig 
-    libselinux-devel 
     readline-devel 
     zlib-devel 
     systemtap-sdt-devel

--- a/configs/platforms/el-9-x86_64.rb
+++ b/configs/platforms/el-9-x86_64.rb
@@ -25,7 +25,6 @@ platform "el-9-x86_64" do |plat|
     java-1.8.0-openjdk-devel
     libsepol
     libsepol-devel
-    libselinux-devel
     pkgconfig
     readline-devel
     rpmdevtools


### PR DESCRIPTION
Prior to this commit, there was a discrepancy between the versions of SELinux we built our Red Hat Enterprise Linux (RHEL) 9 runtimes on and the minimum version available on the OS (SELinux 3.3).

This commit builds RHEL 9 runtimes with version 3.3 of SELinux to resolve that discrepancy.