### PR TITLE
(maint) Use packaged libxml to build nokogiri on MacOS

### DIFF
--- a/configs/components/_base-rubygem.rb
+++ b/configs/components/_base-rubygem.rb
@@ -37,6 +37,15 @@ end
 pkg.url("https://rubygems.org/downloads/#{name}-#{version}.gem")
 pkg.mirror("#{settings[:buildsources_url]}/#{name}-#{version}.gem")
 
-pkg.install do
-  "#{settings[:gem_install]} #{name}-#{version}.gem"
+# If a gem needs more command line options to install set the :gem_install_options
+# in its component file rubygem-<compoment>, before the instance_eval of this file.
+if settings[:gem_install_options].nil?
+  pkg.install do
+    "#{settings[:gem_install]} #{name}-#{version}.gem"
+  end
+else
+  pkg.install do
+    "#{settings[:gem_install]} #{name}-#{version}.gem #{settings[:gem_install_options]}"
+  end
 end
+

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -1,18 +1,24 @@
 component 'rubygem-nokogiri' do |pkg, _settings, _platform|
   pkg.version '1.14.2'
   pkg.sha256sum 'c765a74aac6cf430a710bb0b6038b8ee11f177393cd6ae8dadc7a44a6e2658b6'
+  # On macOS when we are not cross compiling we need to use runtime's libxml2 and libxslt
+  if platform.is_macos? && !platform.is_cross_compiled?
+    settings[:gem_install_options] = "-- --use-system-libraries \
+        --with-xml2-lib=#{settings[:libdir]} \
+        --with-xml2-include=#{settings[:includedir]}/libxml2 \
+        --with-xslt-lib=#{settings[:libdir]} \
+        --with-xslt-include=#{settings[:includedir]}"
+  end
   instance_eval File.read('configs/components/_base-rubygem.rb')
-
   pkg.build_requires 'rubygem-mini_portile2'
-
   gem_home = settings[:gem_home]
   pkg.environment "GEM_HOME", gem_home
-
-  # When cross compiling nokogiri native extensions on macOS 11/12 ARM, there is a 94M tmp
-  # directory that's not needed
-  if platform.is_macos? && platform.architecture == 'arm64'
-    install do
-      "rm -r #{gem_home}/gems/nokogiri-#{pkg.get_version}/ext/nokogiri/tmp"
+  if platform.is_macos?
+    pkg.environment "PKG_CONFIG_PATH", "#{settings[:libdir]}/pkgconfig"
+    if platform.is_cross_compiled?
+      pkg.install do
+        "rm -r #{gem_home}/gems/nokogiri-#{pkg.get_version}/ext/nokogiri/tmp"
+      end
     end
   end
 end


### PR DESCRIPTION
This PR changes the gem install command for the Nokogiri gem. Currently when building nokogiri it uses the system libxml2 and libxslt. We now will pass in an option in the `gem install` command to use the expected libraries.