### PR TITLE
(PA-6283) Patch stringio in Ruby 2.7 for CVE-2024-27280

### DIFF
--- a/configs/components/ruby-2.7.8.rb
+++ b/configs/components/ruby-2.7.8.rb
@@ -41,6 +41,7 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
   pkg.apply_patch "#{base}/regexp_use_after_free.patch"
 
   pkg.apply_patch "#{base}/uri-redos-cve-2023-36617.patch"
+  pkg.apply_patch "#{base}/stringio_cve-2024-27280.patch"
 
   if platform.is_cross_compiled?
     unless platform.is_macos?

--- a/resources/patches/ruby_27/stringio_cve-2024-27280.patch
+++ b/resources/patches/ruby_27/stringio_cve-2024-27280.patch
@@ -1,0 +1,24 @@
+Backport of:
+
+From c58c5f54f1eab99665ea6a161d29ff6a7490afc8 Mon Sep 17 00:00:00 2001
+From: Nobuyoshi Nakada <nobu@ruby-lang.org>
+Date: Tue, 16 Nov 2021 17:39:32 +0900
+Subject: [PATCH] [ruby/stringio] Fix expanding size at ungetc/ungetbyte
+
+https://github.com/ruby/stringio/commit/a35268a3ac
+---
+ ext/stringio/stringio.c        |  2 +-
+ test/stringio/test_stringio.rb | 25 +++++++++++++++++++++----
+ 2 files changed, 22 insertions(+), 5 deletions(-)
+
+--- a/ext/stringio/stringio.c
++++ b/ext/stringio/stringio.c
+@@ -983,7 +983,7 @@ strio_unget_bytes(struct StringIO *ptr,
+     len = RSTRING_LEN(str);
+     rest = pos - len;
+     if (cl > pos) {
+-	long ex = (rest < 0 ? cl-pos : cl+rest);
++	long ex = cl - (rest < 0 ? pos : len);
+ 	rb_str_modify_expand(str, ex);
+ 	rb_str_set_len(str, len + ex);
+ 	s = RSTRING_PTR(str);


### PR DESCRIPTION
 - Upstream fix commit: https://github.com/ruby/stringio/commit/a35268a3ac -