### PR TITLE
Drop openjdk build dependency

### DIFF
--- a/configs/platforms/debian-10-amd64.rb
+++ b/configs/platforms/debian-10-amd64.rb
@@ -4,7 +4,6 @@ platform "debian-10-amd64" do |plat|
     libbz2-dev
     libreadline-dev
     libselinux1-dev
-    openjdk-11-jdk
     swig systemtap-sdt-dev
     zlib1g-dev
   )

--- a/configs/platforms/debian-10-armhf.rb
+++ b/configs/platforms/debian-10-armhf.rb
@@ -18,7 +18,6 @@ platform "debian-10-armhf" do |plat|
     "libreadline-dev",
     "libselinux1-dev",
     "make",
-    "openjdk-11-jre-headless",
     "pkg-config",
     "cmake",
     "gcc",

--- a/configs/platforms/debian-11-aarch64.rb
+++ b/configs/platforms/debian-11-aarch64.rb
@@ -10,7 +10,6 @@ platform "debian-11-aarch64" do |plat|
       'libreadline-dev',
       'libselinux1-dev',
       'make',
-      'openjdk-11-jdk',
       'pkg-config',
       'quilt',
       'rsync',

--- a/configs/platforms/debian-11-amd64.rb
+++ b/configs/platforms/debian-11-amd64.rb
@@ -21,7 +21,6 @@ platform "debian-11-amd64" do |plat|
     'libreadline-dev',
     'libselinux1-dev',
     'make',
-    'openjdk-11-jdk',
     'pkg-config',
     'quilt',
     'rsync',

--- a/configs/platforms/debian-11-armhf.rb
+++ b/configs/platforms/debian-11-armhf.rb
@@ -18,7 +18,6 @@ platform "debian-11-armhf" do |plat|
     "libreadline-dev",
     "libselinux1-dev",
     "make",
-    "openjdk-11-jre-headless",
     "pkg-config",
     "cmake",
     "gcc",

--- a/configs/platforms/el-6-i386.rb
+++ b/configs/platforms/el-6-i386.rb
@@ -3,7 +3,6 @@ platform "el-6-i386" do |plat|
   
   packages = %w(
     bzip2-devel
-    java-1.8.0-openjdk-devel
     libsepol
     libsepol-devel
     libselinux-devel

--- a/configs/platforms/el-6-x86_64.rb
+++ b/configs/platforms/el-6-x86_64.rb
@@ -3,7 +3,6 @@ platform "el-6-x86_64" do |plat|
 
   packages = %w(
     bzip2-devel
-    java-1.8.0-openjdk-devel
     libsepol
     libsepol-devel
     libselinux-devel

--- a/configs/platforms/el-7-ppc64le.rb
+++ b/configs/platforms/el-7-ppc64le.rb
@@ -12,7 +12,6 @@
     "gcc",
     "gcc-c++",
     "imake",
-    "java-1.8.0-openjdk-devel",
     "libsepol",
     "libsepol-devel",
     "libselinux-devel",

--- a/configs/platforms/el-7-x86_64.rb
+++ b/configs/platforms/el-7-x86_64.rb
@@ -2,7 +2,6 @@ platform "el-7-x86_64" do |plat|
   plat.inherit_from_default
   packages = %w(
     bzip2-devel
-    java-1.8.0-openjdk-devel
     libsepol
     libsepol-devel
     libselinux-devel

--- a/configs/platforms/el-8-aarch64.rb
+++ b/configs/platforms/el-8-aarch64.rb
@@ -3,7 +3,6 @@ platform 'el-8-aarch64' do |plat|
 
   packages = %w(
     perl-Getopt-Long 
-    java-1.8.0-openjdk-devel
     patch 
     swig 
     libselinux-devel 

--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -2,7 +2,6 @@ platform "el-8-x86_64" do |plat|
   plat.inherit_from_default
 
   packages = %w(
-    java-1.8.0-openjdk-devel
     libsepol
     libsepol-devel
     libselinux-devel

--- a/configs/platforms/el-9-aarch64.rb
+++ b/configs/platforms/el-9-aarch64.rb
@@ -4,7 +4,6 @@ platform 'el-9-aarch64' do |plat|
   packages = %w(
     perl
     perl-Getopt-Long 
-    java-1.8.0-openjdk-devel
     patch 
     swig 
     readline-devel 

--- a/configs/platforms/el-9-x86_64.rb
+++ b/configs/platforms/el-9-x86_64.rb
@@ -22,7 +22,6 @@ platform "el-9-x86_64" do |plat|
     rpm-sign
     libtool
     libarchive
-    java-1.8.0-openjdk-devel
     libsepol
     libsepol-devel
     pkgconfig

--- a/configs/platforms/sles-12-ppc64le.rb
+++ b/configs/platforms/sles-12-ppc64le.rb
@@ -12,7 +12,6 @@ platform "sles-12-ppc64le" do |plat|
     "bison",
     "gcc",
     "gcc-c++",
-    "java-1_7_0-openjdk-devel",
     "libbz2-devel",
     "make",
     "pkgconfig",

--- a/configs/platforms/sles-12-x86_64.rb
+++ b/configs/platforms/sles-12-x86_64.rb
@@ -1,7 +1,6 @@
 platform "sles-12-x86_64" do |plat|
   plat.inherit_from_default
   packages = %w( 
-    java-1_7_0-openjdk-devel
     libbz2-devel
     pkgconfig
     pl-cmake

--- a/configs/platforms/sles-15-x86_64.rb
+++ b/configs/platforms/sles-15-x86_64.rb
@@ -2,7 +2,6 @@ platform "sles-15-x86_64" do |plat|
   plat.inherit_from_default
 
   packages = %w(
-    java-1_8_0-openjdk-devel
     libbz2-devel
     pkg-config
     readline-devel

--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -5,7 +5,6 @@ platform "ubuntu-18.04-amd64" do |plat|
     libbz2-dev
     libreadline-dev
     libselinux1-dev
-    openjdk-8-jdk
     pl-cmake
     pl-gcc
     swig 

--- a/configs/platforms/ubuntu-20.04-aarch64.rb
+++ b/configs/platforms/ubuntu-20.04-aarch64.rb
@@ -5,7 +5,6 @@ platform "ubuntu-20.04-aarch64" do |plat|
     libbz2-dev
     libreadline-dev
     libselinux1-dev
-    openjdk-8-jre-headless
     gcc
     swig
     systemtap-sdt-dev

--- a/configs/platforms/ubuntu-20.04-amd64.rb
+++ b/configs/platforms/ubuntu-20.04-amd64.rb
@@ -5,7 +5,6 @@ platform "ubuntu-20.04-amd64" do |plat|
     libbz2-dev
     libreadline-dev
     libselinux1-dev
-    openjdk-8-jre-headless
     gcc
     swig
     systemtap-sdt-dev

--- a/configs/platforms/ubuntu-22.04-aarch64.rb
+++ b/configs/platforms/ubuntu-22.04-aarch64.rb
@@ -5,7 +5,6 @@ platform "ubuntu-22.04-aarch64" do |plat|
     libbz2-dev
     libreadline-dev
     libselinux1-dev
-    openjdk-8-jre-headless
     gcc
     swig
     systemtap-sdt-dev

--- a/configs/platforms/ubuntu-22.04-amd64.rb
+++ b/configs/platforms/ubuntu-22.04-amd64.rb
@@ -5,7 +5,6 @@ platform "ubuntu-22.04-amd64" do |plat|
     libbz2-dev
     libreadline-dev
     libselinux1-dev
-    openjdk-8-jre-headless
     gcc
     swig
     systemtap-sdt-dev


### PR DESCRIPTION
Native facter 3.x relied on JNI to bridge between Java and native code so that facter could be required in JRuby/puppetserver[1]. We also relied on javac and javah when building facter.jar. As a result, the puppet-agent project required openjdk in order to build native facter[2]. Note this was before the existence of the puppet-runtime project.

In 2015, we added the ca-cert component to puppet-agent[3]. It was later renamed to puppet-ca-bundle.

In 2017, we extracted ruby, curl, puppet-ca-bundle, etc into a separate puppet-runtime project, and the openjdk dependency was copied[4].

In 2020, we dropped support for facter 3 due to puppet 6 going EOL.

In 2022, we no longer run keytool when building the runtime[5]. Instead we update the puppet-cacerts keystore whenever the puppet-ca-bundle component is updated. When building the runtime, we just copy over the certs.pem and java keystore files.

Now that facter 3 is EOL and we no longer need keytool when building puppet-runtime, we can drop the openjdk dependency.

Closes #751

[1] puppetlabs/facter@b1c916caf6d35fa4da236c3ba7a1ef5ab989969c
[2] puppetlabs/puppet-agent@0da4f8b14addae5926c0186027ae2af5efc20970
[3] puppetlabs/puppet-agent@ee82f3ea0504e875e415825382d3b94a3c1d2f16
[4] puppetlabs/puppet-runtime@a9566bf2881ffc4d832b1c313c7c9eb4d395b440
[5] puppetlabs/puppet-ca-bundle@1b60dd21e1a1d84dda92f65305a60bbc609a97a7