### PR TITLE
Rename amazon 7 to 2

### DIFF
--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -6,7 +6,7 @@ component "yaml-cpp" do |pkg, settings, platform|
   cmake_toolchain_file = ''
   make = 'make'
   mkdir = 'mkdir'
-  cmake = if platform.name =~ /amazon-7-aarch64/
+  cmake = if platform.name =~ /amazon-2-aarch64/
     '/usr/bin/cmake3'
   else
     'cmake'

--- a/configs/platforms/amazon-2-aarch64.rb
+++ b/configs/platforms/amazon-2-aarch64.rb
@@ -1,4 +1,4 @@
-platform 'amazon-7-aarch64' do |plat|
+platform 'amazon-2-aarch64' do |plat|
   plat.inherit_from_default
 
   packages = %w[


### PR DESCRIPTION
Amazon 7 is an implementation detail, the actual OS is named Amazon 2

~Blocked on https://github.com/puppetlabs/vanagon/pull/855~

Generic Builder with packaging 0.120.0 and vanagon 0.52.0: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3003/BUILD_TARGET=amazon-2-aarch64,SLAVE_LABEL=k8s-worker/