### PR TITLE
(PA-6507) Update gem rexml from default to 3.2.9 for CVE-2024-35176

### DIFF
--- a/configs/components/rubygem-rexml.rb
+++ b/configs/components/rubygem-rexml.rb
@@ -1,6 +1,14 @@
 component 'rubygem-rexml' do |pkg, settings, platform|
-  pkg.version '3.2.6'
-  pkg.md5sum 'a57288ae5afed07dd08c9f1302da7b25'
+  pkg.version '3.2.9'
+  pkg.md5sum '73fcf4d686d68dafbca57f941097ebf0'
 
+  # If the platform is solaris with sparc architecture in agent-runtime-7.x project, we want to gem install rexml
+  # ignoring the dependencies, this is because the pl-ruby version used in these platforms is ancient so it gets
+  # confused when installing rexml. It tries to install rexml's dependency 'strscan' by building native extensions
+  # but fails. We can ignore insalling that since strscan is already shipped with ruby 2.7.8 as its default gem.
+  if platform.name =~ /solaris-(10|11)-sparc/ && settings[:ruby_version].to_i < 3
+    settings["#{pkg.get_name}_gem_install_options".to_sym] = "--ignore-dependencies"
+  end
+  
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -61,6 +61,7 @@ proj.component 'rubygem-locale'
 proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
 proj.component 'rubygem-ffi'
+proj.component 'rubygem-rexml'
 
 if platform.is_windows? || platform.is_solaris? || platform.is_aix?
   proj.component 'rubygem-minitar'


### PR DESCRIPTION
 - The CVE was fixed from rexml version 3.2.7.
 - Patching for the CVE wasn't getting applied cleanly and had a lot of conflicts. So updated the gem version to 3.2.9 in the rexml component file.
 - rexml 3.2.7 requires strscan >= 3.0.9 which contains native extensions. We would need a compiler to build the extensions and there are jruby incompatibilities. This requirement has been relaxed starting from rexml 3.2.9. Therefore we update to rexml 3.2.9 here.
 - Added the change to _shared-agent-components since the CVE impacts both agent-runtime-main (ruby 3.2.4 using rexml 3.2.6) and agent-runtime-7.x (ruby 2.7.8 using rexml 3.2.3)
 - For solaris-10-sparc and solaris-11-sparc, we ignore dependency when installing rexml since the ruby in these platforms tries to install strscan (rexml's dependency) but fails while building native extensions. We can ignore installing strscan since it is shipped with ruby 2.7.8 as its default gem.