### PR TITLE
(PA-6350) Enable agent-runtime main builds for fedora 40 Intel

### DIFF
--- a/configs/components/_base-ruby-augeas.rb
+++ b/configs/components/_base-ruby-augeas.rb
@@ -5,6 +5,9 @@
 
 pkg.add_source("file://resources/patches/augeas/ruby-augeas-0.5.0-patch_c_extension.patch")
 
+# We can remove the below patch after https://github.com/hercules-team/ruby-augeas/pull/17 is merged.
+pkg.add_source("file://resources/patches/augeas/ruby-augeas-0.5.0-patch_remove_unused_parameter.patch")
+
 # These can be overridden by the including component.
 ruby_version ||= settings[:ruby_version]
 host_ruby ||= settings[:host_ruby]
@@ -75,6 +78,7 @@ pkg.build do
   if ruby_version =~ /^3/
     build_commands << "#{platform.patch} --strip=2 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../ruby-augeas-0.5.0-patch_c_extension.patch"
   end
+  build_commands << "#{platform.patch} --strip=2 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../ruby-augeas-0.5.0-patch_remove_unused_parameter.patch"
   build_commands << "#{ruby} ext/augeas/extconf.rb"
   build_commands << "#{platform[:make]} -e -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"
 

--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -78,7 +78,7 @@ pkg.build do
 
   if ruby_version =~ /^3/
     # swig 4.1 generated interface does not need patching
-    unless platform.name =~ /^(debian-12|ubuntu-24)/
+    unless platform.name =~ /^(debian-12|ubuntu-24|fedora-40)/
       steps << "#{platform.patch} --strip=0 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../selinuxswig_ruby_wrap.patch"
     end
   end

--- a/configs/platforms/fedora-40-x86_64.rb
+++ b/configs/platforms/fedora-40-x86_64.rb
@@ -1,0 +1,3 @@
+platform 'fedora-40-x86_64' do |plat|
+  plat.inherit_from_default
+end

--- a/resources/patches/augeas/ruby-augeas-0.5.0-patch_remove_unused_parameter.patch
+++ b/resources/patches/augeas/ruby-augeas-0.5.0-patch_remove_unused_parameter.patch
@@ -1,0 +1,12 @@
+diff --git a/ext/augeas/_augeas.c b/ext/augeas/_augeas.c
+index f9b49d1..7ef0d7d 100644
+--- a/ruby-augeas-0.5.0/ext/augeas/_augeas.c
++++ b/ruby-augeas-0.5.0/ext/augeas/_augeas.c
+@@ -184,7 +184,7 @@ VALUE augeas_mv(VALUE s, VALUE src, VALUE dst) {
+  *
+  * Remove path and all its children. Returns the number of entries removed
+  */
+-VALUE augeas_rm(VALUE s, VALUE path, VALUE sibling) {
++VALUE augeas_rm(VALUE s, VALUE path) {
+     augeas *aug = aug_handle(s);
+     const char *cpath = StringValueCStr(path) ;


### PR DESCRIPTION
 - Add Fedora 40 (Intel) platform definition file
 - Patch swig generated interface patch for Fedora 40
 - Apply ruby-augeas patch to remove unused sibling parameter for all platform building ruby-augeas. It breaks Fedora 40 and generates a warning for other platforms.