### PR TITLE
(CAT-1505) Remove unneeded lines from Ruby 3.2 setup

### DIFF
--- a/configs/components/runtime-pdk.rb
+++ b/configs/components/runtime-pdk.rb
@@ -1,7 +1,5 @@
 # This component exists to link in the gcc and stdc++ runtime libraries.
 component "runtime-pdk" do |pkg, settings, platform|
-  pkg.build_requires "libffi"
-  pkg.build_requires "libyaml"
 
   if platform.is_windows?
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"
@@ -20,11 +18,6 @@ component "runtime-pdk" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
-
-    if settings[:ruby_major_version] >= 3
-      pkg.install_file "#{settings[:bindir]}/libyaml-0-2.dll", "#{settings[:ruby_bindir]}/libyaml-0-2.dll"
-      pkg.install_file "#{settings[:bindir]}/libffi-8.dll", "#{settings[:ruby_bindir]}/libffi-8.dll"
-    end
 
     # Copy the DLLs into additional ruby install bindirs as well.
     if settings.has_key?(:additional_rubies)


### PR DESCRIPTION
Explicit components have been added for both `libffi` and `libyaml` so these lines are no longer needed when setting up Ruby 3.2 and above and so can be removed.