### PR TITLE
(PA-5960) Use concurrent-ruby 1.2.2 for all runtimes

### DIFF
--- a/configs/components/rubygem-concurrent-ruby.rb
+++ b/configs/components/rubygem-concurrent-ruby.rb
@@ -1,14 +1,13 @@
 component 'rubygem-concurrent-ruby' do |pkg, settings, platform|
   # Projects may define a :rubygem_concurrent_ruby_version setting
-  version = settings[:rubygem_concurrent_ruby_version] || '1.1.10'
+  version = settings[:rubygem_concurrent_ruby_version] || '1.2.2'
+  pkg.version version
 
   case version
-  when '1.1.9'
-    pkg.version '1.1.9'
-    pkg.md5sum '417a23cac840f6ea8bdd0841429c3c19'
-  when '1.1.10'
-    pkg.version '1.1.10'
-    pkg.md5sum '4588a61d5af26e9ee12e9b8babc1b755'
+  when '1.2.2'
+    pkg.sha256sum '3879119b8b75e3b62616acc256c64a134d0b0a7a9a3fcba5a233025bcde22c4f'
+  else
+    raise "rubygem-concurrent-ruby #{version} has not been configured; Cannot continue."
   end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/configs/projects/agent-runtime-7.x.rb
+++ b/configs/projects/agent-runtime-7.x.rb
@@ -6,7 +6,6 @@ project 'agent-runtime-7.x' do |proj|
   proj.setting :rubygem_fast_gettext_version, '1.1.2'
   proj.setting :rubygem_gettext_version, '3.2.2'
   proj.setting :rubygem_gettext_setup_version, '0.34'
-  proj.setting :rubygem_concurrent_ruby_version, '1.1.9'
 
   # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0
   if platform.is_solaris? || platform.is_aix?

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -4,7 +4,6 @@ project 'bolt-runtime' do |proj|
   proj.setting(:ruby_version, '2.7.8')
   proj.setting(:openssl_version, '1.1.1')
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
-  proj.setting :rubygem_concurrent_ruby_version, '1.1.9'
   proj.setting(:augeas_version, '1.11.0')
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_deep_merge_version, '1.2.2')

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -144,7 +144,6 @@ project 'pdk-runtime' do |proj|
   proj.setting(:git_sysconfdir, '/etc')
 
   # Load PDK component definitions
-  proj.setting(:rubygem_concurrent_ruby_version, '1.1.10')
   proj.setting(:rubygem_deep_merge_version, '1.2.2')
   instance_eval File.read(File.join(File.dirname(__FILE__), '_pdk-components.rb'))
 


### PR DESCRIPTION
Versions prior to 1.2.x have a memory leak in JRuby when storing thread local state. Move everything to 1.2.2 and drop the old versions.

This also switches to SHA256 for this gem and raises if a project requests an unknown version.

Here is what your code changes would affect:

## Project `pe-installer-runtime-main`

### Platform name: `el-7-x86_64`
<details>
  <summary>Component 'rubygem-concurrent-ruby'</summary>

**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `install[0]`
```diff
- /opt/puppetlabs/installer/bin/gem install --no-document --local --bindir=/opt/puppetlabs/installer/bin concurrent-ruby-1.1.10.gem
+ /opt/puppetlabs/installer/bin/gem install --no-document --local --bindir=/opt/puppetlabs/installer/bin concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `mirrors[0]`
```diff
- https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.1.10.gem
+ https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum`
```diff
- 4588a61d5af26e9ee12e9b8babc1b755
+ 3879119b8b75e3b62616acc256c64a134d0b0a7a9a3fcba5a233025bcde22c4f
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum_type`
```diff
- md5
+ sha256
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `url`
```diff
- https://rubygems.org/downloads/concurrent-ruby-1.1.10.gem
+ https://rubygems.org/downloads/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `version`
```diff
- 1.1.10
+ 1.2.2
```
</details>

## Project `pe-bolt-server-runtime-main`

### Platform name: `el-7-x86_64`
<details>
  <summary>Component 'rubygem-concurrent-ruby'</summary>

**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `install[0]`
```diff
- /opt/puppetlabs/server/apps/bolt-server/bin/gem install --no-document --local --bindir=/opt/puppetlabs/server/apps/bolt-server/bin concurrent-ruby-1.1.10.gem
+ /opt/puppetlabs/server/apps/bolt-server/bin/gem install --no-document --local --bindir=/opt/puppetlabs/server/apps/bolt-server/bin concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `mirrors[0]`
```diff
- https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.1.10.gem
+ https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum`
```diff
- 4588a61d5af26e9ee12e9b8babc1b755
+ 3879119b8b75e3b62616acc256c64a134d0b0a7a9a3fcba5a233025bcde22c4f
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum_type`
```diff
- md5
+ sha256
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `url`
```diff
- https://rubygems.org/downloads/concurrent-ruby-1.1.10.gem
+ https://rubygems.org/downloads/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `version`
```diff
- 1.1.10
+ 1.2.2
```
</details>

## Project `agent-runtime-7.x`

### Platform name: `el-7-x86_64`
<details>
  <summary>Component 'rubygem-concurrent-ruby'</summary>

**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `install[0]`
```diff
- /opt/puppetlabs/puppet/bin/gem install --no-document --local concurrent-ruby-1.1.9.gem
+ /opt/puppetlabs/puppet/bin/gem install --no-document --local concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `mirrors[0]`
```diff
- https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.1.9.gem
+ https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum`
```diff
- 417a23cac840f6ea8bdd0841429c3c19
+ 3879119b8b75e3b62616acc256c64a134d0b0a7a9a3fcba5a233025bcde22c4f
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum_type`
```diff
- md5
+ sha256
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `url`
```diff
- https://rubygems.org/downloads/concurrent-ruby-1.1.9.gem
+ https://rubygems.org/downloads/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `version`
```diff
- 1.1.9
+ 1.2.2
```
</details>

## Project `pe-bolt-server-runtime-2021.7.x`

### Platform name: `el-7-x86_64`
<details>
  <summary>Component 'rubygem-concurrent-ruby'</summary>

**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `install[0]`
```diff
- /opt/puppetlabs/puppet/bin/gem install --no-document --local --bindir=/opt/puppetlabs/server/apps/bolt-server/bin concurrent-ruby-1.1.10.gem
+ /opt/puppetlabs/puppet/bin/gem install --no-document --local --bindir=/opt/puppetlabs/server/apps/bolt-server/bin concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `mirrors[0]`
```diff
- https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.1.10.gem
+ https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum`
```diff
- 4588a61d5af26e9ee12e9b8babc1b755
+ 3879119b8b75e3b62616acc256c64a134d0b0a7a9a3fcba5a233025bcde22c4f
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum_type`
```diff
- md5
+ sha256
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `url`
```diff
- https://rubygems.org/downloads/concurrent-ruby-1.1.10.gem
+ https://rubygems.org/downloads/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `version`
```diff
- 1.1.10
+ 1.2.2
```
</details>

## Project `pe-installer-runtime-2021.7.x`

### Platform name: `el-7-x86_64`
<details>
  <summary>Component 'rubygem-concurrent-ruby'</summary>

**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `install[0]`
```diff
- /opt/puppetlabs/installer/bin/gem install --no-document --local --bindir=/opt/puppetlabs/installer/bin concurrent-ruby-1.1.10.gem
+ /opt/puppetlabs/installer/bin/gem install --no-document --local --bindir=/opt/puppetlabs/installer/bin concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `mirrors[0]`
```diff
- https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.1.10.gem
+ https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum`
```diff
- 4588a61d5af26e9ee12e9b8babc1b755
+ 3879119b8b75e3b62616acc256c64a134d0b0a7a9a3fcba5a233025bcde22c4f
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum_type`
```diff
- md5
+ sha256
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `url`
```diff
- https://rubygems.org/downloads/concurrent-ruby-1.1.10.gem
+ https://rubygems.org/downloads/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `version`
```diff
- 1.1.10
+ 1.2.2
```
</details>

## Project `bolt-runtime`

### Platform name: `el-7-x86_64`
<details>
  <summary>Component 'rubygem-concurrent-ruby'</summary>

**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `install[0]`
```diff
- /opt/puppetlabs/bolt/bin/gem install --no-document --local --bindir=/opt/puppetlabs/bolt/bin concurrent-ruby-1.1.9.gem
+ /opt/puppetlabs/bolt/bin/gem install --no-document --local --bindir=/opt/puppetlabs/bolt/bin concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `mirrors[0]`
```diff
- https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.1.9.gem
+ https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum`
```diff
- 417a23cac840f6ea8bdd0841429c3c19
+ 3879119b8b75e3b62616acc256c64a134d0b0a7a9a3fcba5a233025bcde22c4f
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum_type`
```diff
- md5
+ sha256
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `url`
```diff
- https://rubygems.org/downloads/concurrent-ruby-1.1.9.gem
+ https://rubygems.org/downloads/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `version`
```diff
- 1.1.9
+ 1.2.2
```
</details>

## Project `pdk-runtime`

### Platform name: `el-7-x86_64`
<details>
  <summary>Component 'rubygem-concurrent-ruby'</summary>

**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `install[0]`
```diff
- /opt/puppetlabs/pdk/private/ruby/3.2.2/bin/gem install --no-document --local  concurrent-ruby-1.1.10.gem
+ /opt/puppetlabs/pdk/private/ruby/3.2.2/bin/gem install --no-document --local  concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `mirrors[0]`
```diff
- https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.1.10.gem
+ https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum`
```diff
- 4588a61d5af26e9ee12e9b8babc1b755
+ 3879119b8b75e3b62616acc256c64a134d0b0a7a9a3fcba5a233025bcde22c4f
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum_type`
```diff
- md5
+ sha256
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `url`
```diff
- https://rubygems.org/downloads/concurrent-ruby-1.1.10.gem
+ https://rubygems.org/downloads/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `version`
```diff
- 1.1.10
+ 1.2.2
```
</details>

## Project `client-tools-runtime-main`
Nothing is affected 😊

## Project `client-tools-runtime-2021.7.x`
Nothing is affected 😊

## Project `agent-runtime-main`

### Platform name: `el-7-x86_64`
<details>
  <summary>Component 'rubygem-concurrent-ruby'</summary>

**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `install[0]`
```diff
- /opt/puppetlabs/puppet/bin/gem install --no-document --local concurrent-ruby-1.1.10.gem
+ /opt/puppetlabs/puppet/bin/gem install --no-document --local concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `mirrors[0]`
```diff
- https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.1.10.gem
+ https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum`
```diff
- 4588a61d5af26e9ee12e9b8babc1b755
+ 3879119b8b75e3b62616acc256c64a134d0b0a7a9a3fcba5a233025bcde22c4f
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `options|sum_type`
```diff
- md5
+ sha256
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `url`
```diff
- https://rubygems.org/downloads/concurrent-ruby-1.1.10.gem
+ https://rubygems.org/downloads/concurrent-ruby-1.2.2.gem
```
**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Field:** `version`
```diff
- 1.1.10
+ 1.2.2
```
</details>
