### PR TITLE
PA-6132: Back-Port OpenSSL 1.1.1 for agent-runtime-7.x

### DIFF
--- a/configs/components/openssl-1.1.1-fips.rb
+++ b/configs/components/openssl-1.1.1-fips.rb
@@ -24,6 +24,9 @@ component 'openssl-1.1.1-fips' do |pkg, settings, platform|
   pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch'
   pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-remove-env-check.patch'
   pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1l-sm2-plaintext.patch'
+  pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1k-CVE-2023-3446-fips.patch'
+  pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1k-CVE-2023-5678-fips.patch'
+  pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1k-CVE-2024-0727-fips.patch'
 
   if platform.name =~ /-7-/
     pkg.add_source 'file://resources/patches/openssl/openssl-1.1.1-fips-post-rand.patch'
@@ -55,7 +58,10 @@ component 'openssl-1.1.1-fips' do |pkg, settings, platform|
       "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-force-fips-mode.patch && cd -",
       "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-spec-file.patch && cd -",
       "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1-fips-remove-env-check.patch && cd -",
-      "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1l-sm2-plaintext.patch && cd -"
+      "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1l-sm2-plaintext.patch && cd -",
+      "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1k-CVE-2023-3446-fips.patch && cd -",
+      "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1k-CVE-2023-5678-fips.patch && cd -",
+      "cd openssl-#{pkg.get_version} && /usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../openssl-1.1.1k-CVE-2024-0727-fips.patch && cd -"
     ]
   end
 

--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -87,6 +87,9 @@ component 'openssl' do |pkg, settings, platform|
     end
   end
 
+  pkg.apply_patch 'resources/patches/openssl/CVE-2023-5678.patch'
+  pkg.apply_patch 'resources/patches/openssl/CVE-2024-0727.patch'
+
   ####################
   # BUILD REQUIREMENTS
   ####################

--- a/resources/patches/openssl/CVE-2023-5678.patch
+++ b/resources/patches/openssl/CVE-2023-5678.patch
@@ -1,0 +1,142 @@
+Backport of:
+
+From db925ae2e65d0d925adef429afc37f75bd1c2017 Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Fri, 20 Oct 2023 09:18:19 +0200
+Subject: [PATCH] Make DH_check_pub_key() and DH_generate_key() safer yet
+
+We already check for an excessively large P in DH_generate_key(), but not in
+DH_check_pub_key(), and none of them check for an excessively large Q.
+
+This change adds all the missing excessive size checks of P and Q.
+
+It's to be noted that behaviours surrounding excessively sized P and Q
+differ.  DH_check() raises an error on the excessively sized P, but only
+sets a flag for the excessively sized Q.  This behaviour is mimicked in
+DH_check_pub_key().
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Hugo Landau <hlandau@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/22518)
+
+(cherry picked from commit ddeb4b6c6d527e54ce9a99cba785c0f7776e54b6)
+---
+ crypto/dh/dh_check.c    | 12 ++++++++++++
+ crypto/dh/dh_err.c      |  3 ++-
+ crypto/dh/dh_key.c      | 12 ++++++++++++
+ crypto/err/openssl.txt  |  1 +
+ include/crypto/dherr.h  |  2 +-
+ include/openssl/dh.h    |  6 +++---
+ include/openssl/dherr.h |  3 ++-
+ 7 files changed, 33 insertions(+), 6 deletions(-)
+
+--- a/crypto/dh/dh_check.c
++++ b/crypto/dh/dh_check.c
+@@ -201,6 +201,19 @@ int DH_check_pub_key(const DH *dh, const
+     if (ctx == NULL)
+         goto err;
+     BN_CTX_start(ctx);
++
++    /* Don't do any checks at all with an excessively large modulus */
++    if (BN_num_bits(dh->p) > OPENSSL_DH_CHECK_MAX_MODULUS_BITS) {
++        DHerr(DH_F_DH_CHECK, DH_R_MODULUS_TOO_LARGE);
++        *ret = DH_MODULUS_TOO_LARGE | DH_CHECK_PUBKEY_INVALID;
++        goto err;
++    }
++
++    if (dh->q != NULL && BN_ucmp(dh->p, dh->q) < 0) {
++        *ret |= DH_CHECK_INVALID_Q_VALUE | DH_CHECK_PUBKEY_INVALID;
++        goto out;
++    }
++
+     tmp = BN_CTX_get(ctx);
+     if (tmp == NULL || !BN_set_word(tmp, 1))
+         goto err;
+@@ -219,6 +232,7 @@ int DH_check_pub_key(const DH *dh, const
+             *ret |= DH_CHECK_PUBKEY_INVALID;
+     }
+ 
++ out:
+     ok = 1;
+  err:
+     BN_CTX_end(ctx);
+--- a/crypto/dh/dh_err.c
++++ b/crypto/dh/dh_err.c
+@@ -82,6 +82,7 @@ static const ERR_STRING_DATA DH_str_reas
+     {ERR_PACK(ERR_LIB_DH, 0, DH_R_PARAMETER_ENCODING_ERROR),
+     "parameter encoding error"},
+     {ERR_PACK(ERR_LIB_DH, 0, DH_R_PEER_KEY_ERROR), "peer key error"},
++    {ERR_PACK(ERR_LIB_DH, 0, DH_R_Q_TOO_LARGE), "q too large"},
+     {ERR_PACK(ERR_LIB_DH, 0, DH_R_SHARED_INFO_ERROR), "shared info error"},
+     {ERR_PACK(ERR_LIB_DH, 0, DH_R_UNABLE_TO_CHECK_GENERATOR),
+     "unable to check generator"},
+--- a/crypto/dh/dh_key.c
++++ b/crypto/dh/dh_key.c
+@@ -87,6 +87,12 @@ static int generate_key(DH *dh)
+         return 0;
+     }
+ 
++    if (dh->q != NULL
++        && BN_num_bits(dh->q) > OPENSSL_DH_MAX_MODULUS_BITS) {
++        DHerr(DH_F_GENERATE_KEY, DH_R_Q_TOO_LARGE);
++        return 0;
++    }
++
+     ctx = BN_CTX_new();
+     if (ctx == NULL)
+         goto err;
+@@ -180,6 +186,12 @@ static int compute_key(unsigned char *ke
+         goto err;
+     }
+ 
++    if (dh->q != NULL
++        && BN_num_bits(dh->q) > OPENSSL_DH_MAX_MODULUS_BITS) {
++        DHerr(DH_F_COMPUTE_KEY, DH_R_Q_TOO_LARGE);
++        goto err;
++    }
++
+     ctx = BN_CTX_new();
+     if (ctx == NULL)
+         goto err;
+--- a/crypto/err/openssl.txt
++++ b/crypto/err/openssl.txt
+@@ -2110,6 +2110,7 @@ DH_R_NO_PARAMETERS_SET:107:no parameters
+ DH_R_NO_PRIVATE_VALUE:100:no private value
+ DH_R_PARAMETER_ENCODING_ERROR:105:parameter encoding error
+ DH_R_PEER_KEY_ERROR:111:peer key error
++DH_R_Q_TOO_LARGE:130:q too large
+ DH_R_SHARED_INFO_ERROR:113:shared info error
+ DH_R_UNABLE_TO_CHECK_GENERATOR:121:unable to check generator
+ DSA_R_BAD_Q_VALUE:102:bad q value
+--- a/include/openssl/dh.h
++++ b/include/openssl/dh.h
+@@ -71,14 +71,16 @@ DECLARE_ASN1_ITEM(DHparams)
+ /* #define DH_GENERATOR_3       3 */
+ # define DH_GENERATOR_5          5
+ 
+-/* DH_check error codes */
++/* DH_check error codes, some of them shared with DH_check_pub_key */
+ # define DH_CHECK_P_NOT_PRIME            0x01
+ # define DH_CHECK_P_NOT_SAFE_PRIME       0x02
+ # define DH_UNABLE_TO_CHECK_GENERATOR    0x04
+ # define DH_NOT_SUITABLE_GENERATOR       0x08
+ # define DH_CHECK_Q_NOT_PRIME            0x10
+-# define DH_CHECK_INVALID_Q_VALUE        0x20
++# define DH_CHECK_INVALID_Q_VALUE        0x20 /* +DH_check_pub_key */
+ # define DH_CHECK_INVALID_J_VALUE        0x40
++# define DH_MODULUS_TOO_SMALL            0x80
++# define DH_MODULUS_TOO_LARGE            0x100 /* +DH_check_pub_key */
+ 
+ /* DH_check_pub_key error codes */
+ # define DH_CHECK_PUBKEY_TOO_SMALL       0x01
+--- a/include/openssl/dherr.h
++++ b/include/openssl/dherr.h
+@@ -82,6 +82,7 @@ int ERR_load_DH_strings(void);
+ #  define DH_R_NO_PRIVATE_VALUE                            100
+ #  define DH_R_PARAMETER_ENCODING_ERROR                    105
+ #  define DH_R_PEER_KEY_ERROR                              111
++#  define DH_R_Q_TOO_LARGE                                 130
+ #  define DH_R_SHARED_INFO_ERROR                           113
+ #  define DH_R_UNABLE_TO_CHECK_GENERATOR                   121
+ 

--- a/resources/patches/openssl/CVE-2024-0727.patch
+++ b/resources/patches/openssl/CVE-2024-0727.patch
@@ -1,0 +1,116 @@
+Backport of:
+
+From 09df4395b5071217b76dc7d3d2e630eb8c5a79c2 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Fri, 19 Jan 2024 11:28:58 +0000
+Subject: [PATCH] Add NULL checks where ContentInfo data can be NULL
+
+PKCS12 structures contain PKCS7 ContentInfo fields. These fields are
+optional and can be NULL even if the "type" is a valid value. OpenSSL
+was not properly accounting for this and a NULL dereference can occur
+causing a crash.
+
+CVE-2024-0727
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Hugo Landau <hlandau@openssl.org>
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/23362)
+
+(cherry picked from commit d135eeab8a5dbf72b3da5240bab9ddb7678dbd2c)
+---
+ crypto/pkcs12/p12_add.c  | 18 ++++++++++++++++++
+ crypto/pkcs12/p12_mutl.c |  5 +++++
+ crypto/pkcs12/p12_npas.c |  5 +++--
+ crypto/pkcs7/pk7_mime.c  |  7 +++++--
+ 4 files changed, 31 insertions(+), 4 deletions(-)
+
+--- a/crypto/pkcs12/p12_add.c
++++ b/crypto/pkcs12/p12_add.c
+@@ -76,6 +76,13 @@ STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_
+                   PKCS12_R_CONTENT_TYPE_NOT_DATA);
+         return NULL;
+     }
++
++    if (p7->d.data == NULL) {
++        PKCS12err(PKCS12_F_PKCS12_UNPACK_P7DATA,
++                  PKCS12_R_DECODE_ERROR);
++        return NULL;
++    }
++
+     return ASN1_item_unpack(p7->d.data, ASN1_ITEM_rptr(PKCS12_SAFEBAGS));
+ }
+ 
+@@ -132,6 +139,12 @@ STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_
+ {
+     if (!PKCS7_type_is_encrypted(p7))
+         return NULL;
++
++    if (p7->d.encrypted == NULL) {
++        PKCS12err(PKCS12_F_PKCS12_UNPACK_P7DATA, PKCS12_R_DECODE_ERROR);
++        return NULL;
++    }
++
+     return PKCS12_item_decrypt_d2i(p7->d.encrypted->enc_data->algorithm,
+                                    ASN1_ITEM_rptr(PKCS12_SAFEBAGS),
+                                    pass, passlen,
+@@ -159,6 +172,13 @@ STACK_OF(PKCS7) *PKCS12_unpack_authsafes
+                   PKCS12_R_CONTENT_TYPE_NOT_DATA);
+         return NULL;
+     }
++
++    if (p12->authsafes->d.data == NULL) {
++        PKCS12err(PKCS12_F_PKCS12_UNPACK_AUTHSAFES,
++                  PKCS12_R_DECODE_ERROR);
++        return NULL;
++    }
++
+     return ASN1_item_unpack(p12->authsafes->d.data,
+                             ASN1_ITEM_rptr(PKCS12_AUTHSAFES));
+ }
+--- a/crypto/pkcs12/p12_mutl.c
++++ b/crypto/pkcs12/p12_mutl.c
+@@ -93,6 +93,11 @@ static int pkcs12_gen_mac(PKCS12 *p12, c
+         return 0;
+     }
+ 
++    if (p12->authsafes->d.data == NULL) {
++        PKCS12err(PKCS12_F_PKCS12_GEN_MAC, PKCS12_R_DECODE_ERROR);
++        return 0;
++    }
++
+     salt = p12->mac->salt->data;
+     saltlen = p12->mac->salt->length;
+     if (!p12->mac->iter)
+--- a/crypto/pkcs12/p12_npas.c
++++ b/crypto/pkcs12/p12_npas.c
+@@ -78,8 +78,9 @@ static int newpass_p12(PKCS12 *p12, cons
+             bags = PKCS12_unpack_p7data(p7);
+         } else if (bagnid == NID_pkcs7_encrypted) {
+             bags = PKCS12_unpack_p7encdata(p7, oldpass, -1);
+-            if (!alg_get(p7->d.encrypted->enc_data->algorithm,
+-                         &pbe_nid, &pbe_iter, &pbe_saltlen))
++            if (p7->d.encrypted == NULL
++                    || !alg_get(p7->d.encrypted->enc_data->algorithm,
++                                &pbe_nid, &pbe_iter, &pbe_saltlen))
+                 goto err;
+         } else {
+             continue;
+--- a/crypto/pkcs7/pk7_mime.c
++++ b/crypto/pkcs7/pk7_mime.c
+@@ -30,10 +30,13 @@ int SMIME_write_PKCS7(BIO *bio, PKCS7 *p
+ {
+     STACK_OF(X509_ALGOR) *mdalgs;
+     int ctype_nid = OBJ_obj2nid(p7->type);
+-    if (ctype_nid == NID_pkcs7_signed)
++    if (ctype_nid == NID_pkcs7_signed) {
++        if (p7->d.sign == NULL)
++            return 0;
+         mdalgs = p7->d.sign->md_algs;
+-    else
++    } else {
+         mdalgs = NULL;
++    }
+ 
+     flags ^= SMIME_OLDMIME;
+ 

--- a/resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch
+++ b/resources/patches/openssl/openssl-1.1.1-fips-spec-file.patch
@@ -1,6 +1,6 @@
 --- a/SPECS/openssl.spec	2019-05-11 00:45:45.000000000 +0000
 +++ b/SPECS/openssl.spec	2020-01-13 15:16:29.224852120 +0000
-@@ -83,16 +83,20 @@
+@@ -83,16 +83,23 @@
  Patch75: openssl-1.1.1-tls13-curves.patch
  Patch81: openssl-1.1.1-read-buff.patch
  Patch82: openssl-1.1.1-cve-2022-0778.patch
@@ -8,6 +8,9 @@
 +Patch101: openssl-1.1.1-openssl-cnf-fips-mode.patch
 +Patch102: openssl-1.1.1-remove-env-check.patch
 +Patch103: openssl-1.1.1l-sm2-plaintext.patch
++Patch104: openssl-1.1.1k-CVE-2023-3446-fips.patch
++Patch105: openssl-1.1.1k-CVE-2023-5678-fips.patch
++Patch106: openssl-1.1.1k-CVE-2024-0727-fips.patch
  
  License: OpenSSL and ASL 2.0
  URL: http://www.openssl.org/
@@ -23,7 +26,7 @@
  BuildRequires: perl(Module::Load::Conditional), perl(File::Temp)
  BuildRequires: perl(Time::HiRes)
  BuildRequires: perl(FindBin), perl(lib), perl(File::Compare), perl(File::Copy)
-@@ -107,7 +112,6 @@
+@@ -109,7 +116,6 @@
  Summary: A general purpose cryptography library with TLS implementation
  Requires: ca-certificates >= 2008-5
  Requires: crypto-policies >= 20180730
@@ -31,7 +34,7 @@
  # Needed obsoletes due to the base/lib subpackage split
  Obsoletes: openssl < 1:1.0.1-0.3.beta3
  Obsoletes: openssl-fips < 1:1.0.1e-28
-@@ -141,7 +145,7 @@
+@@ -143,7 +149,7 @@
  
  %package perl
  Summary: Perl scripts provided with OpenSSL
@@ -40,18 +43,22 @@
  Requires: %{name}%{?_isa} = %{epoch}:%{version}-%{release}
  
  %description perl
-@@ -208,6 +215,10 @@
+@@ -204,7 +210,13 @@
  %patch80 -p1 -b .s390x-test-aes
  %patch81 -p1 -b .read-buff
  %patch82 -p1 -b .cve-2022-0778
+-
 +%patch100 -p1 -b .force-fips-on-init
 +%patch101 -p1 -b .openssl-cnf-fips-mode
 +%patch102 -p1 -b .remove-env-check
 +%patch103 -p1 -b .sm2-plaintext
- 
++%patch104 -p1 -F2 -b .CVE-2023-3446-fips
++%patch105 -p1 -F2 -b .CVE-2023-5678-fips
++%patch106 -p1 -b .CVE-2024-0727-fips
  
  %build
-@@ -266,7 +275,7 @@
+ # Figure out which flags we want to use.
+@@ -270,7 +282,7 @@
  # marked as not requiring an executable stack.
  # Also add -DPURIFY to make using valgrind with openssl easier as we do not
  # want to depend on the uninitialized memory as a source of entropy anyway.
@@ -60,18 +67,18 @@
  
  export HASHBANGPERL=/usr/bin/perl
  
-@@ -275,8 +284,8 @@
+@@ -279,8 +291,8 @@
  # usable on all platforms.  The Configure script already knows to use -fPIC and
  # RPM_OPT_FLAGS, so we can skip specifiying them here.
  ./Configure \
--	--prefix=%{_prefix} --openssldir=%{_sysconfdir}/pki/tls ${sslflags} \
--	--system-ciphers-file=%{_sysconfdir}/crypto-policies/back-ends/openssl.config \
-+	--prefix=%{_prefix} --openssldir=%{_prefix}/ssl ${sslflags} \
-+	--system-ciphers-file=%{_prefix}/etc/crypto-policies/back-ends/openssl.config \
- 	zlib enable-camellia enable-seed enable-rfc3779 enable-sctp \
- 	enable-cms enable-md2 enable-rc5\
- 	enable-weak-ssl-ciphers \
-@@ -348,14 +357,14 @@
+-  --prefix=%{_prefix} --openssldir=%{_sysconfdir}/pki/tls ${sslflags} \
+-  --system-ciphers-file=%{_sysconfdir}/crypto-policies/back-ends/openssl.config \
++  --prefix=%{_prefix} --openssldir=%{_prefix}/ssl ${sslflags} \
++  --system-ciphers-file=%{_prefix}/etc/crypto-policies/back-ends/openssl.config \
+   zlib enable-camellia enable-seed enable-rfc3779 enable-sctp \
+   enable-cms enable-md2 enable-rc5\
+   enable-weak-ssl-ciphers \
+@@ -352,14 +364,14 @@
  
  # Install a makefile for generating keys and self-signed certs, and a script
  # for generating them on the fly.
@@ -89,7 +96,7 @@
  
  # Drop the SSLv3 methods from includes
  sed -i '/ifndef OPENSSL_NO_SSL3_METHOD/,+4d' $RPM_BUILD_ROOT%{_includedir}/openssl/ssl.h
-@@ -382,19 +391,19 @@
+@@ -386,19 +398,19 @@
  done
  popd
  
@@ -118,7 +125,7 @@
  
  # Determine which arch opensslconf.h is going to try to #include.
  basearch=%{_arch}
-@@ -441,12 +450,12 @@
+@@ -445,12 +457,12 @@
  %files libs
  %{!?_licensedir:%global license %%doc}
  %license LICENSE
@@ -137,7 +144,7 @@
  %attr(0755,root,root) %{_libdir}/libcrypto.so.%{version}
  %attr(0755,root,root) %{_libdir}/libcrypto.so.%{soversion}
  %attr(0755,root,root) %{_libdir}/libssl.so.%{version}
-@@ -473,11 +482,11 @@
+@@ -477,11 +489,11 @@
  %{_mandir}/man1*/c_rehash*
  %{_mandir}/man1*/tsget*
  %{_mandir}/man1*/openssl-tsget*

--- a/resources/patches/openssl/openssl-1.1.1k-CVE-2023-3446-fips.patch
+++ b/resources/patches/openssl/openssl-1.1.1k-CVE-2023-3446-fips.patch
@@ -1,0 +1,54 @@
+--- /dev/null	2024-02-22 20:27:57
++++ openssl-1.1.1k/SOURCES/openssl-1.1.1k-CVE-2023-3446-fips.patch	2024-02-22 20:24:39
+@@ -0,0 +1,50 @@
++diff --git a/crypto/dh/dh_err.c b/crypto/dh/dh_err.c
++index 7285587b4a..8dd8ca0f92 100644
++--- a/crypto/dh/dh_err.c
+++++ b/crypto/dh/dh_err.c
++@@ -18,6 +18,7 @@ static const ERR_STRING_DATA DH_str_functs[] = {
++     {ERR_PACK(ERR_LIB_DH, DH_F_DHPARAMS_PRINT_FP, 0), "DHparams_print_fp"},
++     {ERR_PACK(ERR_LIB_DH, DH_F_DH_BUILTIN_GENPARAMS, 0),
++      "dh_builtin_genparams"},
+++    {ERR_PACK(ERR_LIB_DH, DH_F_DH_CHECK, 0), "DH_check"},
++     {ERR_PACK(ERR_LIB_DH, DH_F_DH_CHECK_EX, 0), "DH_check_ex"},
++     {ERR_PACK(ERR_LIB_DH, DH_F_DH_CHECK_PARAMS_EX, 0), "DH_check_params_ex"},
++     {ERR_PACK(ERR_LIB_DH, DH_F_DH_CHECK_PUB_KEY_EX, 0), "DH_check_pub_key_ex"},
++diff --git a/crypto/err/openssl.txt b/crypto/err/openssl.txt
++index 7e1776375d..df2fc4e830 100644
++--- a/crypto/err/openssl.txt
+++++ b/crypto/err/openssl.txt
++@@ -401,6 +401,7 @@ CT_F_SCT_SET_VERSION:104:SCT_set_version
++ DH_F_COMPUTE_KEY:102:compute_key
++ DH_F_DHPARAMS_PRINT_FP:101:DHparams_print_fp
++ DH_F_DH_BUILTIN_GENPARAMS:106:dh_builtin_genparams
+++DH_F_DH_CHECK:126:DH_check
++ DH_F_DH_CHECK_EX:121:DH_check_ex
++ DH_F_DH_CHECK_PARAMS_EX:122:DH_check_params_ex
++ DH_F_DH_CHECK_PUB_KEY_EX:123:DH_check_pub_key_ex
++diff --git a/include/openssl/dh.h b/include/openssl/dh.h
++index 3527540cdd..892e31559d 100644
++--- a/include/openssl/dh.h
+++++ b/include/openssl/dh.h
++@@ -29,6 +29,9 @@ extern "C" {
++ # ifndef OPENSSL_DH_MAX_MODULUS_BITS
++ #  define OPENSSL_DH_MAX_MODULUS_BITS    10000
++ # endif
+++# ifndef OPENSSL_DH_CHECK_MAX_MODULUS_BITS
+++#  define OPENSSL_DH_CHECK_MAX_MODULUS_BITS  32768
+++# endif
++ 
++ # define OPENSSL_DH_FIPS_MIN_MODULUS_BITS 1024
++ 
++diff --git a/include/openssl/dherr.h b/include/openssl/dherr.h
++index 916b3bed0b..9955f24652 100644
++--- a/include/openssl/dherr.h
+++++ b/include/openssl/dherr.h
++@@ -30,6 +30,7 @@ int ERR_load_DH_strings(void);
++ #  define DH_F_COMPUTE_KEY                                 102
++ #  define DH_F_DHPARAMS_PRINT_FP                           101
++ #  define DH_F_DH_BUILTIN_GENPARAMS                        106
+++#  define DH_F_DH_CHECK                                    126
++ #  define DH_F_DH_CHECK_EX                                 121
++ #  define DH_F_DH_CHECK_PARAMS_EX                          122
++ #  define DH_F_DH_CHECK_PUB_KEY_EX                         123
++

--- a/resources/patches/openssl/openssl-1.1.1k-CVE-2023-5678-fips.patch
+++ b/resources/patches/openssl/openssl-1.1.1k-CVE-2023-5678-fips.patch
@@ -1,0 +1,145 @@
+--- /dev/null	2024-02-26 19:17:51
++++ openssl-1.1.1k-6/SOURCES/openssl-1.1.1k-CVE-2023-5678-fips.patch	2024-02-01 02:02:19
+@@ -0,0 +1,142 @@
++Backport of:
++
++From db925ae2e65d0d925adef429afc37f75bd1c2017 Mon Sep 17 00:00:00 2001
++From: Richard Levitte <levitte@openssl.org>
++Date: Fri, 20 Oct 2023 09:18:19 +0200
++Subject: [PATCH] Make DH_check_pub_key() and DH_generate_key() safer yet
++
++We already check for an excessively large P in DH_generate_key(), but not in
++DH_check_pub_key(), and none of them check for an excessively large Q.
++
++This change adds all the missing excessive size checks of P and Q.
++
++It's to be noted that behaviours surrounding excessively sized P and Q
++differ.  DH_check() raises an error on the excessively sized P, but only
++sets a flag for the excessively sized Q.  This behaviour is mimicked in
++DH_check_pub_key().
++
++Reviewed-by: Tomas Mraz <tomas@openssl.org>
++Reviewed-by: Matt Caswell <matt@openssl.org>
++Reviewed-by: Hugo Landau <hlandau@openssl.org>
++(Merged from https://github.com/openssl/openssl/pull/22518)
++
++(cherry picked from commit ddeb4b6c6d527e54ce9a99cba785c0f7776e54b6)
++---
++ crypto/dh/dh_check.c    | 12 ++++++++++++
++ crypto/dh/dh_err.c      |  3 ++-
++ crypto/dh/dh_key.c      | 12 ++++++++++++
++ crypto/err/openssl.txt  |  1 +
++ include/crypto/dherr.h  |  2 +-
++ include/openssl/dh.h    |  6 +++---
++ include/openssl/dherr.h |  3 ++-
++ 7 files changed, 33 insertions(+), 6 deletions(-)
++
++--- a/crypto/dh/dh_check.c
+++++ b/crypto/dh/dh_check.c
++@@ -201,6 +201,19 @@ int DH_check_pub_key(const DH *dh, const
++     if (ctx == NULL)
++         goto err;
++     BN_CTX_start(ctx);
+++
+++    /* Don't do any checks at all with an excessively large modulus */
+++    if (BN_num_bits(dh->p) > OPENSSL_DH_CHECK_MAX_MODULUS_BITS) {
+++        DHerr(DH_F_DH_CHECK, DH_R_MODULUS_TOO_LARGE);
+++        *ret = DH_MODULUS_TOO_LARGE | DH_CHECK_PUBKEY_INVALID;
+++        goto err;
+++    }
+++
+++    if (dh->q != NULL && BN_ucmp(dh->p, dh->q) < 0) {
+++        *ret |= DH_CHECK_INVALID_Q_VALUE | DH_CHECK_PUBKEY_INVALID;
+++        goto out;
+++    }
+++
++     tmp = BN_CTX_get(ctx);
++     if (tmp == NULL || !BN_set_word(tmp, 1))
++         goto err;
++@@ -219,6 +232,7 @@ int DH_check_pub_key(const DH *dh, const
++             *ret |= DH_CHECK_PUBKEY_INVALID;
++     }
++ 
+++ out:
++     ok = 1;
++  err:
++     BN_CTX_end(ctx);
++--- a/crypto/dh/dh_err.c
+++++ b/crypto/dh/dh_err.c
++@@ -82,6 +82,7 @@ static const ERR_STRING_DATA DH_str_reas
++     {ERR_PACK(ERR_LIB_DH, 0, DH_R_PARAMETER_ENCODING_ERROR),
++     "parameter encoding error"},
++     {ERR_PACK(ERR_LIB_DH, 0, DH_R_PEER_KEY_ERROR), "peer key error"},
+++    {ERR_PACK(ERR_LIB_DH, 0, DH_R_Q_TOO_LARGE), "q too large"},
++     {ERR_PACK(ERR_LIB_DH, 0, DH_R_SHARED_INFO_ERROR), "shared info error"},
++     {ERR_PACK(ERR_LIB_DH, 0, DH_R_UNABLE_TO_CHECK_GENERATOR),
++     "unable to check generator"},
++--- a/crypto/dh/dh_key.c
+++++ b/crypto/dh/dh_key.c
++@@ -87,6 +87,12 @@ static int generate_key(DH *dh)
++         return 0;
++     }
++ 
+++    if (dh->q != NULL
+++        && BN_num_bits(dh->q) > OPENSSL_DH_MAX_MODULUS_BITS) {
+++        DHerr(DH_F_GENERATE_KEY, DH_R_Q_TOO_LARGE);
+++        return 0;
+++    }
+++
++     ctx = BN_CTX_new();
++     if (ctx == NULL)
++         goto err;
++@@ -180,6 +186,12 @@ static int compute_key(unsigned char *ke
++         goto err;
++     }
++ 
+++    if (dh->q != NULL
+++        && BN_num_bits(dh->q) > OPENSSL_DH_MAX_MODULUS_BITS) {
+++        DHerr(DH_F_COMPUTE_KEY, DH_R_Q_TOO_LARGE);
+++        goto err;
+++    }
+++
++     ctx = BN_CTX_new();
++     if (ctx == NULL)
++         goto err;
++--- a/crypto/err/openssl.txt
+++++ b/crypto/err/openssl.txt
++@@ -2110,6 +2110,7 @@ DH_R_NO_PARAMETERS_SET:107:no parameters
++ DH_R_NO_PRIVATE_VALUE:100:no private value
++ DH_R_PARAMETER_ENCODING_ERROR:105:parameter encoding error
++ DH_R_PEER_KEY_ERROR:111:peer key error
+++DH_R_Q_TOO_LARGE:130:q too large
++ DH_R_SHARED_INFO_ERROR:113:shared info error
++ DH_R_UNABLE_TO_CHECK_GENERATOR:121:unable to check generator
++ DSA_R_BAD_Q_VALUE:102:bad q value
++--- a/include/openssl/dh.h
+++++ b/include/openssl/dh.h
++@@ -71,14 +71,16 @@ DECLARE_ASN1_ITEM(DHparams)
++ /* #define DH_GENERATOR_3       3 */
++ # define DH_GENERATOR_5          5
++ 
++-/* DH_check error codes */
+++/* DH_check error codes, some of them shared with DH_check_pub_key */
++ # define DH_CHECK_P_NOT_PRIME            0x01
++ # define DH_CHECK_P_NOT_SAFE_PRIME       0x02
++ # define DH_UNABLE_TO_CHECK_GENERATOR    0x04
++ # define DH_NOT_SUITABLE_GENERATOR       0x08
++ # define DH_CHECK_Q_NOT_PRIME            0x10
++-# define DH_CHECK_INVALID_Q_VALUE        0x20
+++# define DH_CHECK_INVALID_Q_VALUE        0x20 /* +DH_check_pub_key */
++ # define DH_CHECK_INVALID_J_VALUE        0x40
+++# define DH_MODULUS_TOO_SMALL            0x80
+++# define DH_MODULUS_TOO_LARGE            0x100 /* +DH_check_pub_key */
++ 
++ /* DH_check_pub_key error codes */
++ # define DH_CHECK_PUBKEY_TOO_SMALL       0x01
++--- a/include/openssl/dherr.h
+++++ b/include/openssl/dherr.h
++@@ -82,6 +82,7 @@ int ERR_load_DH_strings(void);
++ #  define DH_R_NO_PRIVATE_VALUE                            100
++ #  define DH_R_PARAMETER_ENCODING_ERROR                    105
++ #  define DH_R_PEER_KEY_ERROR                              111
+++#  define DH_R_Q_TOO_LARGE                                 130
++ #  define DH_R_SHARED_INFO_ERROR                           113
++ #  define DH_R_UNABLE_TO_CHECK_GENERATOR                   121
++ 

--- a/resources/patches/openssl/openssl-1.1.1k-CVE-2024-0727-fips.patch
+++ b/resources/patches/openssl/openssl-1.1.1k-CVE-2024-0727-fips.patch
@@ -1,0 +1,119 @@
+--- /dev/null	2024-02-26 19:19:09
++++ openssl-1.1.1k-6/SOURCES/openssl-1.1.1k-CVE-2024-0727-fips.patch	2024-02-01 02:15:27
+@@ -0,0 +1,116 @@
++Backport of:
++
++From 09df4395b5071217b76dc7d3d2e630eb8c5a79c2 Mon Sep 17 00:00:00 2001
++From: Matt Caswell <matt@openssl.org>
++Date: Fri, 19 Jan 2024 11:28:58 +0000
++Subject: [PATCH] Add NULL checks where ContentInfo data can be NULL
++
++PKCS12 structures contain PKCS7 ContentInfo fields. These fields are
++optional and can be NULL even if the "type" is a valid value. OpenSSL
++was not properly accounting for this and a NULL dereference can occur
++causing a crash.
++
++CVE-2024-0727
++
++Reviewed-by: Tomas Mraz <tomas@openssl.org>
++Reviewed-by: Hugo Landau <hlandau@openssl.org>
++Reviewed-by: Neil Horman <nhorman@openssl.org>
++(Merged from https://github.com/openssl/openssl/pull/23362)
++
++(cherry picked from commit d135eeab8a5dbf72b3da5240bab9ddb7678dbd2c)
++---
++ crypto/pkcs12/p12_add.c  | 18 ++++++++++++++++++
++ crypto/pkcs12/p12_mutl.c |  5 +++++
++ crypto/pkcs12/p12_npas.c |  5 +++--
++ crypto/pkcs7/pk7_mime.c  |  7 +++++--
++ 4 files changed, 31 insertions(+), 4 deletions(-)
++
++--- a/crypto/pkcs12/p12_add.c
+++++ b/crypto/pkcs12/p12_add.c
++@@ -76,6 +76,13 @@ STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_
++                   PKCS12_R_CONTENT_TYPE_NOT_DATA);
++         return NULL;
++     }
+++
+++    if (p7->d.data == NULL) {
+++        PKCS12err(PKCS12_F_PKCS12_UNPACK_P7DATA,
+++                  PKCS12_R_DECODE_ERROR);
+++        return NULL;
+++    }
+++
++     return ASN1_item_unpack(p7->d.data, ASN1_ITEM_rptr(PKCS12_SAFEBAGS));
++ }
++ 
++@@ -132,6 +139,12 @@ STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_
++ {
++     if (!PKCS7_type_is_encrypted(p7))
++         return NULL;
+++
+++    if (p7->d.encrypted == NULL) {
+++        PKCS12err(PKCS12_F_PKCS12_UNPACK_P7DATA, PKCS12_R_DECODE_ERROR);
+++        return NULL;
+++    }
+++
++     return PKCS12_item_decrypt_d2i(p7->d.encrypted->enc_data->algorithm,
++                                    ASN1_ITEM_rptr(PKCS12_SAFEBAGS),
++                                    pass, passlen,
++@@ -159,6 +172,13 @@ STACK_OF(PKCS7) *PKCS12_unpack_authsafes
++                   PKCS12_R_CONTENT_TYPE_NOT_DATA);
++         return NULL;
++     }
+++
+++    if (p12->authsafes->d.data == NULL) {
+++        PKCS12err(PKCS12_F_PKCS12_UNPACK_AUTHSAFES,
+++                  PKCS12_R_DECODE_ERROR);
+++        return NULL;
+++    }
+++
++     return ASN1_item_unpack(p12->authsafes->d.data,
++                             ASN1_ITEM_rptr(PKCS12_AUTHSAFES));
++ }
++--- a/crypto/pkcs12/p12_mutl.c
+++++ b/crypto/pkcs12/p12_mutl.c
++@@ -93,6 +93,11 @@ static int pkcs12_gen_mac(PKCS12 *p12, c
++         return 0;
++     }
++ 
+++    if (p12->authsafes->d.data == NULL) {
+++        PKCS12err(PKCS12_F_PKCS12_GEN_MAC, PKCS12_R_DECODE_ERROR);
+++        return 0;
+++    }
+++
++     salt = p12->mac->salt->data;
++     saltlen = p12->mac->salt->length;
++     if (!p12->mac->iter)
++--- a/crypto/pkcs12/p12_npas.c
+++++ b/crypto/pkcs12/p12_npas.c
++@@ -78,8 +78,9 @@ static int newpass_p12(PKCS12 *p12, cons
++             bags = PKCS12_unpack_p7data(p7);
++         } else if (bagnid == NID_pkcs7_encrypted) {
++             bags = PKCS12_unpack_p7encdata(p7, oldpass, -1);
++-            if (!alg_get(p7->d.encrypted->enc_data->algorithm,
++-                         &pbe_nid, &pbe_iter, &pbe_saltlen))
+++            if (p7->d.encrypted == NULL
+++                    || !alg_get(p7->d.encrypted->enc_data->algorithm,
+++                                &pbe_nid, &pbe_iter, &pbe_saltlen))
++                 goto err;
++         } else {
++             continue;
++--- a/crypto/pkcs7/pk7_mime.c
+++++ b/crypto/pkcs7/pk7_mime.c
++@@ -30,10 +30,13 @@ int SMIME_write_PKCS7(BIO *bio, PKCS7 *p
++ {
++     STACK_OF(X509_ALGOR) *mdalgs;
++     int ctype_nid = OBJ_obj2nid(p7->type);
++-    if (ctype_nid == NID_pkcs7_signed)
+++    if (ctype_nid == NID_pkcs7_signed) {
+++        if (p7->d.sign == NULL)
+++            return 0;
++         mdalgs = p7->d.sign->md_algs;
++-    else
+++    } else {
++         mdalgs = NULL;
+++    }
++ 
++     flags ^= SMIME_OLDMIME;
++ 


### PR DESCRIPTION
Applied CVE patches for openssl-1.1.1v :
1. CVE-2023-5678
2. CVE-2024-0727

Applied CVE patched for openssl-1.1.1k-6-fips :
1. CVE-2023-3446 (Required for CVE-2023-5678 patch to apply suceessfully)
2. CVE-2023-5678
3. CVE-2023-0727