### PR TITLE
Switch to Ruby 3.3 for GitHub Actions

### DIFF
--- a/.github/workflows/component_diff_check.yaml
+++ b/.github/workflows/component_diff_check.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install ruby version ${{ matrix.cfg.ruby }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
 
       - name: Bundle project
         run: |

--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
       - name: Create lock
         run: bundle lock
       - uses: actions/setup-java@v3

--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Ruby version 3.2
+      - name: Install Ruby version 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
       - name: Update rubygems and install gems
         run: |
           gem update --system --silent --no-document


### PR DESCRIPTION
This commit updates Ruby from 3.2 to 3.3 in our GitHub Actions. The latest Ubuntu 22.04 runner image from GitHub has started causing errors in our builds, possibly due to the new inclusion of Ruby 3.2 in the base image.