### PR TITLE
Install missing dependencies for Ruby 3.2

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -127,13 +127,15 @@ end
 # RE-7593. However, Windows paths were changed to match *nix in puppet 6, see
 # commit 4b9d126dd5b. So only the pdk has this issue.
 if platform.is_windows? && settings[:bindir] != ruby_bindir
+  bindir = settings[:bindir]
+
   # Ruby 3+
   if Gem::Version.new(pkg.get_version) >= Gem::Version.new('3.0')
     pkg.install do
       [
         "cp #{settings[:gcc_bindir]}/libssp-0.dll #{ruby_bindir}",
-        "cp #{settings[:bindir]}/libffi-8.dll #{ruby_bindir}",
-        "cp #{settings[:bindir]}/libyaml-0-2.dll #{ruby_bindir}"
+        "cp #{bindir}/libffi-8.dll #{ruby_bindir}",
+        "cp #{bindir}/libyaml-0-2.dll #{ruby_bindir}"
       ]
     end
   end
@@ -160,9 +162,9 @@ if platform.is_windows? && settings[:bindir] != ruby_bindir
 
   pkg.install do
     [
-      "cp #{settings[:bindir]}/libgcc_s_#{gcc_postfix}-1.dll #{ruby_bindir}",
-      "cp #{settings[:bindir]}/#{ssl_lib} #{ruby_bindir}",
-      "cp #{settings[:bindir]}/#{crypto_lib} #{ruby_bindir}",
+      "cp #{bindir}/libgcc_s_#{gcc_postfix}-1.dll #{ruby_bindir}",
+      "cp #{bindir}/#{ssl_lib} #{ruby_bindir}",
+      "cp #{bindir}/#{crypto_lib} #{ruby_bindir}"
     ]
   end
 

--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -132,6 +132,8 @@ if platform.is_windows? && settings[:bindir] != ruby_bindir
     pkg.install do
       [
         "cp #{settings[:gcc_bindir]}/libssp-0.dll #{ruby_bindir}",
+        "cp #{settings[:bindir]}/libffi-8.dll #{ruby_bindir}",
+        "cp #{settings[:bindir]}/libyaml-0-2.dll #{ruby_bindir}"
       ]
     end
   end

--- a/configs/components/runtime-pdk.rb
+++ b/configs/components/runtime-pdk.rb
@@ -7,26 +7,30 @@ component "runtime-pdk" do |pkg, settings, platform|
       pkg.install_file File.join(settings[:gcc_bindir], dll), File.join(settings[:bindir], dll)
     end
 
-    # Ruby needs zlib
+    tools_bindir = File.join(settings[:tools_root], 'bin')
+
+    # curl, openssl, etc need zlib, so install in *main* bin dir
     pkg.build_requires "pl-zlib-#{platform.architecture}"
-    pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:bindir]}/zlib1.dll"
+    pkg.install_file "#{tools_bindir}/zlib1.dll", "#{settings[:bindir]}/zlib1.dll"
 
     # zlib, gdbm, yaml-cpp and iconv are all runtime dependancies of ruby, and their libraries need
-    # To exist inside our vendored ruby
-    pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:ruby_bindir]}/zlib1.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{settings[:ruby_bindir]}/libgdbm-4.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll" if settings[:ruby_version].start_with?('2')
+    # to exist inside our primary ruby's bin dir
+    ruby_bindir = settings[:ruby_bindir]
+    pkg.install_file "#{tools_bindir}/zlib1.dll",            "#{ruby_bindir}/zlib1.dll"
+    pkg.install_file "#{tools_bindir}/libgdbm-4.dll",        "#{ruby_bindir}/libgdbm-4.dll"
+    pkg.install_file "#{tools_bindir}/libgdbm_compat-4.dll", "#{ruby_bindir}/libgdbm_compat-4.dll"
+    pkg.install_file "#{tools_bindir}/libiconv-2.dll",       "#{ruby_bindir}/libiconv-2.dll"
+    pkg.install_file "#{tools_bindir}/libffi-6.dll",         "#{ruby_bindir}/libffi-6.dll" if settings[:ruby_version].start_with?('2')
 
     # Copy the DLLs into additional ruby install bindirs as well.
     if settings.has_key?(:additional_rubies)
       settings[:additional_rubies].each do |rubyver, local_settings|
-        pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{local_settings[:ruby_bindir]}/zlib1.dll"
-        pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{local_settings[:ruby_bindir]}/libgdbm-4.dll"
-        pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{local_settings[:ruby_bindir]}/libgdbm_compat-4.dll"
-        pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{local_settings[:ruby_bindir]}/libiconv-2.dll"
-        pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{local_settings[:ruby_bindir]}/libffi-6.dll" if rubyver.start_with?('2')
+        local_bindir = local_settings[:ruby_bindir]
+        pkg.install_file "#{tools_bindir}/zlib1.dll",            "#{local_bindir}/zlib1.dll"
+        pkg.install_file "#{tools_bindir}/libgdbm-4.dll",        "#{local_bindir}/libgdbm-4.dll"
+        pkg.install_file "#{tools_bindir}/libgdbm_compat-4.dll", "#{local_bindir}/libgdbm_compat-4.dll"
+        pkg.install_file "#{tools_bindir}/libiconv-2.dll",       "#{local_bindir}/libiconv-2.dll"
+        pkg.install_file "#{tools_bindir}/libffi-6.dll",         "#{local_bindir}/libffi-6.dll" if rubyver.start_with?('2')
       end
     end
 

--- a/configs/components/runtime-pdk.rb
+++ b/configs/components/runtime-pdk.rb
@@ -17,7 +17,7 @@ component "runtime-pdk" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{settings[:ruby_bindir]}/libgdbm-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll" if settings[:ruby_version].start_with?('2')
 
     # Copy the DLLs into additional ruby install bindirs as well.
     if settings.has_key?(:additional_rubies)
@@ -26,7 +26,7 @@ component "runtime-pdk" do |pkg, settings, platform|
         pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{local_settings[:ruby_bindir]}/libgdbm-4.dll"
         pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{local_settings[:ruby_bindir]}/libgdbm_compat-4.dll"
         pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{local_settings[:ruby_bindir]}/libiconv-2.dll"
-        pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{local_settings[:ruby_bindir]}/libffi-6.dll"
+        pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{local_settings[:ruby_bindir]}/libffi-6.dll" if rubyver.start_with?('2')
       end
     end
 

--- a/configs/projects/_pdk-components.rb
+++ b/configs/projects/_pdk-components.rb
@@ -25,12 +25,6 @@ proj.component 'libxml2' unless platform.is_windows?
 proj.component 'libxslt' unless platform.is_windows?
 proj.component "ruby-#{proj.ruby_version}"
 
-# After installing ruby, we need to copy libssp to the ruby bindir on windows
-if platform.is_windows?
-  ruby_component = @project.get_component "ruby-#{proj.ruby_version}"
-  ruby_component.install.push "cp '#{settings[:bindir]}/libssp-0.dll' '#{settings[:ruby_bindir]}/libssp-0.dll'"
-end
-
 proj.component 'ruby-augeas' unless platform.is_windows?
 proj.component 'ruby-selinux' if platform.is_el? || platform.is_fedora?
 proj.component 'ruby-stomp'


### PR DESCRIPTION
Previously, the pdk-vanagon's gem prune command[1] failed on Windows with Ruby 3.2:
    
     $ GEM_PATH="C:/ProgramFiles64Folder/PuppetLabs/DevelopmentKit/private/puppet/ruby/3.2.0;C:/ProgramFiles64Folder/PuppetLabs/DevelopmentKit/share/cache/ruby/3.2.0" RUBYOPT="-Irubygems-prune" C:/ProgramFiles64Folder/PuppetLabs/DevelopmentKit/private/ruby/3.2.2/bin/gem.bat prune
        .. The specified module could not be found.   - C:/ProgramFiles64Folder/PuppetLabs/DevelopmentKit/private/ruby/3.2.2/lib/ruby/3.2.0/x64-mingw32/psych.so (LoadError)

This commit:

* Installs libffi-8.dll, libyaml-0-2.dll and libssp-0.dll into the pdk's primary ruby 3.2 bin directory
* Removes libffi-6.dll from ruby 3.2 bin directory

See individual commits for gory details

[1] https://github.com/puppetlabs/pdk-vanagon/blob/c7d35b03fa014f95570cee9c84fcfd2bbfc7df32/configs/components/gem-prune.rb#L37
