### PR TITLE
Add support for labeling pull requests

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -4,9 +4,12 @@ name: Export issue to Jira
 on:
   issues:
     types: [labeled]
+  pull_requests:
+    types: [labeled]
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   export:


### PR DESCRIPTION
Note the dash vs underscore inconsistency when specifying pull request triggers vs permissions.