### PR TITLE
ensure ruby-selinux component is included consistently across runtimes

### DIFF
--- a/configs/projects/_pdk-components.rb
+++ b/configs/projects/_pdk-components.rb
@@ -26,7 +26,10 @@ proj.component 'libxslt' unless platform.is_windows?
 proj.component "ruby-#{proj.ruby_version}"
 
 proj.component 'ruby-augeas' unless platform.is_windows?
-proj.component 'ruby-selinux' if platform.is_el? || platform.is_fedora?
+# We only build ruby-selinux for EL, Fedora, Debian and Ubuntu (amd64/i386)
+if platform.is_el? || platform.is_fedora? || platform.is_debian? || (platform.is_ubuntu? && platform.architecture !~ /ppc64el$/)
+  proj.component 'ruby-selinux'
+end
 
 # Additional Rubies
 if proj.respond_to?(:additional_rubies)

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -41,10 +41,8 @@ proj.component 'libxslt' unless platform.is_windows?
 proj.component 'ruby-augeas' unless platform.is_windows?
 proj.component 'ruby-shadow' unless platform.is_aix? || platform.is_windows?
 # We only build ruby-selinux for EL, Fedora, Debian and Ubuntu (amd64/i386)
-if platform.is_el? || platform.is_fedora? || platform.name =~ /debian|ubuntu/
-  if platform.name !~ /ubuntu-.*-ppc64el/
-    proj.component 'ruby-selinux'
-  end
+if platform.is_el? || platform.is_fedora? || platform.is_debian? || (platform.is_ubuntu? && platform.architecture !~ /ppc64el$/)
+  proj.component 'ruby-selinux'
 end
 
 # libedit is used instead of readline on these platforms

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -222,8 +222,8 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-winrm-fs'
 
   # Components from puppet-runtime included to support apply on localhost
-  # Only bundle SELinux gem for RHEL,Centos,Fedora
-  if platform.is_el? || platform.is_fedora?
+  # We only build ruby-selinux for EL, Fedora, Debian and Ubuntu (amd64/i386)
+  if platform.is_el? || platform.is_fedora? || platform.is_debian? || (platform.is_ubuntu? && platform.architecture !~ /ppc64el$/)
     proj.component 'ruby-selinux'
   end
 


### PR DESCRIPTION
bolt, pdk, and agent runtimes have different support for selinux depending on the Linux platform

- [x] [agent-runtime-7.x](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1497/)
- [x] [agent-runtime-main](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1500/)
- [x] [bolt-runtime](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1502/)
- [x] [pdk-runtime](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1501/)