### PR TITLE
Add minitar rubygem on AIX

### DIFF
--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -60,10 +60,10 @@ proj.component 'rubygem-text'
 proj.component 'rubygem-locale'
 proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
+proj.component 'rubygem-ffi'
 
 if platform.is_windows? || platform.is_solaris?
   proj.component 'rubygem-minitar'
-  proj.component 'rubygem-ffi'
 end
 
 if platform.is_macos?

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -62,7 +62,7 @@ proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
 proj.component 'rubygem-ffi'
 
-if platform.is_windows? || platform.is_solaris?
+if platform.is_windows? || platform.is_solaris? || platform.is_aix?
   proj.component 'rubygem-minitar'
 end
 

--- a/configs/projects/agent-runtime-7.x.rb
+++ b/configs/projects/agent-runtime-7.x.rb
@@ -54,7 +54,6 @@ project 'agent-runtime-7.x' do |proj|
   # When adding components to this list, please
   # add them to pe-installer-runtime-main as well
   proj.component 'rubygem-concurrent-ruby'
-  proj.component 'rubygem-ffi'
   proj.component 'rubygem-multi_json'
   proj.component 'rubygem-optimist'
   proj.component 'rubygem-highline'

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -56,7 +56,6 @@ project 'agent-runtime-main' do |proj|
   # When adding components to this list, please
   # add them to pe-installer-runtime-main as well
   proj.component 'rubygem-concurrent-ruby'
-  proj.component 'rubygem-ffi'
   proj.component 'rubygem-multi_json'
   proj.component 'rubygem-optimist'
   proj.component 'rubygem-highline'


### PR DESCRIPTION
The puppet module install command assumes tar is GNUtar, which doesn't
work on AIX. Install minitar on AIX like we do for Windows and Solaris.

This relates to https://github.com/puppetlabs/puppet/pull/9387#discussion_r1643631563

Built https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3018/BUILD_TARGET=aix-7.2-ppc,SLAVE_LABEL=k8s-worker/

```
14:19:04 export GEM_HOME="/opt/puppetlabs/puppet/lib/ruby/gems/3.2.0" && \
14:19:04 export GEM_PATH="/opt/puppetlabs/puppet/lib/ruby/gems/3.2.0" && \
14:19:04 export RUBYLIB="/opt/puppetlabs/puppet/lib/ruby/vendor_ruby:" && \
14:19:04 cd ./ && \
14:19:04 /opt/puppetlabs/puppet/bin/gem install --no-document --local minitar-0.9.gem
14:19:05 The `minitar` executable is no longer bundled with `minitar`. If you are
14:19:05 expecting this executable, make sure you also install `minitar-cli`.
14:19:05 Successfully installed minitar-0.9
14:19:05 1 gem installed
```