### PR TITLE
(PA-5902) Enable puppet-runtime builds for macOS 14(ARM)

### DIFF
--- a/configs/platforms/osx-14-arm64.rb
+++ b/configs/platforms/osx-14-arm64.rb
@@ -1,0 +1,8 @@
+platform 'osx-14-arm64' do |plat|
+  plat.inherit_from_default
+
+  packages = %w[automake cmake pkg-config yaml-cpp]
+  plat.provision_with "su test -c '/opt/homebrew/bin/brew install #{packages.join(' ')}'"
+
+  plat.output_dir File.join('apple', '14', 'PC1', 'arm64')
+end


### PR DESCRIPTION
Enable puppet-runtime builds for macOS 14(ARM)