### PR TITLE
(PA-6131) Bump openssl version

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -1,6 +1,6 @@
 component 'openssl' do |pkg, settings, platform|
-  pkg.version '3.0.12'
-  pkg.sha256sum 'f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61'
+  pkg.version '3.0.13'
+  pkg.sha256sum '88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313'
   pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/openssl-#{pkg.get_version}.tar.gz"
 
@@ -27,6 +27,8 @@ component 'openssl' do |pkg, settings, platform|
     pkg.environment 'CYGWIN', settings[:cygwin]
     pkg.environment 'MAKE', platform[:make]
 
+    pkg.apply_patch 'resources/patches/openssl/openssl-3.0.13-create-dir-win.patch'
+    
     target = platform.architecture == 'x64' ? 'mingw64' : 'mingw'
   # elsif platform.is_cross_compiled_linux?
   #   pkg.environment 'PATH', "/opt/pl-build-tools/bin:$(PATH)"

--- a/resources/patches/openssl/openssl-3.0.13-create-dir-win.patch
+++ b/resources/patches/openssl/openssl-3.0.13-create-dir-win.patch
@@ -1,0 +1,14 @@
+diff --git a/Configure b/Configure
+index 84cc409464..bdf4f3c460 100755
+--- a/Configure
++++ b/Configure
+@@ -3409,7 +3409,8 @@ sub absolutedir {
+     # We use realpath() on Unix, since no other will properly clean out
+     # a directory spec.
+     use Cwd qw/realpath/;
+-
++    
++    mkdir $dir unless -d $dir;
+     return realpath($dir);
+ }
+ 


### PR DESCRIPTION
Bump open-ssl version from 3.1.12 to 3.1.13 which address following vulnerabilities 

[NVD - CVE-2023-5678](https://nvd.nist.gov/vuln/detail/CVE-2023-5678) 

[NVD - CVE-2023-6129](https://nvd.nist.gov/vuln/detail/CVE-2023-6129) 

[CVE-2023-6237](https://security-tracker.debian.org/tracker/CVE-2023-6237) 

[NVD - CVE-2024-0727](https://nvd.nist.gov/vuln/detail/CVE-2024-0727)