### PR TITLE
Revert "(PA-6507) Update gem rexml from default to 3.2.9 for CVE-2024-35176"

### DIFF
--- a/configs/components/rubygem-rexml.rb
+++ b/configs/components/rubygem-rexml.rb
@@ -1,14 +1,6 @@
 component 'rubygem-rexml' do |pkg, settings, platform|
-  pkg.version '3.2.9'
-  pkg.md5sum '73fcf4d686d68dafbca57f941097ebf0'
+  pkg.version '3.2.6'
+  pkg.md5sum 'a57288ae5afed07dd08c9f1302da7b25'
 
-  # If the platform is solaris with sparc architecture in agent-runtime-7.x project, we want to gem install rexml
-  # ignoring the dependencies, this is because the pl-ruby version used in these platforms is ancient so it gets
-  # confused when installing rexml. It tries to install rexml's dependency 'strscan' by building native extensions
-  # but fails. We can ignore insalling that since strscan is already shipped with ruby 2.7.8 as its default gem.
-  if platform.name =~ /solaris-(10|11)-sparc/ && settings[:ruby_version].to_i < 3
-    settings["#{pkg.get_name}_gem_install_options".to_sym] = "--ignore-dependencies"
-  end
-  
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -61,7 +61,6 @@ proj.component 'rubygem-locale'
 proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
 proj.component 'rubygem-ffi'
-proj.component 'rubygem-rexml'
 
 if platform.is_windows? || platform.is_solaris? || platform.is_aix?
   proj.component 'rubygem-minitar'


### PR DESCRIPTION
Reverts puppetlabs/puppet-runtime#873 as this wont be going in the current release because of issue identified while validating package

`Unresolved or ambiguous specs during Gem::Specification.reset`