### PR TITLE
(PA-6386) Patch Ruby for CVE-2024-27282

### DIFF
--- a/configs/components/ruby-2.7.8.rb
+++ b/configs/components/ruby-2.7.8.rb
@@ -38,6 +38,7 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
   base = 'resources/patches/ruby_27'
   # Patch for https://bugs.ruby-lang.org/issues/14972
   pkg.apply_patch "#{base}/net_http_eof_14972_r2.5.patch"
+  pkg.apply_patch "#{base}/regexp_use_after_free.patch"
 
   pkg.apply_patch "#{base}/uri-redos-cve-2023-36617.patch"
 

--- a/configs/components/ruby-3.2.3.rb
+++ b/configs/components/ruby-3.2.3.rb
@@ -37,6 +37,7 @@ component 'ruby-3.2.3' do |pkg, settings, platform|
   #########
 
   base = 'resources/patches/ruby_32'
+  pkg.apply_patch "#{base}/regexp_use_after_free.patch"
 
   if platform.is_cross_compiled?
     pkg.apply_patch "#{base}/rbinstall_gem_path.patch"

--- a/resources/patches/ruby_27/regexp_use_after_free.patch
+++ b/resources/patches/ruby_27/regexp_use_after_free.patch
@@ -1,0 +1,13 @@
+diff --git a/regexec.c b/regexec.c
+index 73694ab14a..140691ad42 100644
+--- a/regexec.c
++++ b/regexec.c
+@@ -3449,8 +3449,8 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+     CASE(OP_MEMORY_END_PUSH_REC)  MOP_IN(OP_MEMORY_END_PUSH_REC);
+       GET_MEMNUM_INC(mem, p);
+       STACK_GET_MEM_START(mem, stkp); /* should be before push mem-end. */
+-      STACK_PUSH_MEM_END(mem, s);
+       mem_start_stk[mem] = GET_STACK_INDEX(stkp);
++      STACK_PUSH_MEM_END(mem, s);
+       MOP_OUT;
+       JUMP;

--- a/resources/patches/ruby_32/regexp_use_after_free.patch
+++ b/resources/patches/ruby_32/regexp_use_after_free.patch
@@ -1,0 +1,13 @@
+diff --git a/regexec.c b/regexec.c
+index 73694ab14a..140691ad42 100644
+--- a/regexec.c
++++ b/regexec.c
+@@ -3449,8 +3449,8 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+     CASE(OP_MEMORY_END_PUSH_REC)  MOP_IN(OP_MEMORY_END_PUSH_REC);
+       GET_MEMNUM_INC(mem, p);
+       STACK_GET_MEM_START(mem, stkp); /* should be before push mem-end. */
+-      STACK_PUSH_MEM_END(mem, s);
+       mem_start_stk[mem] = GET_STACK_INDEX(stkp);
++      STACK_PUSH_MEM_END(mem, s);
+       MOP_OUT;
+       JUMP;


### PR DESCRIPTION
 - Patches the ruby 'Use-After-Free' issue for regexp.
 - Upstream fix commit: https://github.com/ruby/ruby/commit/90b194b5e3fe793c1ed895a4522675845181e6fd