### PR TITLE
(PA-6259) openssl error Can't locate IPC/Cmd.pm

### DIFF
--- a/configs/platforms/amazon-7-aarch64.rb
+++ b/configs/platforms/amazon-7-aarch64.rb
@@ -4,6 +4,7 @@ platform 'amazon-7-aarch64' do |plat|
   packages = %w[
     perl-FindBin
     perl-lib
+    perl-IPC-Cmd
     readline-devel
     systemtap-sdt-devel
     zlib-devel


### PR DESCRIPTION
While constructing agent-runtime-main for Amazon-7-aarch, I encountered an obstacle during the OpenSSL 3.0.1 build process. Through online research, I discovered that adding perl-IPC-Cmd resolves this issue.
[vanagon build main](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=amazon-7-aarch64,SLAVE_LABEL=k8s-worker/2900/consoleFull)