### PR TITLE
(PA-5999) Add sles11 intel platform support

### DIFF
--- a/configs/components/ruby-2.7.8.rb
+++ b/configs/components/ruby-2.7.8.rb
@@ -118,7 +118,9 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
     special_flags += " --with-openssl-dir=#{settings[:prefix]} "
   elsif platform.is_solaris? && platform.architecture == "sparc"
     special_flags += " --with-baseruby=#{host_ruby} --enable-close-fds-by-recvmsg-with-peek "
-  elsif platform.name =~ /el-6/
+  elsif platform.name =~ /el-6/ || platform.name =~ /sles-11-x86_64/
+    # Since we're not cross compiling, ignore old ruby versions that happen to be in the PATH
+    # and force ruby to build miniruby and use that to bootstrap the rest of the build
     special_flags += " --with-baseruby=no "
   elsif platform.is_windows?
     special_flags = " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
@@ -130,6 +132,7 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
     'osx-11-arm64',
     'osx-12-arm64',
     'redhatfips-7-x86_64',
+    'sles-11-x86_64',
     'sles-12-ppc64le',
     'solaris-10-sparc',
     'solaris-11-sparc',

--- a/configs/platforms/sles-11-x86_64.rb
+++ b/configs/platforms/sles-11-x86_64.rb
@@ -8,8 +8,6 @@ platform "sles-11-x86_64" do |plat|
     "aaa_base",
     "autoconf",
     "automake",
-    "gcc",
-    "java-1_7_1-ibm-devel",
     "libbz2-devel",
     "make",
     "pkgconfig",
@@ -20,6 +18,8 @@ platform "sles-11-x86_64" do |plat|
     "zlib-devel"
   ]
   plat.provision_with("zypper -n --no-gpg-checks install -y #{packages.join(' ')}")
+  plat.provision_with "zypper install -y --oldpackage pl-gcc=4.8.2-1"
+  plat.provision_with "zypper install -y --oldpackage pl-cmake=3.2.3-13.sles11"
   plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
   plat.vmpooler_template "sles-11-x86_64"
 end


### PR DESCRIPTION
Added sles11 to ruby-2.7.8 and removed java-1.7.1

Vanagon generic builder : https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2639/console

artifacts : https://builds.delivery.puppetlabs.net/puppet-runtime/9885a2f903730910232330a40320487574f27da7/artifacts/