### PR TITLE
Disable nghttp2 explicitly

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -79,6 +79,7 @@ component 'curl' do |pkg, settings, platform|
         --disable-ldaps \
         --with-ca-bundle=#{settings[:prefix]}/ssl/cert.pem \
         --with-ca-path=#{settings[:prefix]}/ssl/certs \
+        --without-nghttp2 \
         CFLAGS='#{settings[:cflags]} #{extra_cflags.join(" ")}' \
         #{settings[:host]}"]
   end


### PR DESCRIPTION
After commit 9a62dd5, curl 8 on AIX was adding a runtime dependency on libnghttp2 because the library happened to be present in /opt/freeware/lib:

    # ldd /opt/puppetlabs/puppet/bin/curl
    /opt/puppetlabs/puppet/bin/curl needs:
         /usr/lib/libc.a(shr.o)
         /usr/lib/libpthreads.a(shr_xpg5.o)
         /opt/puppetlabs/puppet/lib/libcurl.a(libcurl.so.4)
         /opt/puppetlabs/puppet/lib/libz.a(libz.so.1)
    Cannot find libnghttp2.a(libnghttp2.so.14)

However, libnghttp2 is not a runtime component nor is it redistributed with the agent, so curl would fail to load:

	exec(): 0509-036 Cannot load program curl because of the following errors:
		0509-150   Dependent module libnghttp2.a(libnghttp2.so.14) could not be loaded.
		0509-022 Cannot load module libnghttp2.a(libnghttp2.so.14).
		0509-026 System error: A file or directory in the path name does not exist.

Since we don't enable nghttp2 on other platforms, explicitly disable it so we're not sensitive to build host differences.

Note curl uses enable/disable for optional features like ldap, but with/without for optional packages like nghttp2.

- [x] [agent-runtime-main](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2854/)