### PR TITLE
Set Mend branch to master

### DIFF
--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -3,8 +3,7 @@ name: Mend Monitor
 on:
   push:
     branches:
-      - 7.x
-      - main
+      - master
 jobs:
   mend_monitor:
     if: ${{ github.repository_owner == 'puppetlabs' }}
@@ -33,4 +32,3 @@ jobs:
           WS_USERKEY: ${{ secrets.MEND_TOKEN }}
           WS_PRODUCTNAME: Puppet Agent
           WS_PROJECTNAME: ${{ github.event.repository.name }}
-


### PR DESCRIPTION
Previously, the Mend action referenced 7.x and main branches. These branches do not exist in this repository and were likely copied over from the puppet or puppet-agent repositories.

This commit updates Mend to reference the master branch, which is the default branch for puppet-runtime.