### PR TITLE
(PA-6383) consistently apply PIE compiler flags

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -76,6 +76,9 @@ elsif platform.is_macos?
   elsif platform.architecture == 'arm64' && platform.os_version.to_i >= 13
     pkg.environment 'CC', 'clang'
   end
+else
+  pkg.environment 'LDFLAGS', settings[:ldflags]
+  pkg.environment 'optflags', settings[:cflags]
 end
 
 ####################

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -125,7 +125,15 @@ component 'augeas' do |pkg, settings, platform|
     end
   end
 
-  if platform.name =~ /sles-15|el-8|debian-10/ || platform.is_fedora?
+  # conditional taken from projects/_shared-compiler-settings
+  # TODO: refactor condition
+  if ((platform.is_sles? && platform.os_version.to_i >= 15) ||
+      (platform.is_el? && platform.os_version.to_i >= 8) ||
+      platform.is_debian? ||
+      (platform.is_ubuntu? && platform.os_version.to_i >= 20) ||
+      (platform.is_amazon? && platform.os_version.to_i >= 2023) ||
+      platform.is_fedora?
+     )
     pkg.environment 'CFLAGS', settings[:cflags]
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment "LDFLAGS", settings[:ldflags]

--- a/configs/components/libedit.rb
+++ b/configs/components/libedit.rb
@@ -11,9 +11,8 @@ component 'libedit' do |pkg, settings, platform|
   elsif platform.is_aix?
     pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
     pkg.environment "LDFLAGS", settings[:ldflags]
-  end
-
-  if platform.is_macos?
+  else
+    pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", settings[:cflags]
   end
 

--- a/configs/components/ruby-2.7.8.rb
+++ b/configs/components/ruby-2.7.8.rb
@@ -98,7 +98,15 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
 
   special_flags = " --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
 
-  if platform.name =~ /sles-15|el-8|debian-10/
+  # conditional taken from projects/_shared-compiler-settings
+  # TODO: refactor condition
+  if ((platform.is_sles? && platform.os_version.to_i >= 15) ||
+      (platform.is_el? && platform.os_version.to_i >= 8) ||
+      platform.is_debian? ||
+      (platform.is_ubuntu? && platform.os_version.to_i >= 20) ||
+      (platform.is_amazon? && platform.os_version.to_i >= 2023) ||
+      platform.is_fedora?
+     )
     special_flags += " CFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}' CPPFLAGS='#{settings[:cppflags]}' "
   end
 

--- a/configs/components/ruby-3.2.3.rb
+++ b/configs/components/ruby-3.2.3.rb
@@ -93,7 +93,15 @@ component 'ruby-3.2.3' do |pkg, settings, platform|
 
   special_flags = " --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
 
-  if platform.name =~ /sles-15|el-8|debian-10/
+  # conditional taken from projects/_shared-compiler-settings
+  # TODO: refactor condition
+  if ((platform.is_sles? && platform.os_version.to_i >= 15) ||
+      (platform.is_el? && platform.os_version.to_i >= 8) ||
+      platform.is_debian? ||
+      (platform.is_ubuntu? && platform.os_version.to_i >= 20) ||
+      (platform.is_amazon? && platform.os_version.to_i >= 2023) ||
+      platform.is_fedora?
+     )
     special_flags += " CFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}' CPPFLAGS='#{settings[:cppflags]}' "
   end
 

--- a/configs/components/runtime-bolt.rb
+++ b/configs/components/runtime-bolt.rb
@@ -13,7 +13,7 @@ component "runtime-bolt" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
-  elsif platform.is_macos? or platform.name =~ /sles-15|el-8|debian-10|ubuntu-20.04|ubuntu-22.04/ || platform.is_fedora?
+  elsif platform.is_macos? || (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
 
     # Do nothing for distros that have a suitable compiler do not use pl-build-tools
 

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -152,7 +152,7 @@ proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{
 # stack canary and full RELRO.
 # We only do this on platforms that use their default OS toolchain since pl-gcc versions
 # are too old to support these flags.
-if platform.name =~ /sles-15|el-8|debian-10/ || platform.is_fedora?
+if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
   proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
   proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
   proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -140,23 +140,8 @@ end
 proj.setting(:platform_triple, platform_triple)
 proj.setting(:host, host)
 
-# Define default CFLAGS and LDFLAGS for most platforms, and then
-# tweak or adjust them as needed.
-proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-proj.setting(:cflags, "#{proj.cppflags}")
-proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
-
-# Platform specific overrides or settings, which may override the defaults
-
-# Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
-# stack canary and full RELRO.
-# We only do this on platforms that use their default OS toolchain since pl-gcc versions
-# are too old to support these flags.
-if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
-  proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
-  proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
-  proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
-end
+# Load default compiler settings
+instance_eval File.read('configs/projects/_shared-compiler-settings.rb')
 
 if ruby_version_x == "3"
   proj.setting(:openssl_version, '3.0')

--- a/configs/projects/_shared-client-tools-runtime.rb
+++ b/configs/projects/_shared-client-tools-runtime.rb
@@ -92,20 +92,8 @@ elsif platform.is_windows?
   proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir} -Wl,--nxcompat -Wl,--dynamicbase")
   proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
 else
-  proj.setting(:tools_root, "/opt/pl-build-tools")
-  proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-  proj.setting(:cflags, "#{proj.cppflags}")
-  proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
-
-  # Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
-  # stack canary and full RELRO.
-  # We only do this on platforms that use their default OS toolchain since pl-gcc versions
-  # are too old to support these flags.
-  if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
-    proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
-    proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
-    proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
-  end
+  # Load default compiler settings
+  instance_eval File.read('configs/projects/_shared-compiler-settings.rb')
 end
 
 # What to build?

--- a/configs/projects/_shared-client-tools-runtime.rb
+++ b/configs/projects/_shared-client-tools-runtime.rb
@@ -96,6 +96,16 @@ else
   proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
   proj.setting(:cflags, "#{proj.cppflags}")
   proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+
+  # Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
+  # stack canary and full RELRO.
+  # We only do this on platforms that use their default OS toolchain since pl-gcc versions
+  # are too old to support these flags.
+  if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
+    proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
+    proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
+    proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
+  end
 end
 
 # What to build?

--- a/configs/projects/_shared-compiler-settings.rb
+++ b/configs/projects/_shared-compiler-settings.rb
@@ -1,0 +1,22 @@
+# Define default CFLAGS and LDFLAGS for most platforms, and then
+# tweak or adjust them as needed.
+proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+proj.setting(:cflags, "#{proj.cppflags}")
+proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+
+# Platform specific overrides or settings, which may override the defaults
+
+# Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
+# stack canary and full RELRO.
+# We only do this on platforms that use their default OS toolchain since pl-gcc versions
+# are too old to support these flags.
+if ((platform.is_sles? && platform.os_version.to_i >= 15) ||
+    (platform.is_el? && platform.os_version.to_i >= 8) ||
+    platform.is_debian? ||
+    (platform.is_ubuntu? && platform.os_version.to_i >= 20) ||
+    platform.is_fedora?
+   )
+  proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
+  proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
+  proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
+end

--- a/configs/projects/_shared-compiler-settings.rb
+++ b/configs/projects/_shared-compiler-settings.rb
@@ -14,6 +14,7 @@ if ((platform.is_sles? && platform.os_version.to_i >= 15) ||
     (platform.is_el? && platform.os_version.to_i >= 8) ||
     platform.is_debian? ||
     (platform.is_ubuntu? && platform.os_version.to_i >= 20) ||
+    (platform.is_amazon? && platform.os_version.to_i >= 2023) ||
     platform.is_fedora?
    )
   proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")

--- a/configs/projects/_shared-compiler-settings.rb
+++ b/configs/projects/_shared-compiler-settings.rb
@@ -1,7 +1,7 @@
 # Define default CFLAGS and LDFLAGS for most platforms, and then
 # tweak or adjust them as needed.
 proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-proj.setting(:cflags, "#{proj.cppflags}")
+proj.setting(:cflags, "-frecord-gcc-switches #{proj.cppflags}")
 proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
 
 # Platform specific overrides or settings, which may override the defaults
@@ -18,6 +18,6 @@ if ((platform.is_sles? && platform.os_version.to_i >= 15) ||
     platform.is_fedora?
    )
   proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
-  proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
+  proj.setting(:cflags, '-frecord-gcc-switches -fstack-protector-strong -fno-plt -O2')
   proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
 end

--- a/configs/projects/_shared-pe-bolt-server_with_ruby.rb
+++ b/configs/projects/_shared-pe-bolt-server_with_ruby.rb
@@ -87,7 +87,7 @@ proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{
 # stack canary and full RELRO.
 # We only do this on platforms that use their default OS toolchain since pl-gcc versions
 # are too old to support these flags.
-if platform.name =~ /sles-15|el-8|debian-10/ || platform.is_fedora?
+if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
   proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
   proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
   proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")

--- a/configs/projects/_shared-pe-bolt-server_with_ruby.rb
+++ b/configs/projects/_shared-pe-bolt-server_with_ruby.rb
@@ -75,23 +75,8 @@ proj.setting(:mandir, File.join(proj.datadir, "man"))
 ruby_base_version = proj.ruby_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2.0')
 proj.setting(:gem_home, File.join(proj.libdir, 'ruby', 'gems', ruby_base_version))
 
-# Define default CFLAGS and LDFLAGS for most platforms, and then
-# tweak or adjust them as needed.
-proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-proj.setting(:cflags, "#{proj.cppflags}")
-proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
-
-# Platform specific overrides or settings, which may override the defaults
-
-# Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
-# stack canary and full RELRO.
-# We only do this on platforms that use their default OS toolchain since pl-gcc versions
-# are too old to support these flags.
-if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
-  proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
-  proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
-  proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
-end
+# Load default compiler settings
+instance_eval File.read('configs/projects/_shared-compiler-settings.rb')
 
 # Required to build ruby
 proj.component 'libffi'

--- a/configs/projects/_shared-pe-installer-runtime.rb
+++ b/configs/projects/_shared-pe-installer-runtime.rb
@@ -37,6 +37,16 @@ proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
 proj.setting(:cflags, "#{proj.cppflags}")
 proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
 
+# Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
+# stack canary and full RELRO.
+# We only do this on platforms that use their default OS toolchain since pl-gcc versions
+# are too old to support these flags.
+if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
+  proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
+  proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
+  proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
+end
+
 # These flags are applied in addition to the defaults in configs/component/openssl.rb.
 proj.setting(:openssl_extra_configure_flags, [
   'no-dtls',

--- a/configs/projects/_shared-pe-installer-runtime.rb
+++ b/configs/projects/_shared-pe-installer-runtime.rb
@@ -31,21 +31,8 @@ proj.setting(:gem_install, "#{proj.host_gem} install --no-document --local --bin
 proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
 proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
 
-# Define default CFLAGS and LDFLAGS for most platforms, and then
-# tweak or adjust them as needed.
-proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-proj.setting(:cflags, "#{proj.cppflags}")
-proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
-
-# Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
-# stack canary and full RELRO.
-# We only do this on platforms that use their default OS toolchain since pl-gcc versions
-# are too old to support these flags.
-if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
-  proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
-  proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
-  proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
-end
+# Load default compiler settings
+instance_eval File.read('configs/projects/_shared-compiler-settings.rb')
 
 # These flags are applied in addition to the defaults in configs/component/openssl.rb.
 proj.setting(:openssl_extra_configure_flags, [

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -72,6 +72,16 @@ project 'bolt-runtime' do |proj|
   proj.setting(:cflags, "#{proj.cppflags}")
   proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
 
+  # Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
+  # stack canary and full RELRO.
+  # We only do this on platforms that use their default OS toolchain since pl-gcc versions
+  # are too old to support these flags.
+  if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
+    proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
+    proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
+    proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
+  end
+
   # Platform specific overrides or settings, which may override the defaults
   if platform.is_windows?
     arch = platform.architecture == "x64" ? "64" : "32"

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -66,21 +66,8 @@ project 'bolt-runtime' do |proj|
   proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
   proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
 
-  # Define default CFLAGS and LDFLAGS for most platforms, and then
-  # tweak or adjust them as needed.
-  proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-  proj.setting(:cflags, "#{proj.cppflags}")
-  proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
-
-  # Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
-  # stack canary and full RELRO.
-  # We only do this on platforms that use their default OS toolchain since pl-gcc versions
-  # are too old to support these flags.
-  if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
-    proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
-    proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
-    proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
-  end
+  # Load default compiler settings
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-compiler-settings.rb'))
 
   # Platform specific overrides or settings, which may override the defaults
   if platform.is_windows?

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -111,21 +111,8 @@ project 'pdk-runtime' do |proj|
     proj.setting(:host, "--host #{platform.platform_triple}")
   end
 
-  # Define default CFLAGS and LDFLAGS for most platforms, and then
-  # tweak or adjust them as needed.
-  proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-  proj.setting(:cflags, proj.cppflags.to_s)
-  proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
-
-  # Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
-  # stack canary and full RELRO.
-  # We only do this on platforms that use their default OS toolchain since pl-gcc versions
-  # are too old to support these flags.
-  if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
-    proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
-    proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
-    proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
-  end
+  # Load default compiler settings
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-compiler-settings.rb'))
 
   if platform.is_windows?
     proj.setting(:gcc_root, 'C:/tools/mingw64')

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -117,6 +117,16 @@ project 'pdk-runtime' do |proj|
   proj.setting(:cflags, proj.cppflags.to_s)
   proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
 
+  # Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
+  # stack canary and full RELRO.
+  # We only do this on platforms that use their default OS toolchain since pl-gcc versions
+  # are too old to support these flags.
+  if (platform.is_sles? && platform.os_version.to_i >= 15) || (platform.is_el? && platform.os_version.to_i >= 8) || platform.is_debian? || (platform.is_ubuntu? && platform.os_version.to_i >= 20) || platform.is_fedora?
+    proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
+    proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
+    proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
+  end
+
   if platform.is_windows?
     proj.setting(:gcc_root, 'C:/tools/mingw64')
     proj.setting(:gcc_bindir, "#{proj.gcc_root}/bin")


### PR DESCRIPTION
Had a rough version of this patch stashed away. Intends to addresses #819

- [x] [agent-runtime-7.x](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1517/)
- [x] [agent-runtime-main](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1514/)
- [x] [bolt-runtime](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1518/)
- [ ] pdk-runtime
- [ ] client-tools-runtime-2021.7.x
- [ ] client-tools-runtime-main
- [ ] pe-bolt-server-runtime-2021.7.x
- [ ] pe-bolt-server-runtime-main
- [ ] pe-installer-runtime-2021.7.x
- [ ] pe-installer-runtime-main