### PR TITLE
Use cmake3 for Amazon Linux 2

### DIFF
--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -4,9 +4,13 @@ component "yaml-cpp" do |pkg, settings, platform|
 
   # Build-time Configuration
   cmake_toolchain_file = ''
-  cmake = '/usr/bin/cmake'
   make = 'make'
   mkdir = 'mkdir'
+  cmake = if platform.name =~ /amazon-7-aarch64/
+    '/usr/bin/cmake3'
+  else
+    'cmake'
+  end
 
   if platform.is_cross_compiled_linux?
     # We're using the x86_64 version of cmake


### PR DESCRIPTION
Upstream in Vanagon in puppetlabs/vanagon@055c817, we changed Amazon Linux 2 to use the cmake3 package instead of cmake.

This commit adds a case to the yaml-cpp component to refer to cmake3 when building on AL2 instead of cmake.