### PR TITLE
(maint) Use Nori 2.6.0 for pe-installer-runtime-2021.7.x

### DIFF
--- a/configs/projects/pe-installer-runtime-2021.7.x.rb
+++ b/configs/projects/pe-installer-runtime-2021.7.x.rb
@@ -99,6 +99,7 @@ project 'pe-installer-runtime-2021.7.x' do |proj|
   proj.component 'rubygem-sys-filesystem'
   proj.component 'rubygem-prime'
   proj.component 'rubygem-erubi'
+  proj.component 'rubygem-nori'
 
   # What to include in package?
   proj.directory proj.prefix


### PR DESCRIPTION
2.7.0 requires Ruby 3, so include this at 2.6 so Bolt doesn't try pulling in 2.7.