### PR TITLE
(CAT-1869) - Add puppet-modulebuilder to pdk bundled gems

### DIFF
--- a/configs/components/rubygem-puppet-modulebuilder.rb
+++ b/configs/components/rubygem-puppet-modulebuilder.rb
@@ -1,0 +1,6 @@
+component 'rubygem-puppet-modulebuilder' do |pkg, settings, platform|
+  pkg.version '1.0.0'
+  pkg.sha256sum 'cf9d9e8146aeae780b7c61f30847a4cb631debcf708c21281976d5ed79820cfd'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/_pdk-components.rb
+++ b/configs/projects/_pdk-components.rb
@@ -91,6 +91,9 @@ proj.component 'rubygem-public_suffix'
 proj.component 'rubygem-addressable'
 proj.component 'rubygem-json-schema'
 
+# PDK build
+proj.component 'rubygem-puppet-modulebuilder'
+
 # Other deps
 proj.component 'rubygem-deep_merge'
 proj.component 'rubygem-json_pure'


### PR DESCRIPTION
This PR adds the puppet-modulebuilder gem to the gems bundled with the pdk. This gem is now required for the module build functionality.