### PR TITLE
(PA-5999) Use pl-autotools instead of autoconf and automake for SLES-11

### DIFF
--- a/configs/platforms/sles-11-x86_64.rb
+++ b/configs/platforms/sles-11-x86_64.rb
@@ -6,11 +6,10 @@ platform "sles-11-x86_64" do |plat|
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/11/x86_64/pl-build-tools-sles-11-x86_64.repo"
   packages = [
     "aaa_base",
-    "autoconf",
-    "automake",
     "libbz2-devel",
     "make",
     "pkgconfig",
+    "pl-autotools",
     "pl-cmake",
     "pl-gcc",
     "readline-devel",


### PR DESCRIPTION
 - For Puppet8, we use ruby3 which requires autoconf to be >= 2.67, but SLES-11 supports only upto 2.63. So, we use pl-autotools for both puppet7 and puppet8 for consistency.