### PR TITLE
(PA-5932) Add name to Jira workflow

### DIFF
--- a/.github/workflows/component_diff_check.yaml
+++ b/.github/workflows/component_diff_check.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Check
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,3 +1,6 @@
+---
+name: Export issue to Jira
+
 on:
   issues:
     types: [labeled]

--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Mend Monitor
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Ruby version 2.7


### PR DESCRIPTION
This PR:

- Adds a friendly name to the GitHub Actions workflow that exports GitHub Issues to Jira.
- Updates the Checkout action.
