### PR TITLE
(PA-5715) Download release tarballs for libxml2 and libxslt

### DIFF
--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -1,12 +1,10 @@
 component "libxml2" do |pkg, settings, platform|
   pkg.version '2.10.3'
-  pkg.sha256sum '26d2415e1c23e0aad8ca52358523fc9116a2eb6e4d4ef47577b1635c7cee3d5f'
-  pkg.url "#{settings[:buildsources_url]}/libxml2-#{pkg.get_version}.tar.gz"
+  pkg.sha256sum '5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c'
 
-  # Newer versions of libxml2 either ship as tar.xz or do not ship with a configure file
-  # and require a newer version of GNU Autotools to generate. This causes problems with
-  # the older and esoteric (AIX, Solaris) platforms that we support.
-  # So we generate a configure file manually, compress as tar.gz, and host internally.
+  libxml2_version_y = pkg.get_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+  pkg.url "https://download.gnome.org/sources/libxml2/#{libxml2_version_y}/libxml2-#{pkg.get_version}.tar.xz"
+  pkg.mirror "#{settings[:buildsources_url]}/libxml2-#{pkg.get_version}.tar.xz"
 
   if platform.is_aix?
     if platform.name == 'aix-7.1-ppc'

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -10,7 +10,7 @@ component "libxml2" do |pkg, settings, platform|
 
   if platform.is_aix?
     if platform.name == 'aix-7.1-ppc'
-      pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
+      pkg.environment "PATH", "/opt/pl-build-tools/bin:/opt/freeware/bin:$(PATH)"
     else
       pkg.environment "PATH", "/opt/freeware/bin:$(PATH)"
     end
@@ -19,7 +19,7 @@ component "libxml2" do |pkg, settings, platform|
     pkg.environment "CFLAGS", settings[:cflags]
     pkg.environment "LDFLAGS", settings[:ldflags]
   elsif platform.is_solaris?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:/opt/csw/bin:#{settings[:bindir]}"
     pkg.environment "CFLAGS", "#{settings[:cflags]} -std=c99"
     pkg.environment "LDFLAGS", settings[:ldflags]
   elsif platform.is_macos?

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -12,7 +12,7 @@ component "libxslt" do |pkg, settings, platform|
 
   if platform.is_aix?
     if platform.name == 'aix-7.1-ppc'
-      pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
+      pkg.environment "PATH", "/opt/pl-build-tools/bin:/opt/freeware/bin:$(PATH)"
     else
       pkg.environment "PATH", "/opt/freeware/bin:$(PATH)"
     end
@@ -26,7 +26,7 @@ component "libxslt" do |pkg, settings, platform|
     # don't depend on libgcrypto
     disable_crypto = "--without-crypto"
   elsif platform.is_solaris?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:/opt/csw/bin:#{settings[:bindir]}"
     pkg.environment "CFLAGS", settings[:cflags]
     pkg.environment "LDFLAGS", settings[:ldflags]
   elsif platform.is_macos?

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -1,12 +1,10 @@
 component "libxslt" do |pkg, settings, platform|
   pkg.version '1.1.37'
-  pkg.sha256sum 'a4ecab265f44e888ed3b39e11c7e925103ef6e26e09d62e9381f26977df96343'
-  pkg.url "#{settings[:buildsources_url]}/libxslt-v#{pkg.get_version}.tar.gz"
+  pkg.sha256sum '3a4b27dc8027ccd6146725950336f1ec520928f320f144eb5fa7990ae6123ab4'
 
-  # Newer versions of libxslt either ship as tar.xz or do not ship with a configure file
-  # and require a newer version of GNU Autotools to generate. This causes problems with
-  # the older and esoteric (AIX, Solaris) platforms that we support.
-  # So we generate a configure file manually, compress as tar.gz, and host internally.
+  libxslt_version_y = pkg.get_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+  pkg.url "https://download.gnome.org/sources/libxslt/#{libxslt_version_y}/libxslt-#{pkg.get_version}.tar.xz"
+  pkg.mirror "#{settings[:buildsources_url]}/libxslt-#{pkg.get_version}.tar.xz"
 
   pkg.build_requires "libxml2"
 

--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -42,7 +42,7 @@ tar xvf openssl-1.0.2.1800.tar;
 cd openssl-1.0.2.1800 && /usr/sbin/installp -acgwXY -d $PWD openssl.base;
 curl --output yum.sh https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/aix-yum.sh && sh yum.sh;
 /opt/freeware/bin/sed -i 's|https://anonymous:anonymous@public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS|https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS|' /opt/freeware/etc/yum/yum.conf;
-yum install -y gcc8-c++;
+yum install -y gcc8-c++ xz-5.2.5;
 ln -sf /opt/freeware/lib/gcc/powerpc-ibm-aix7.1.0.0/8/libgcc_s.a /opt/freeware/lib/libgcc_s.a]
 
   # We use --force with rpm because the pl-gettext and pl-autoconf

--- a/configs/platforms/aix-7.2-ppc.rb
+++ b/configs/platforms/aix-7.2-ppc.rb
@@ -49,6 +49,7 @@ rpm -Uvh https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix
     readline-devel
     sed
     tar
+    xz-5.4.3
     zlib
     zlib-devel
   )

--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -50,7 +50,7 @@ basedir=default" > /var/tmp/vanagon-noask;
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep libffi_dev libreadline6 || exit 1;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep libffi_dev libreadline6 CSWxz-5.2.8,REV=2022.11.16 || exit 1;
 
   # Install base build dependencies
   for pkg in #{base_pkgs.map { |pkg| "SUNW#{pkg}.pkg.gz" }.join(' ')}; do \

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -51,7 +51,7 @@ basedir=default" > /var/tmp/vanagon-noask;
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake libgcc_s1 libreadline6 pkgconfig ggrep ruby20 ruby20_dev gcc4g++ || exit 1;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake libgcc_s1 libreadline6 pkgconfig ggrep ruby20 ruby20_dev gcc4g++ CSWxz-5.2.8,REV=2022.11.16 || exit 1;
   # For some reason, the bison reference is invalid on our artifactory mirror, so get it directly from opencsw.
   /opt/csw/bin/pkgutil -y -i bison;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep

--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -41,7 +41,7 @@ action=nocheck
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
   pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev autoconf gcc4core || exit 1;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev autoconf gcc4core CSWxz-5.2.8,REV=2022.11.16 || exit 1;
   ntpdate pool.ntp.org]
   plat.output_dir File.join("solaris", "11", "PC1")
 end

--- a/configs/platforms/solaris-11-native-sparc.rb
+++ b/configs/platforms/solaris-11-native-sparc.rb
@@ -55,6 +55,6 @@ action=nocheck
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
   pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-  /opt/csw/bin/pkgutil -U && /opt/csw/bin/pkgutil -y -i bison || exit 1
+  /opt/csw/bin/pkgutil -U && /opt/csw/bin/pkgutil -y -i bison CSWxz-5.2.8,REV=2022.11.16 || exit 1
   ]
 end

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -41,7 +41,7 @@ action=nocheck
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
   pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-  /opt/csw/bin/pkgutil -U && /opt/csw/bin/pkgutil -y -i gcc4g++ bison || exit 1
+  /opt/csw/bin/pkgutil -U && /opt/csw/bin/pkgutil -y -i gcc4g++ bison CSWxz-5.2.8,REV=2022.11.16 || exit 1
 
   ntpdate pool.ntp.org]
 end


### PR DESCRIPTION
These changes make it possible for anyone to build the `agent-runtime-*` projects for modern linux outside of our network. This is done by installing the release tarballs from libxml2 and libxslt and installing the necessary packages to decompress the tarballs. And this will make it possible to easily bump to newer versions of libxml2 and libxslt in the future.

- [x] [agent-runtime-7.x](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2810/)
- [x] [agent-runtime-main](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2813/)