### PR TITLE
(PA-6131) Bump openssl version

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -1,6 +1,6 @@
 component 'openssl' do |pkg, settings, platform|
-  pkg.version '3.0.12'
-  pkg.sha256sum 'f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61'
+  pkg.version '3.0.13'
+  pkg.sha256sum '88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313'
   pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/openssl-#{pkg.get_version}.tar.gz"
 
@@ -26,6 +26,9 @@ component 'openssl' do |pkg, settings, platform|
     pkg.environment 'PATH', "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
     pkg.environment 'CYGWIN', settings[:cygwin]
     pkg.environment 'MAKE', platform[:make]
+
+    # Remove this in 3.0.14 or later
+    pkg.apply_patch 'resources/patches/openssl/openssl-3.0.13-crypto-providers.patch'
 
     target = platform.architecture == 'x64' ? 'mingw64' : 'mingw'
   # elsif platform.is_cross_compiled_linux?

--- a/resources/patches/openssl/openssl-3.0.13-crypto-providers.patch
+++ b/resources/patches/openssl/openssl-3.0.13-crypto-providers.patch
@@ -1,0 +1,64 @@
+From 7b3eda56d7891aceef91867de64f24b20e3db212 Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Thu, 1 Feb 2024 10:57:51 +0100
+Subject: [PATCH] Fix a few incorrect paths in some build.info files
+
+The following files referred to ../liblegacy.a when they should have
+referred to ../../liblegacy.a.  This cause the creation of a mysterious
+directory 'crypto/providers', and because of an increased strictness
+with regards to where directories are created, configuration failure
+on some platforms.
+
+Fixes #23436
+
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Tom Cosgrove <tom.cosgrove@arm.com>
+(Merged from https://github.com/openssl/openssl/pull/23452)
+
+(cherry picked from commit 667b45454a47959ce2934b74c899662e686993de)
+---
+ crypto/aes/build.info | 2 +-
+ crypto/ec/build.info  | 2 +-
+ crypto/sha/build.info | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/crypto/aes/build.info b/crypto/aes/build.info
+index b250903fa6e26..271015e35e1bb 100644
+--- a/crypto/aes/build.info
++++ b/crypto/aes/build.info
+@@ -76,7 +76,7 @@ DEFINE[../../providers/libdefault.a]=$AESDEF
+ # already gets everything that the static libcrypto.a has, and doesn't need it
+ # added again.
+ IF[{- !$disabled{module} && !$disabled{shared} -}]
+-  DEFINE[../providers/liblegacy.a]=$AESDEF
++  DEFINE[../../providers/liblegacy.a]=$AESDEF
+ ENDIF
+ 
+ GENERATE[aes-ia64.s]=asm/aes-ia64.S
+diff --git a/crypto/ec/build.info b/crypto/ec/build.info
+index a511e887a9ba1..6dd98e9f4f172 100644
+--- a/crypto/ec/build.info
++++ b/crypto/ec/build.info
+@@ -77,7 +77,7 @@ DEFINE[../../providers/libdefault.a]=$ECDEF
+ # Otherwise, it already gets everything that the static libcrypto.a
+ # has, and doesn't need it added again.
+ IF[{- !$disabled{module} && !$disabled{shared} -}]
+-  DEFINE[../providers/liblegacy.a]=$ECDEF
++  DEFINE[../../providers/liblegacy.a]=$ECDEF
+ ENDIF
+ 
+ GENERATE[ecp_nistz256-x86.S]=asm/ecp_nistz256-x86.pl
+diff --git a/crypto/sha/build.info b/crypto/sha/build.info
+index d61f7de9b6bde..186ec13cc82a1 100644
+--- a/crypto/sha/build.info
++++ b/crypto/sha/build.info
+@@ -88,7 +88,7 @@ DEFINE[../../providers/libdefault.a]=$SHA1DEF $KECCAK1600DEF
+ # linked with libcrypto.  Otherwise, it already gets everything that
+ # the static libcrypto.a has, and doesn't need it added again.
+ IF[{- !$disabled{module} && !$disabled{shared} -}]
+-  DEFINE[../providers/liblegacy.a]=$SHA1DEF $KECCAK1600DEF
++  DEFINE[../../providers/liblegacy.a]=$SHA1DEF $KECCAK1600DEF
+ ENDIF
+ 
+ GENERATE[sha1-586.S]=asm/sha1-586.pl


### PR DESCRIPTION
Patch is needed to resolve this error:

    $ ./Configure shared mingw64
    Configuring OpenSSL version 3.0.13 for target mingw64
    Using os-specific seed configuration

    Failure!  Makefile wasn't produced.
    Please read INSTALL.md and associated NOTES-* files.  You may also have to
    look over your available compiler tool chain or change your configuration.

    /var/tmp/openssl-3.0.13/crypto/sha/../providers: No such file or directory at ./Configure line 3413.

Building https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2780/