### PR TITLE
(PA-6379): Applied patch to openssl 1.1.1

### DIFF
--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -89,6 +89,7 @@ component 'openssl' do |pkg, settings, platform|
 
   pkg.apply_patch 'resources/patches/openssl/CVE-2023-5678.patch'
   pkg.apply_patch 'resources/patches/openssl/CVE-2024-0727.patch'
+  pkg.apply_patch 'resources/patches/openssl/openssl-1.1.1-CVE-2024-2511.patch'
 
   ####################
   # BUILD REQUIREMENTS

--- a/resources/patches/openssl/openssl-1.1.1-CVE-2024-2511.patch
+++ b/resources/patches/openssl/openssl-1.1.1-CVE-2024-2511.patch
@@ -1,0 +1,136 @@
+Fix unconstrained session cache growth in TLSv1.3
+In TLSv1.3 we create a new session object for each ticket that we send.
+We do this by duplicating the original session. If SSL_OP_NO_TICKET is in
+use then the new session will be added to the session cache. However, if
+early data is not in use (and therefore anti-replay protection is being
+used), then multiple threads could be resuming from the same session
+simultaneously. If this happens and a problem occurs on one of the threads,
+then the original session object could be marked as not_resumable. When we
+duplicate the session object this not_resumable status gets copied into the
+new session object. The new session object is then added to the session
+cache even though it is not_resumable.
+
+Subsequently, another bug means that the session_id_length is set to 0 for
+sessions that are marked as not_resumable - even though that session is
+still in the cache. Once this happens the session can never be removed from
+the cache. When that object gets to be the session cache tail object the
+cache never shrinks again and grows indefinitely.
+
+CVE-2024-2511
+
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from #24044)
+
+(cherry picked from commit 7e4d731)
+---
+
+diff --git a/include/openssl/ssl.h b/include/openssl/ssl.h
+index 9af0c8995e..64eaca338a 100644
+--- a/include/openssl/ssl.h
++++ b/include/openssl/ssl.h
+@@ -1659,7 +1659,7 @@ __owur int SSL_SESSION_set1_id(SSL_SESSION *s, const unsigned char *sid,
+ __owur int SSL_SESSION_is_resumable(const SSL_SESSION *s);
+ 
+ __owur SSL_SESSION *SSL_SESSION_new(void);
+-__owur SSL_SESSION *SSL_SESSION_dup(SSL_SESSION *src);
++__owur SSL_SESSION *SSL_SESSION_dup(const SSL_SESSION *src);
+ const unsigned char *SSL_SESSION_get_id(const SSL_SESSION *s,
+                                         unsigned int *len);
+ const unsigned char *SSL_SESSION_get0_id_context(const SSL_SESSION *s,
+diff --git a/ssl/ssl_lib.c b/ssl/ssl_lib.c
+index 47adc3211c..c01ad8291c 100644
+--- a/ssl/ssl_lib.c
++++ b/ssl/ssl_lib.c
+@@ -3515,9 +3515,10 @@ void ssl_update_cache(SSL *s, int mode)
+ 
+     /*
+      * If the session_id_length is 0, we are not supposed to cache it, and it
+-     * would be rather hard to do anyway :-)
++     * would be rather hard to do anyway :-). Also if the session has already
++     * been marked as not_resumable we should not cache it for later reuse.
+      */
+-    if (s->session->session_id_length == 0)
++    if (s->session->session_id_length == 0 || s->session->not_resumable)
+         return;
+ 
+     /*
+diff --git a/ssl/ssl_local.h b/ssl/ssl_local.h
+index 5c79215423..5e73fa4e22 100644
+--- a/ssl/ssl_local.h
++++ b/ssl/ssl_local.h
+@@ -2261,7 +2261,7 @@ __owur int ssl_get_new_session(SSL *s, int session);
+ __owur SSL_SESSION *lookup_sess_in_cache(SSL *s, const unsigned char *sess_id,
+                                          size_t sess_id_len);
+ __owur int ssl_get_prev_session(SSL *s, CLIENTHELLO_MSG *hello);
+-__owur SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket);
++__owur SSL_SESSION *ssl_session_dup(const SSL_SESSION *src, int ticket);
+ __owur int ssl_cipher_id_cmp(const SSL_CIPHER *a, const SSL_CIPHER *b);
+ DECLARE_OBJ_BSEARCH_GLOBAL_CMP_FN(SSL_CIPHER, SSL_CIPHER, ssl_cipher_id);
+ __owur int ssl_cipher_ptr_id_cmp(const SSL_CIPHER *const *ap,
+diff --git a/ssl/ssl_sess.c b/ssl/ssl_sess.c
+index cda6b7cc5b..404599169d 100644
+--- a/ssl/ssl_sess.c
++++ b/ssl/ssl_sess.c
+@@ -94,16 +94,11 @@ SSL_SESSION *SSL_SESSION_new(void)
+     return ss;
+ }
+ 
+-SSL_SESSION *SSL_SESSION_dup(SSL_SESSION *src)
+-{
+-    return ssl_session_dup(src, 1);
+-}
+-
+ /*
+  * Create a new SSL_SESSION and duplicate the contents of |src| into it. If
+  * ticket == 0 then no ticket information is duplicated, otherwise it is.
+  */
+-SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket)
++static SSL_SESSION *ssl_session_dup_intern(const SSL_SESSION *src, int ticket)
+ {
+     SSL_SESSION *dest;
+ 
+@@ -223,6 +218,27 @@ SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket)
+     return NULL;
+ }
+ 
++SSL_SESSION *SSL_SESSION_dup(const SSL_SESSION *src)
++{
++    return ssl_session_dup_intern(src, 1);
++}
++
++/*
++ * Used internally when duplicating a session which might be already shared.
++ * We will have resumed the original session. Subsequently we might have marked
++ * it as non-resumable (e.g. in another thread) - but this copy should be ok to
++ * resume from.
++ */
++SSL_SESSION *ssl_session_dup(const SSL_SESSION *src, int ticket)
++{
++    SSL_SESSION *sess = ssl_session_dup_intern(src, ticket);
++
++    if (sess != NULL)
++        sess->not_resumable = 0;
++
++    return sess;
++}
++
+ const unsigned char *SSL_SESSION_get_id(const SSL_SESSION *s, unsigned int *len)
+ {
+     if (len)
+diff --git a/ssl/statem/statem_srvr.c b/ssl/statem/statem_srvr.c
+index 43f77a5899..f55e11bde9 100644
+--- a/ssl/statem/statem_srvr.c
++++ b/ssl/statem/statem_srvr.c
+@@ -2403,9 +2403,8 @@ int tls_construct_server_hello(SSL *s, WPACKET *pkt)
+      * so the following won't overwrite an ID that we're supposed
+      * to send back.
+      */
+-    if (s->session->not_resumable ||
+-        (!(s->ctx->session_cache_mode & SSL_SESS_CACHE_SERVER)
+-         && !s->hit))
++    if (!(s->ctx->session_cache_mode & SSL_SESS_CACHE_SERVER)
++            && !s->hit)
+         s->session->session_id_length = 0;
+ 
+     if (usetls13) {


### PR DESCRIPTION
Applied following patch to openssl-1.1.1
1. [CVE-2024-2511](https://www.openssl.org/news/secadv/20240408.txt)