### PR TITLE
Remove unused mingw package

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -24,7 +24,6 @@ platform "windows-2012r2-x64" do |plat|
     "pl-toolchain-#{self._platform.architecture}",
     "pl-zlib-#{self._platform.architecture}",
     "mingw-w64 -version 5.2.0 -debug",
-    "mingw",
     "Wix310 -version 3.10.2 -debug -x86"
   ]
 


### PR DESCRIPTION
Commit aea5e889c3e4344549af63573d5444e7f3f572db added mingw on windows-2012r2-x64 (only) for bootsnap (in bolt). Later the bootsnap changes were removed 65fd77a9d59993068cae3f9ab89a6e9a5bfec876 but the mingw package was not removed. As a result, we've continued to install the package:

    mingw v8.1.0
    mingw package files install completed. Performing other installation steps.
    Downloading mingw 64 bit from 'https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z/download'
    Download of x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z (47.08 MB) completed.
    Hashes match.
    Extracting C:\Users\Administrator\chocolatey\mingw\8.1.0\x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z to C:\ProgramData\chocolatey\lib\mingw\tools\install...

We don't actully need mingw, as the structured exception handling libraries are implemented in the mingw-w64 we've already installed:

    Running Install-ChocolateyZipPackage -packageName 'mingw-w64' -url 'C:\ProgramData\chocolatey\lib\mingw-w64\tools\x86_64-5.2.0-release-win32-seh-rt_v4-rev0.7z' -unzipLocation 'C:\tools'