### PR TITLE
(CAT-270) Set special flag to run against Mac OS on ruby 3.2.2

### DIFF
--- a/configs/components/ruby-3.2.2.rb
+++ b/configs/components/ruby-3.2.2.rb
@@ -129,6 +129,8 @@ component 'ruby-3.2.2' do |pkg, settings, platform|
     else
       special_flags += " --build i686-w64-mingw32 "
     end
+  elsif platform.is_macos?
+    special_flags += " --with-openssl-dir=#{settings[:prefix]} "
   end
 
   without_dtrace = [


### PR DESCRIPTION
Jenkins builds failing for Mac OSX with current version: https://jenkins-platform.delivery.puppetlabs.net/job/platform_pdk-runtime_runtime-vanagon-packaging_main/BUILD_TARGET=osx-12-x86_64,SLAVE_LABEL=k8s-worker/314/console

Set special flag `--with-openssl-dir=` to run against Mac OS on Ruby 3.2.2.
This flag works to force the use of the openssl version included within the runtime itself rather than the one that is installed by homebrew as default.
