### PR TITLE
(PA-6549) Fix warning:undefining the allocator of T_DATA class

### DIFF
--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -4,6 +4,7 @@
 #
 
 pkg.add_source("file://resources/patches/ruby-selinux/selinuxswig_ruby_wrap.patch")
+pkg.add_source("file://resources/patches/ruby-selinux/selinuxswig_ruby_undefining_allocator.patch")
 
 # These can be overridden by the including component.
 ruby_version ||= settings[:ruby_version]
@@ -81,6 +82,7 @@ pkg.build do
     unless platform.name =~ /^(debian-12|ubuntu-24|fedora-40)/
       steps << "#{platform.patch} --strip=0 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../selinuxswig_ruby_wrap.patch"
     end
+    steps << "#{platform.patch} --strip=0 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < ../selinuxswig_ruby_undefining_allocator.patch"
   end
 
   # libselinux 3.3 is the minimum version we want to build on RHEL 9, but the

--- a/resources/patches/ruby-selinux/selinuxswig_ruby_undefining_allocator.patch
+++ b/resources/patches/ruby-selinux/selinuxswig_ruby_undefining_allocator.patch
@@ -1,0 +1,10 @@
+--- selinuxswig_ruby_wrap.c.orig	2024-06-11 20:02:30.112707265 +0000
++++ selinuxswig_ruby_wrap.c	2024-06-11 22:34:16.000151780 +0000
+@@ -1510,7 +1510,7 @@
+     _cSWIG_Pointer = rb_define_class_under(_mSWIG, "Pointer", rb_cObject);
+     rb_undef_method(CLASS_OF(_cSWIG_Pointer), "new");
+   }
+-  rb_define_class_under(_mSWIG, klass_name, _cSWIG_Pointer);
++  rb_undef_alloc_func(rb_define_class_under(_mSWIG, klass_name, _cSWIG_Pointer));
+   free((void *) klass_name);
+ }


### PR DESCRIPTION
After puppetlabs/puppet#9349 was merged the
       `warning: undefining the allocator of T_DATA class SWIG::TYPE_p_selabel_handle`
error popped up again on RHEL-8 x86_64.

We ran into this previously and thought puppetlabs/puppet-runtime#620 fixed it completely. This issue was completely fixed in swig 4.2.0+.

This commit patches selinuxswig_ruby_wrap.c with swig/swig@aa21014 and is applied after the patch from puppetlabs/puppet-runtime#620 since the fix in swig/swig@aa21014 came after.