### PR TITLE
Switch to Ruby 3.2 for GH actions

### DIFF
--- a/.github/workflows/component_diff_check.yaml
+++ b/.github/workflows/component_diff_check.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install ruby version ${{ matrix.cfg.ruby }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
 
       - name: Bundle project
         run: |

--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
       - name: Create lock
         run: bundle lock
       - uses: actions/setup-java@v3

--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Ruby version 2.7
+      - name: Install Ruby version 3.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
       - name: Update rubygems and install gems
         run: |
           gem update --system --silent --no-document


### PR DESCRIPTION
The `gem install bundler` step started failing because the latest bundler is not compatible with Ruby 2.7:

    The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22.
    Try installing it with `gem install bundler -v 2.4.22`

Just move everything to 3.2. Note this doesn't affect the ruby we build or ship, just the version that's used to run GH actions.