### PR TITLE
(PA-5999) Add support for SLES-11 (Intel)

### DIFF
--- a/configs/components/ruby-2.7.8.rb
+++ b/configs/components/ruby-2.7.8.rb
@@ -118,7 +118,9 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
     special_flags += " --with-openssl-dir=#{settings[:prefix]} "
   elsif platform.is_solaris? && platform.architecture == "sparc"
     special_flags += " --with-baseruby=#{host_ruby} --enable-close-fds-by-recvmsg-with-peek "
-  elsif platform.name =~ /el-6/
+  elsif platform.name =~ /el-6/  || platform.name =~ /sles-11-x86_64/
+    # Since we're not cross compiling, ignore old ruby versions that happen to be in the PATH
+    # and force ruby to build miniruby and use that to bootstrap the rest of the build
     special_flags += " --with-baseruby=no "
   elsif platform.is_windows?
     special_flags = " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
@@ -130,6 +132,7 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
     'osx-11-arm64',
     'osx-12-arm64',
     'redhatfips-7-x86_64',
+    'sles-11-x86_64',
     'sles-12-ppc64le',
     'solaris-10-sparc',
     'solaris-11-sparc',

--- a/configs/platforms/sles-11-x86_64.rb
+++ b/configs/platforms/sles-11-x86_64.rb
@@ -8,8 +8,6 @@ platform "sles-11-x86_64" do |plat|
     "aaa_base",
     "autoconf",
     "automake",
-    "gcc",
-    "java-1_7_1-ibm-devel",
     "libbz2-devel",
     "make",
     "pkgconfig",
@@ -19,6 +17,16 @@ platform "sles-11-x86_64" do |plat|
     "rsync",
     "zlib-devel"
   ]
+  plat.provision_with(%q{cat <<END > /etc/zypp/repos.d/localmirror-os.repo
+    [localmirror-os]
+    name=localmirror-os
+    baseurl=http://osmirror.delivery.puppetlabs.net/sles-11-sp4-x86_64/RPMS.os
+    enabled=1
+    gpgcheck=0
+    gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-SLES-11
+    autorefresh=1
+    type=rpm-md 
+    END})
   plat.provision_with("zypper -n --no-gpg-checks install -y #{packages.join(' ')}")
   plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
   plat.vmpooler_template "sles-11-x86_64"


### PR DESCRIPTION
 - Removed the java package because its no longer needed and removed gcc(version 4.3.4 in the image) because we are supposed to be using pl-gcc (version 4.8.4).
 - Added SLES-11 to without-dtrace platforms to build ruby
 - Add --with-baseruby=no to configure script to not use base ruby since the image has ruby 1.8.7.