### PR TITLE
Revert "Add curl 8.7.1 and configure agent-runtime-main to use it"

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -1,17 +1,6 @@
 component 'curl' do |pkg, settings, platform|
-  # Projects may define a :curl_version setting
-  version = settings[:curl_version] || '7.88.1'
-  pkg.version version
-
-  case version
-  when '7.88.1'
-    pkg.sha256sum 'cdb38b72e36bc5d33d5b8810f8018ece1baa29a8f215b4495e495ded82bbf3c7'
-  when '8.7.1'
-    pkg.sha256sum 'f91249c87f68ea00cf27c44fdfa5a78423e41e71b7d408e5901a9896d905c495'
-  else
-    raise "curl version #{version} has not been configured; Cannot continue."
-  end
-
+  pkg.version '7.88.1'
+  pkg.sha256sum 'cdb38b72e36bc5d33d5b8810f8018ece1baa29a8f215b4495e495ded82bbf3c7'
   pkg.url "https://curl.se/download/curl-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/curl-#{pkg.get_version}.tar.gz"
 
@@ -37,17 +26,15 @@ component 'curl' do |pkg, settings, platform|
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
   end
 
-  # Following lines should we removed once we drop curl 7
-  if version.start_with?('7')
-    pkg.apply_patch 'resources/patches/curl/CVE-2023-27535.patch'
-    pkg.apply_patch 'resources/patches/curl/CVE-2023-28319.patch'
-    pkg.apply_patch 'resources/patches/curl/CVE-2023-32001.patch'
-    pkg.apply_patch 'resources/patches/curl/CVE-2023-38545.patch'
-    pkg.apply_patch 'resources/patches/curl/CVE-2023-38546.patch'
-    pkg.apply_patch 'resources/patches/curl/CVE-2023-46218.patch'
-    pkg.apply_patch 'resources/patches/curl/CVE-2024-2004.patch'
-    pkg.apply_patch 'resources/patches/curl/CVE-2024-2398.patch'
-  end
+  # Following 3 lines should we removed once we upgrade CURL to 8.x.x
+  pkg.apply_patch 'resources/patches/curl/CVE-2023-27535.patch'
+  pkg.apply_patch 'resources/patches/curl/CVE-2023-28319.patch'
+  pkg.apply_patch 'resources/patches/curl/CVE-2023-32001.patch'
+  pkg.apply_patch 'resources/patches/curl/CVE-2023-38545.patch'
+  pkg.apply_patch 'resources/patches/curl/CVE-2023-38546.patch'
+  pkg.apply_patch 'resources/patches/curl/CVE-2023-46218.patch'
+  pkg.apply_patch 'resources/patches/curl/CVE-2024-2004.patch'
+  pkg.apply_patch 'resources/patches/curl/CVE-2024-2398.patch'
 
   configure_options = []
   configure_options << "--with-ssl=#{settings[:prefix]}"

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -14,8 +14,6 @@ project 'agent-runtime-main' do |proj|
     proj.setting :augeas_version, '1.14.1'
   end
 
-  proj.setting :curl_version, '8.7.1'
-
   ########
   # Load shared agent settings
   ########

--- a/resources/patches/curl/curl-7.55.1-aix-poll.patch
+++ b/resources/patches/curl/curl-7.55.1-aix-poll.patch
@@ -1,0 +1,40 @@
+From 44b69e23fb7522e1e0d6052c4d379715f9aa6447 Mon Sep 17 00:00:00 2001
+From: Michael Smith <michael.smith@puppet.com>
+Date: Thu, 24 Aug 2017 16:43:01 -0700
+Subject: [PATCH] Compilation fails on AIX with 7.55.1 (#1828)
+
+Compilation fails on multi.c. The root of it is that on AIX, when
+_ALL_SOURCE is set to 1 (as CURL does), sys/poll.h uses #define for
+event and revent. Because multi.c includes sys/poll.h but multi.h
+doesn't, we end up with a mismatch between names for the curl_waitfd
+struct.
+
+Previously this appears to have built with curl 7.51.0 because multi.h
+also included sys/poll.h, so they were equally wrong. Based on
+https://curl.haxx.se/mail/lib-2013-02/0330.html, this appears to have
+been an issue off-and-on for years.
+
+My workaround has been to undef _ALL_SOURCE before including select.h in
+multi.c, and redefine it after. This probably isn't a good general
+solution.
+---
+ lib/multi.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/multi.c b/lib/multi.c
+index d5bc532ea..ecc00d3af 100644
+--- a/lib/multi.c
++++ b/lib/multi.c
+@@ -35,7 +35,9 @@
+ #include "sendf.h"
+ #include "timeval.h"
+ #include "http.h"
++#undef _ALL_SOURCE
+ #include "select.h"
++#define _ALL_SOURCE 1
+ #include "warnless.h"
+ #include "speedcheck.h"
+ #include "conncache.h"
+-- 
+2.14.1
+


### PR DESCRIPTION
Reverts puppetlabs/puppet-runtime#816

We're seeing failures with the curl package on MacOS-12-ARM, details are in PA-6387, related to cross compiling. 