### PR TITLE
(maint) Fix typo in component name

### DIFF
--- a/configs/components/rubygem-base64.rb
+++ b/configs/components/rubygem-base64.rb
@@ -1,4 +1,4 @@
-component 'rubygem-bas64' do |pkg, settings, platform|
+component 'rubygem-base64' do |pkg, settings, platform|
   pkg.version '0.2.0'
   pkg.md5sum 'fe02f4347a5846f79f4d4615edababd3'
 


### PR DESCRIPTION
Luckily the filename itself covered this typo up (base64 gem still included). this commit fixes the typo for consistency.