### PR TITLE
(PA-5876) Enable macOS 14 (Intel) puppet-runtime builds for agent-run…

### DIFF
--- a/configs/platforms/osx-14-x86_64.rb
+++ b/configs/platforms/osx-14-x86_64.rb
@@ -1,0 +1,8 @@
+platform 'osx-14-x86_64' do |plat|
+  plat.inherit_from_default
+
+  packages = %w[cmake pkg-config yaml-cpp]
+  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+
+  plat.output_dir File.join('apple', '14', 'PC1', 'x86_64')
+end


### PR DESCRIPTION
Build: [vanagon-generic-builder_vanagon agent-runtime-main](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=osx-14-x86_64,SLAVE_LABEL=k8s-worker/2519/console)