### PR TITLE
Build pdk runtime components against openssl 3

### DIFF
--- a/configs/components/post-additional-rubies.rb
+++ b/configs/components/post-additional-rubies.rb
@@ -1,0 +1,6 @@
+component "post-additional-rubies" do |pkg, settings, platform|
+  pkg.build do
+    [ "rm -rf #{settings[:prefix]}/include/openssl",
+      "mv /tmp/openssl #{settings[:prefix]}/include/openssl"]
+  end
+end

--- a/configs/components/pre-additional-rubies.rb
+++ b/configs/components/pre-additional-rubies.rb
@@ -1,0 +1,5 @@
+component "pre-additional-rubies" do |pkg, settings, platform|
+  pkg.build do
+    ["mv #{settings[:prefix]}/include/openssl /tmp/openssl"]
+  end
+end

--- a/configs/projects/_pdk-components.rb
+++ b/configs/projects/_pdk-components.rb
@@ -41,6 +41,7 @@ if proj.respond_to?(:additional_rubies)
     raise "Not sure which openssl version to use for ruby #{rubyver}" unless rubyver.start_with?("2.7")
 
     # old ruby versions don't support openssl 3
+    proj.component "pre-additional-rubies"
     proj.component "openssl-1.1.1"
     proj.component "ruby-#{rubyver}"
 
@@ -49,6 +50,7 @@ if proj.respond_to?(:additional_rubies)
     proj.component "ruby-#{ruby_minor}-augeas" unless platform.is_windows?
     proj.component "ruby-#{ruby_minor}-selinux" if platform.is_el? || platform.is_fedora?
     proj.component "ruby-#{ruby_minor}-stomp"
+    proj.component "post-additional-rubies"
   end
 end
 

--- a/configs/projects/_pdk-components.rb
+++ b/configs/projects/_pdk-components.rb
@@ -1,21 +1,6 @@
 # This file is used to define the components that make up the PDK runtime package.
 
 if proj.ruby_major_version >= 3
-
-  openssl3_platform = [
-    platform.is_el?,
-    platform.is_fedora?,
-    platform.is_sles?,
-    platform.is_deb?,
-    platform.is_macos?,
-    platform.is_windows?
-  ].any?
-
-  openssl_version = proj.openssl_version
-  openssl_version = '3.0' if openssl3_platform
-
-  proj.component "openssl-#{openssl_version}"
-
   # Ruby 3.2 does not package these two libraries so we need to add them
   proj.component 'libffi'
   proj.component 'libyaml'
@@ -53,6 +38,10 @@ proj.component 'ruby-stomp'
 # Additional Rubies
 if proj.respond_to?(:additional_rubies)
   proj.additional_rubies.each_key do |rubyver|
+    raise "Not sure which openssl version to use for ruby #{rubyver}" unless rubyver.start_with?("2.7")
+
+    # old ruby versions don't support openssl 3
+    proj.component "openssl-1.1.1"
     proj.component "ruby-#{rubyver}"
 
     ruby_minor = rubyver.split('.')[0, 2].join('.')

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -1,6 +1,6 @@
 project 'pdk-runtime' do |proj|
   proj.setting(:runtime_project, 'pdk')
-  proj.setting(:openssl_version, '1.1.1')
+  proj.setting(:openssl_version, '3.0')
   proj.setting(:augeas_version, '1.14.1')
   proj.setting(:rubygem_fast_gettext_version, '1.1.2')
   proj.setting(:rubygem_gettext_version, '3.2.2')
@@ -157,10 +157,4 @@ project 'pdk-runtime' do |proj|
   proj.publish_yaml_settings
 
   proj.timeout 7200 if platform.is_windows?
-
-  # Here we rewrite public http urls to use our internal source host instead.
-  # Something like https://www.openssl.org/source/openssl-1.0.0r.tar.gz gets
-  # rewritten as
-  # https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/openssl-1.0.0r.tar.gz
-  # proj.register_rewrite_rule 'http', proj.buildsources_url
 end


### PR DESCRIPTION
The order that components are listed in pdk-components matters, so build openssl 3 first followed by other components that rely on it (curl, git, etc). Then build openssl 1.1.1 before building the extra ruby 2.7.8.

Note the openssl 1.1.1 headers still overwrite the 3.0.x, which is bad and needs to be resolved somehow as it may confuse any rubygem with native extension that we install in ruby 2.7.

```
ashen-control:~ root# otool -L /opt/puppetlabs/pdk/lib/libcurl.4.dylib
/opt/puppetlabs/pdk/lib/libcurl.4.dylib:
	/opt/puppetlabs/pdk/lib/libcurl.4.dylib (compatibility version 13.0.0, current version 13.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1856.105.0)
	/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration (compatibility version 1.0.0, current version 1163.60.3)
	/opt/puppetlabs/pdk/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
	/opt/puppetlabs/pdk/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.0.0)
ashen-control:~ root# export PDK_DISABLE_ANALYTICS="true"
ashen-control:~ root# export PATH="/opt/puppetlabs/pdk/bin:$PATH"
ashen-control:~ root# /opt/puppetlabs/pdk/private/git/bin/git clone https://github.com/puppetlabs/puppetlabs-motd /var/root/puppetlabs-motd
Cloning into '/var/root/puppetlabs-motd'...
remote: Enumerating objects: 2366, done.
remote: Counting objects: 100% (579/579), done.
remote: Compressing objects: 100% (259/259), done.
remote: Total 2366 (delta 297), reused 474 (delta 279), pack-reused 1787
Receiving objects: 100% (2366/2366), 549.52 KiB | 16.16 MiB/s, done.
Resolving deltas: 100% (1172/1172), done.
```

```
ashen-control:~ root# /opt/puppetlabs/pdk/private/ruby/2.7.8/bin/irb
irb(main):001:0> require 'openssl'
=> true
irb(main):002:0> OpenSSL::VERSION
=> "2.1.4"
irb(main):003:0> OpenSSL.constants.sort
=> [:ASN1, :BN, :BNError, :Buffering, :Cipher, :Config, :ConfigError, :Digest, :Engine, :ExtConfig, :HMAC, :HMACError, :KDF, :Netscape, :OCSP, :OPENSSL_FIPS, :OPENSSL_LIBRARY_VERSION, :OPENSSL_VERSION, :OPENSSL_VERSION_NUMBER, :OpenSSLError, :PKCS12, :PKCS5, :PKCS7, :PKey, :Random, :SSL, :VERSION, :X509]
irb(main):004:0> OpenSSL::OPENSSL_LIBRARY_VERSION
=> "OpenSSL 1.1.1v  1 Aug 2023"
...
irb(main):005:0> require 'net/http'
=> true
...
irb(main):007:0> Net::HTTP.get(URI("https://www.google.com/index.html"))
=> "<!doctype html><html itemscope=\"\" itemtype=\"http://schema.org/WebPage\" lang=\"en\"><head><meta content=\"Search the world's information, including webpages, images, videos and more. Google has many special features to help you...
```