### PR TITLE
Drop unused win32 gems from bolt-runtime and other cleanup

### DIFF
--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -1,36 +1,34 @@
 component 'dmidecode' do |pkg, settings, platform|
-    pkg.version '3.3'
-    pkg.md5sum 'afca949fd71a23dd39c4a3c9cd946dc0'
+  pkg.version '3.3'
+  pkg.md5sum 'afca949fd71a23dd39c4a3c9cd946dc0'
 
-    pkg.apply_patch 'resources/patches/dmidecode/1117390c.patch'
-    pkg.apply_patch 'resources/patches/dmidecode/11e134e5.patch'
-  
-    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-install-to-bin.patch'
-    pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.xz"
-    pkg.mirror "#{settings[:buildsources_url]}/dmidecode-#{pkg.get_version}.tar.xz"
-  
-    pkg.environment "LDFLAGS", settings[:ldflags]
-    pkg.environment "CFLAGS", settings[:cflags]
-  
-    if platform.is_cross_compiled?
-      # The Makefile doesn't honor environment overrides, so we need to
-      # edit it directly for cross-compiling
-      pkg.configure do
-        ["sed -i \"s|gcc|/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc|g\" Makefile"]
-      end
-    end
-  
-    pkg.build do
-      ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
-    end
-  
-    pkg.install do
-      [
-        "#{platform[:make]} prefix=#{settings[:prefix]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
-        "rm -f #{settings[:bindir]}/vpddecode #{settings[:bindir]}/biosdecode #{settings[:bindir]}/ownership",
-        "rm -f #{settings[:mandir]}/man8/ownership.8 #{settings[:mandir]}/man8/biosdecode.8 #{settings[:mandir]}/man8/vpddecode.8"
-      ]
+  pkg.apply_patch 'resources/patches/dmidecode/1117390c.patch'
+  pkg.apply_patch 'resources/patches/dmidecode/11e134e5.patch'
+
+  pkg.apply_patch 'resources/patches/dmidecode/dmidecode-install-to-bin.patch'
+  pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.xz"
+  pkg.mirror "#{settings[:buildsources_url]}/dmidecode-#{pkg.get_version}.tar.xz"
+
+  pkg.environment "LDFLAGS", settings[:ldflags]
+  pkg.environment "CFLAGS", settings[:cflags]
+
+  if platform.is_cross_compiled?
+    # The Makefile doesn't honor environment overrides, so we need to
+    # edit it directly for cross-compiling
+    pkg.configure do
+      ["sed -i \"s|gcc|/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc|g\" Makefile"]
     end
   end
-  
-  
+
+  pkg.build do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    [
+      "#{platform[:make]} prefix=#{settings[:prefix]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
+      "rm -f #{settings[:bindir]}/vpddecode #{settings[:bindir]}/biosdecode #{settings[:bindir]}/ownership",
+      "rm -f #{settings[:mandir]}/man8/ownership.8 #{settings[:mandir]}/man8/biosdecode.8 #{settings[:mandir]}/man8/vpddecode.8"
+    ]
+  end
+end

--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -28,26 +28,6 @@ component 'openssl' do |pkg, settings, platform|
     pkg.environment 'MAKE', platform[:make]
 
     target = platform.architecture == 'x64' ? 'mingw64' : 'mingw'
-  # elsif platform.is_cross_compiled_linux?
-  #   pkg.environment 'PATH', "/opt/pl-build-tools/bin:$(PATH)"
-  #   pkg.environment 'CC', "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-
-  #   cflags = "#{settings[:cflags]} -fPIC"
-  #   if platform.architecture =~ /aarch/
-  #     # OpenSSL fails to work on aarch unless we turn down the compiler optimization.
-  #     # See PA-2135 for details
-  #     cflags += " -O2"
-  #   end
-  #   ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
-  #   target = if platform.architecture == 'aarch64'
-  #               'linux-aarch64'
-  #             elsif platform.name =~ /debian-8-arm/
-  #               'linux-armv4'
-  #             elsif platform.architecture =~ /ppc64le|ppc64el/ # Little-endian
-  #               'linux-ppc64le'
-  #             elsif platform.architecture =~ /ppc64/ # Big-endian
-  #               'linux-ppc64'
-  #             end
   elsif platform.is_aix?
     raise "openssl-3.0 is not supported on older AIX" if platform.name == 'aix-7.1-ppc'
 
@@ -147,7 +127,6 @@ component 'openssl' do |pkg, settings, platform|
     configure_flags << 'no-legacy' << 'no-md4'
   end
 
-
   # Individual projects may provide their own openssl configure flags:
   project_flags = settings[:openssl_extra_configure_flags] || []
   perl_exec = ''
@@ -200,11 +179,6 @@ component 'openssl' do |pkg, settings, platform|
 
   # Skip man and html docs
   install_commands << "#{platform[:make]} #{install_prefix} install_sw install_ssldirs"
-
-  # if settings[:runtime_project] == 'pdk'
-  #   install_commands << "rm -f #{settings[:prefix]}/bin/{openssl,c_rehash}"
-  # end
-
   install_commands << "rm -f #{settings[:prefix]}/bin/c_rehash"
 
   pkg.install do

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -127,7 +127,7 @@ component "rubygem-ffi" do |pkg, settings, platform|
 
       # move ld back after the gem is installed
       pkg.install { "mv /usr/bin/ld1 /usr/bin/ld" }
-    
+
     elsif platform.name =~ /solaris-10-sparc/
       sed_exp = 's|CONFIG\["LDFLAGS"\].*|CONFIG["LDFLAGS"] = "-Wl,-rpath-link,/opt/pl-build-tools/sparc-sun-solaris2.10/sysroot/lib:/opt/pl-build-tools/sparc-sun-solaris2.10/sysroot/usr/lib -L. -Wl,-rpath=/opt/puppetlabs/puppet/lib -fstack-protector"|'
       pkg.configure do

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -19,6 +19,18 @@ component "rubygem-ffi" do |pkg, settings, platform|
 
   rb_major_minor_version = settings[:ruby_version].to_f
 
+  # Prior to ruby 3.2, both ruby and the ffi gem vendored a version of libffi.
+  # If libffi happened to be installed in /usr/lib, then the ffi gem preferred
+  # that instead of building libffi itself. To ensure consistency, we use
+  # --disable-system-ffi so that the ffi gem *always* builds libffi, then
+  # builds the ffi_c native extension and links it against libffi.so.
+  #
+  # In ruby 3.2 and up, libffi is no longer vendored. So we created a separate
+  # libffi vanagon component which is built before ruby. The ffi gem still
+  # vendors libffi, so we use the --enable-system-ffi option to ensure the ffi
+  # gem *always* uses the libffi.so we already built. Note the term "system" is
+  # misleading, because we override PKG_CONFIG_PATH below so that our libffi.so
+  # is preferred, not the one in /usr/lib.
   if rb_major_minor_version > 2.7
     pkg.install do
       "#{settings[:gem_install]} ffi-#{pkg.get_version}.gem -- --enable-system-ffi"
@@ -97,6 +109,7 @@ component "rubygem-ffi" do |pkg, settings, platform|
   if platform.name =~ /solaris-11-i386/ && rb_major_minor_version < 3.2
     pkg.install_file "/usr/lib/libffi.so.5.0.10", "#{settings[:libdir]}/libffi.so"
   elsif platform.name =~ /solaris-10-i386/
+    # If we ever support Solaris-11 on Ruby 3.2, then we won't want to do this
     pkg.install_file "/opt/csw/lib/libffi.so.6", "#{settings[:libdir]}/libffi.so.6"
   end
 

--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -4,7 +4,7 @@ component "rubygem-gettext" do |pkg, settings, platform|
 
   case version
   when '3.4.3'
-    pkg.sha256sum '1b98e1272d0f55a56f519ee86d24e0fcd114b94c9d10b26e72512d65f9174251'    
+    pkg.sha256sum '1b98e1272d0f55a56f519ee86d24e0fcd114b94c9d10b26e72512d65f9174251'
   when '3.2.2'
     pkg.sha256sum '9d250bb79273efb4a268977f219d2daca05cdc7473eff40288b8ab8ddd0f51b4'
   else

--- a/configs/components/rubygem-prime.rb
+++ b/configs/components/rubygem-prime.rb
@@ -1,7 +1,6 @@
 component 'rubygem-prime' do |pkg, settings, platform|
-    pkg.version '0.1.2'
-    pkg.sha256sum 'd4e956cadfaf04de036dc7dc74f95bf6a285a62cc509b28b7a66b245d19fe3a4'
-  
-    instance_eval File.read('configs/components/_base-rubygem.rb')
-  end
-  
+  pkg.version '0.1.2'
+  pkg.sha256sum 'd4e956cadfaf04de036dc7dc74f95bf6a285a62cc509b28b7a66b245d19fe3a4'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-public_suffix.rb
+++ b/configs/components/rubygem-public_suffix.rb
@@ -3,4 +3,4 @@ component 'rubygem-public_suffix' do |pkg, _settings, _platform|
   pkg.md5sum '504e45c1f5f7b629e46e4deef7d0f46f'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
- end
+end

--- a/configs/components/rubygem-rgen.rb
+++ b/configs/components/rubygem-rgen.rb
@@ -4,4 +4,3 @@ component 'rubygem-rgen' do |pkg, settings, platform|
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end
-

--- a/configs/components/rubygem-win32-dir.rb
+++ b/configs/components/rubygem-win32-dir.rb
@@ -1,6 +1,0 @@
-component "rubygem-win32-dir" do |pkg, settings, platform|
-  pkg.version "0.4.9"
-  pkg.md5sum "df14aa01bd6011f4b6332a05e15b7fb8"
-
-  instance_eval File.read('configs/components/_base-rubygem.rb')
-end

--- a/configs/components/rubygem-win32-process.rb
+++ b/configs/components/rubygem-win32-process.rb
@@ -1,6 +1,0 @@
-component "rubygem-win32-process" do |pkg, settings, platform|
-  pkg.version "0.7.5"
-  pkg.md5sum "d7ff67c7934b0d6ab93030d2cc2fc4f0"
-
-  instance_eval File.read('configs/components/_base-rubygem.rb')
-end

--- a/configs/components/rubygem-win32-security.rb
+++ b/configs/components/rubygem-win32-security.rb
@@ -1,6 +1,0 @@
-component "rubygem-win32-security" do |pkg, settings, platform|
-  pkg.version "0.2.5"
-  pkg.md5sum "97c4b971ea19ca48cea7dec1d21d506a"
-
-  instance_eval File.read('configs/components/_base-rubygem.rb')
-end

--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -1,6 +1,0 @@
-component "rubygem-win32-service" do |pkg, settings, platform|
-  pkg.version "0.8.8"
-  pkg.md5sum "24cc05fed398eb931e14b8ee22196634"
-
-  instance_eval File.read('configs/components/_base-rubygem.rb')
-end

--- a/configs/components/runtime-pe-installer.rb
+++ b/configs/components/runtime-pe-installer.rb
@@ -1,7 +1,7 @@
 # This component exists to link in the gcc runtime libraries.
 component "runtime-pe-installer" do |pkg, settings, platform|
   pkg.environment "PROJECT_SHORTNAME", "installer"
-  
+
   if platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
     libbase = platform.architecture =~ /64/ ? 'lib64' : 'lib'
     libdir = "/opt/pl-build-tools/#{libbase}"

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -1,47 +1,46 @@
 component "virt-what" do |pkg, settings, platform|
-    pkg.version "1.22"
-    pkg.md5sum "0e9923de6a6c6f07bc0ddc3ec8fc1018"
-  
-    pkg.url "https://people.redhat.com/~rjones/virt-what/files/virt-what-#{pkg.get_version}.tar.gz"
-    pkg.mirror "#{settings[:buildsources_url]}/virt-what-#{pkg.get_version}.tar.gz"
-  
-    pkg.replaces 'pe-virt-what'
-  
-    # Run-time requirements
-    unless platform.is_deb?
-      requires "util-linux"
-    end
-  
-    if platform.is_rpm?
-      pkg.build_requires "util-linux"
-    end
-  
-    if platform.is_linux?
-      if platform.architecture =~ /ppc64le$/
-        host_opt = '--host powerpc64le-unknown-linux-gnu'
-      elsif platform.architecture =~ /ppc64$/
-        host_opt = '--host powerpc64-unknown-linux-gnu'
-      end
-    end
-  
-    if platform.is_cross_compiled_linux?
-      host_opt = "--host #{settings[:platform_triple]}"
-  
-      pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-      pkg.environment "CFLAGS" => settings[:cflags]
-      pkg.environment "LDFLAGS" => settings[:ldflags]
-    end
-  
-    pkg.configure do
-      ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/virt-what #{host_opt}"]
-    end
-  
-    pkg.build do
-      ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
-    end
-  
-    pkg.install do
-      ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  pkg.version "1.22"
+  pkg.md5sum "0e9923de6a6c6f07bc0ddc3ec8fc1018"
+
+  pkg.url "https://people.redhat.com/~rjones/virt-what/files/virt-what-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/virt-what-#{pkg.get_version}.tar.gz"
+
+  pkg.replaces 'pe-virt-what'
+
+  # Run-time requirements
+  unless platform.is_deb?
+    requires "util-linux"
+  end
+
+  if platform.is_rpm?
+    pkg.build_requires "util-linux"
+  end
+
+  if platform.is_linux?
+    if platform.architecture =~ /ppc64le$/
+      host_opt = '--host powerpc64le-unknown-linux-gnu'
+    elsif platform.architecture =~ /ppc64$/
+      host_opt = '--host powerpc64-unknown-linux-gnu'
     end
   end
-  
+
+  if platform.is_cross_compiled_linux?
+    host_opt = "--host #{settings[:platform_triple]}"
+
+    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "CFLAGS" => settings[:cflags]
+    pkg.environment "LDFLAGS" => settings[:ldflags]
+  end
+
+  pkg.configure do
+    ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/virt-what #{host_opt}"]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -215,15 +215,6 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-yard'
 
   # Core Windows dependencies
-
-  # Omits from non-Windows platforms to avoid licensing issues
-  if platform.is_windows?
-    proj.component 'rubygem-win32-dir'
-    proj.component 'rubygem-win32-process'
-    proj.component 'rubygem-win32-security'
-    proj.component 'rubygem-win32-service'
-  end
-  
   proj.component 'rubygem-windows_error'
   proj.component 'rubygem-winrm'
   proj.component 'rubygem-winrm-fs'


### PR DESCRIPTION
Puppet 6 was the last stream to depend on win32-* gems, see https://github.com/puppetlabs/puppet-runtime/commit/513c5583bb6449187eb7ef6306997398917a5c10. In
Puppet 7, all of the required functionality was implemented in puppet itself.

Since bolt-runtime has moved to puppet 7.27, we can drop these gems.