### PR TITLE
(maint) Bump Aix-7.1's xz to 5.4.3

### DIFF
--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -42,7 +42,7 @@ tar xvf openssl-1.0.2.1800.tar;
 cd openssl-1.0.2.1800 && /usr/sbin/installp -acgwXY -d $PWD openssl.base;
 curl --output yum.sh https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/aix-yum.sh && sh yum.sh;
 /opt/freeware/bin/sed -i 's|https://anonymous:anonymous@public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS|https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS|' /opt/freeware/etc/yum/yum.conf;
-yum install -y gcc8-c++ xz-5.2.5;
+yum install -y gcc8-c++ xz-5.4.3;
 ln -sf /opt/freeware/lib/gcc/powerpc-ibm-aix7.1.0.0/8/libgcc_s.a /opt/freeware/lib/libgcc_s.a]
 
   # We use --force with rpm because the pl-gettext and pl-autoconf


### PR DESCRIPTION
Libxml2 requires XZ, previously we were installing libxml2 version 2.10.4 which allowed older versions of XZ.
Now agent-runtime-7.x for AIX 7.1 attempts to install LibXML2 version 2.12.6 which requires a newer xz version of then the 2.5.4 we install on AIX 7.1. This commit updates the xz we install for agent-runtime-7.x for AIX from 5.2.4 to 5.4.3.