### PR TITLE
POC to build agent-runtime-main on fedora 40 using docker

### DIFF
--- a/configs/components/_base-ruby-augeas.rb
+++ b/configs/components/_base-ruby-augeas.rb
@@ -4,6 +4,7 @@
 #
 
 pkg.add_source("file://resources/patches/augeas/ruby-augeas-0.5.0-patch_c_extension.patch")
+pkg.add_source("file://resources/patches/augeas/ruby-augeas-0.5.0-remove-sibling-argument.patch")
 
 # These can be overridden by the including component.
 ruby_version ||= settings[:ruby_version]
@@ -75,6 +76,7 @@ pkg.build do
   if ruby_version =~ /^3/
     build_commands << "#{platform.patch} --strip=2 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../ruby-augeas-0.5.0-patch_c_extension.patch"
   end
+  build_commands << "#{platform.patch} --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../ruby-augeas-0.5.0-remove-sibling-argument.patch"
   build_commands << "#{ruby} ext/augeas/extconf.rb"
   build_commands << "#{platform[:make]} -e -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"
 

--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -78,7 +78,8 @@ pkg.build do
 
   if ruby_version =~ /^3/
     # swig 4.1 generated interface does not need patching
-    unless platform.name =~ /^(debian-12|ubuntu-24)/
+    if (!platform.is_debian? || platform.os_version.to_i < 12) &&
+       (!platform.is_ubuntu? || platform.os_version.to_i < 24)
       steps << "#{platform.patch} --strip=0 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../selinuxswig_ruby_wrap.patch"
     end
   end

--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -79,6 +79,7 @@ pkg.build do
   if ruby_version =~ /^3/
     # swig 4.1 generated interface does not need patching
     if (!platform.is_debian? || platform.os_version.to_i < 12) &&
+       (!platform.is_fedora? || platform.os_version.to_i < 40) &&
        (!platform.is_ubuntu? || platform.os_version.to_i < 24)
       steps << "#{platform.patch} --strip=0 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../selinuxswig_ruby_wrap.patch"
     end

--- a/configs/platforms/fedora-40-x86_64.rb
+++ b/configs/platforms/fedora-40-x86_64.rb
@@ -1,0 +1,20 @@
+platform 'fedora-40-x86_64' do |plat|
+  plat.servicedir '/usr/lib/systemd/system'
+  plat.defaultdir '/etc/sysconfig'
+  plat.servicetype 'systemd'
+  plat.dist 'fc40'
+
+  packages = %w[
+    autoconf automake bzip2-devel gcc gcc-c++ libselinux-devel
+    libsepol libsepol-devel make cmake pkgconfig readline-devel
+    rpmdevtools rsync swig zlib-devel systemtap-sdt-devel
+    perl-lib perl-FindBin
+  ]
+  plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+
+  plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
+
+  plat.docker_image 'fedora:40'
+  plat.docker_run_args ['--tty', '--entrypoint=/bin/sh']
+  plat.use_docker_exec true
+end

--- a/resources/patches/augeas/ruby-augeas-0.5.0-remove-sibling-argument.patch
+++ b/resources/patches/augeas/ruby-augeas-0.5.0-remove-sibling-argument.patch
@@ -1,0 +1,27 @@
+From 9f1f9df48ef8c6f62349eccb90dc54a3c3d75e3f Mon Sep 17 00:00:00 2001
+From: Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl>
+Date: Wed, 31 Jan 2024 12:52:45 +0100
+Subject: [PATCH] Remove unused sibling argument from augeas_rm
+
+This makes the function match the method definition. There was already a
+warning about this, but Fedora 40 applies more hardening and it's a
+fatal error.
+
+Fixes: e6b57c58d24b ("Initial ruby bindings, written by Bryan Kearney")
+---
+ ext/augeas/_augeas.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ext/augeas/_augeas.c b/ext/augeas/_augeas.c
+index f9b49d1..7ef0d7d 100644
+--- a/ext/augeas/_augeas.c
++++ b/ext/augeas/_augeas.c
+@@ -184,7 +184,7 @@ VALUE augeas_mv(VALUE s, VALUE src, VALUE dst) {
+  *
+  * Remove path and all its children. Returns the number of entries removed
+  */
+-VALUE augeas_rm(VALUE s, VALUE path, VALUE sibling) {
++VALUE augeas_rm(VALUE s, VALUE path) {
+     augeas *aug = aug_handle(s);
+     const char *cpath = StringValueCStr(path) ;
+ 


### PR DESCRIPTION
Based on https://github.com/puppetlabs/puppet-runtime/pull/827

I'm able to build the runtime using public sources. It currently relies on a vanagon PR that hasn't been released yet:

```
$ export VANAGON_LOCATION=https://github.com/puppetlabs/vanagon#main
$ bundle update
$ docker pull fedora:40                                                  
40: Pulling from library/fedora
Digest: sha256:bd0b8ed03d00b53d8cefab42c6a9ffac4b90a72f8934355a009ac5fb1258040b
Status: Image is up to date for fedora:40
docker.io/library/fedora:40
$ bundle exec vanagon build agent-runtime-main fedora-40-x86_64 -e docker
```

During iterative development, I sometimes get the following error:

```
docker: Error response from daemon: Conflict. The container name "/fedora_40-builder" is already in use by container "707cb97e2d4d2f854cddca125fdf66574b7a47f892a1ed86a99e7403fd45508f". You have to remove (or rename) that container to be able to reuse that name.
```

Which can be resolved with the following:

```
$ docker kill $(docker ps -q) 
$ docker remove fedora_40-builder 
```