### PR TITLE
(PA-5852) Apply CVE-2023-38545 patch for curl vulnerablity

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -30,6 +30,7 @@ component 'curl' do |pkg, settings, platform|
   pkg.apply_patch 'resources/patches/curl/CVE-2023-27535.patch'
   pkg.apply_patch 'resources/patches/curl/CVE-2023-28319.patch'
   pkg.apply_patch 'resources/patches/curl/CVE-2023-32001.patch'
+  pkg.apply_patch 'resources/patches/curl/CVE-2023-38545.patch'
 
   configure_options = []
   configure_options << "--with-ssl=#{settings[:prefix]}"

--- a/resources/patches/curl/CVE-2023-38545.patch
+++ b/resources/patches/curl/CVE-2023-38545.patch
@@ -1,0 +1,27 @@
+diff --git a/lib/socks.c b/lib/socks.c
+index 95c2b004c..8cf694d1d 100644
+--- a/lib/socks.c
++++ b/lib/socks.c
+@@ -588,9 +588,9 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
+ 
+     /* RFC1928 chapter 5 specifies max 255 chars for domain name in packet */
+     if(!socks5_resolve_local && hostname_len > 255) {
+-      infof(data, "SOCKS5: server resolving disabled for hostnames of "
+-            "length > 255 [actual len=%zu]", hostname_len);
+-      socks5_resolve_local = TRUE;
++      failf(data, "SOCKS5: the destination hostname is too long to be "
++            "resolved remotely by the proxy.");
++      return CURLPX_LONG_HOSTNAME;
+     }
+ 
+     if(auth & ~(CURLAUTH_BASIC | CURLAUTH_GSSAPI))
+@@ -904,7 +904,7 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
+       }
+       else {
+         socksreq[len++] = 3;
+-        socksreq[len++] = (char) hostname_len; /* one byte address length */
++        socksreq[len++] = (unsigned char) hostname_len; /* one byte length */
+         memcpy(&socksreq[len], sx->hostname, hostname_len); /* w/o NULL */
+         len += hostname_len;
+       }
+


### PR DESCRIPTION
apply patch for curl CVE-2023-38545

ref: https://github.com/curl/curl/discussions/12026
https://curl.se/docs/CVE-2023-38545.html