### PR TITLE
Leave comment to remove patch

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -85,6 +85,7 @@ component 'openssl' do |pkg, settings, platform|
     end
   end
 
+  # Remove this in 3.0.14 or later
   pkg.apply_patch 'resources/patches/openssl/CVE-2024-2511.patch'
 
   ####################


### PR DESCRIPTION
I should have left a review on https://github.com/puppetlabs/puppet-runtime/pull/822 but I was too fast merging. This just leaves a comment to remember to remove the patch for CVE-2024-2511 after the next OpenSSL 3.0.x release.