### PR TITLE
(PA-6260) Add Amazon Linux2 ARM in puppet-runtime build 7.x

### DIFF
--- a/configs/platforms/amazon-7-aarch64.rb
+++ b/configs/platforms/amazon-7-aarch64.rb
@@ -1,0 +1,15 @@
+platform 'amazon-7-aarch64' do |plat|
+  plat.inherit_from_default
+
+  packages = %w[
+    perl-FindBin
+    perl-lib
+    readline-devel
+    systemtap-sdt-devel
+    zlib-devel
+  ]
+
+  plat.provision_with "yum install -y #{packages.join(' ')}"
+  plat.install_build_dependencies_with 'yum install --assumeyes'
+  plat.vmpooler_template 'amazon-7-arm64'
+end


### PR DESCRIPTION
Enabled AL2 arm for puppet-runtime