### PR TITLE
(PA-5960) Bump vendored puppet gems for concurrent-ruby 1.2.2 compat

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -4,9 +4,21 @@ component 'rubygem-puppet' do |pkg, settings, platform|
   version = settings[:rubygem_puppet_version] || '6.28.0'
   pkg.version version
 
+  # There are 4 platform-specific puppet gems for each tag:
+  #
+  #   generic
+  #   universal-darwin
+  #   x64-mingw32
+  #   x86_mingw32
+  #
+  # Always use the generic version below
   case version
+  when '8.3.1'
+    pkg.md5sum '9cff495eff59639fce989dceeff34560'
   when '8.0.1'
     pkg.md5sum '7e87d988e485c0f0c3d6ef76bd39409d'
+  when '7.27.0'
+    pkg.md5sum '6a49f375dffe5f786ed474b3eaaaf931'
   when '7.26.0'
     pkg.md5sum '347ec39281f59232be5cbb47daf9b539'
   when '6.28.0'

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -7,7 +7,7 @@ project 'bolt-runtime' do |proj|
   proj.setting(:augeas_version, '1.11.0')
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_deep_merge_version, '1.2.2')
-  proj.setting(:rubygem_puppet_version, '7.26.0')
+  proj.setting(:rubygem_puppet_version, '7.27.0')
 
   platform = proj.get_platform
 

--- a/configs/projects/pe-bolt-server-runtime-2021.7.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2021.7.x.rb
@@ -1,6 +1,6 @@
 project 'pe-bolt-server-runtime-2021.7.x' do |proj|
   proj.setting(:pe_version, '2021.7')
-  proj.setting(:rubygem_puppet_version, '7.26.0')
+  proj.setting(:rubygem_puppet_version, '7.27.0')
   proj.setting(:rubygem_puppet_strings_version, '3.0.1')
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.7 we need to use a --no-document flag

--- a/configs/projects/pe-bolt-server-runtime-main.rb
+++ b/configs/projects/pe-bolt-server-runtime-main.rb
@@ -1,6 +1,6 @@
 project 'pe-bolt-server-runtime-main' do |proj|
   proj.setting(:pe_version, 'main')
-  proj.setting(:rubygem_puppet_version, '8.0.1')
+  proj.setting(:rubygem_puppet_version, '8.3.1')
   proj.setting(:rubygem_net_ssh_version, '7.0.1')
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.7 we need to use a --no-document flag
   # for gem installs instead of --no-ri --no-rdoc. This setting allows us to use this while we support both ruby 2.5 and 2.7


### PR DESCRIPTION
Commit f201ef9 bumped all runtime projects to use concurrent-ruby 1.2.2, but some runtime projects vendor an older version of puppet that requires concurrent-ruby less than 1.2. So bump those runtime projects to use the latest released puppet version.

Technically, puppet versions 7.25.0 and 8.1.0 were the first gems to support concurrent-ruby 1.2 and up, but there are some other bug fixes with binary Strings and monkey patching `File,Dir.exists?` back, so bump to latest.