### PR TITLE
(CAT-1871) Add `strscan` as a PDK dependency for windows.

### DIFF
--- a/configs/components/rubygem-strscan.rb
+++ b/configs/components/rubygem-strscan.rb
@@ -1,0 +1,6 @@
+component "rubygem-strscan" do |pkg, settings, platform|
+  pkg.version "3.1.0"
+  pkg.sha256sum '01b8a81d214fbf7b5308c6fb51b5972bbfc4a6aa1f166fd3618ba97e0fcd5555'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/_pdk-components.rb
+++ b/configs/projects/_pdk-components.rb
@@ -70,6 +70,7 @@ proj.component 'rubygem-cri'
 # Childprocess and deps
 proj.component 'rubygem-childprocess'
 proj.component 'rubygem-hitimes'
+proj.component 'rubygem-strscan' if platform.is_windows?
 
 ## tty-reader and deps
 proj.component 'rubygem-tty-screen'
@@ -93,8 +94,8 @@ proj.component 'rubygem-json-schema'
 
 # Other deps
 proj.component 'rubygem-deep_merge'
-proj.component 'rubygem-json_pure'
 proj.component 'rubygem-diff-lcs'
+proj.component 'rubygem-json_pure'
 proj.component 'rubygem-pathspec'
 
 proj.component 'ansicon' if platform.is_windows?


### PR DESCRIPTION
The PDK Build step for windows is currently hitting an error related to `strscan`