### PR TITLE
(PA-6507) Cleanup bundled version of rexml (3.2.5) from ruby 3

### DIFF
--- a/configs/components/_base-rubygem.rb
+++ b/configs/components/_base-rubygem.rb
@@ -40,13 +40,22 @@ pkg.mirror("#{settings[:buildsources_url]}/#{name}-#{version}.gem")
 # If a gem needs more command line options to install set the :gem_install_options
 # in its component file rubygem-<compoment>, before the instance_eval of this file.
 gem_install_options = settings["#{pkg.get_name}_gem_install_options".to_sym]
-if gem_install_options.nil?
-  pkg.install do
-    "#{settings[:gem_install]} #{name}-#{version}.gem"
+pkg.install do
+  steps = []
+  if gem_install_options.nil?
+    steps << "#{settings[:gem_install]} #{name}-#{version}.gem"
+  else
+    steps << "#{settings[:gem_install]} #{name}-#{version}.gem #{gem_install_options}"
   end
-else
-  pkg.install do
-    "#{settings[:gem_install]} #{name}-#{version}.gem #{gem_install_options}"
+
+  # We gem installed rexml to 3.2.9 in ruby 3 for CVE 2024-35176. Since rexml is a bundled gem in ruby 3, we end up having 
+  # two versions of rexml -- 1) the bundled version shipped with ruby 3 (3.2.5) and 2) the one we manually installed with 
+  # the above gem install command (3.2.9).
+  # So, we run gem cleanup so that it deletes the older version 3.2.5. 
+  # Note: We won't need to cleanup and install rexml once we upgrade to ruby >= 3.3.3
+  if name == 'rexml' && settings[:ruby_version].to_i == 3
+    steps << "#{settings[:gem_cleanup]} #{name}"
   end
+  steps
 end
 

--- a/configs/projects/_shared-pe-bolt-server.rb
+++ b/configs/projects/_shared-pe-bolt-server.rb
@@ -66,6 +66,8 @@ else
   proj.setting(:gem_install, "#{proj.host_gem} install --no-rdoc --no-ri --local --bindir=#{proj.bindir}")
 end
 
+proj.setting(:gem_cleanup, "#{proj.host_gem} cleanup")
+
 # What to build?
 # --------------
 

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -43,6 +43,8 @@ project 'agent-runtime-main' do |proj|
   # platforms that use older rubies.
   proj.setting(:gem_install, "#{proj.host_gem} install --no-document --local")
 
+  proj.setting(:gem_cleanup, "#{proj.host_gem} cleanup")
+
   ########
   # Load shared agent components
   ########


### PR DESCRIPTION
 - rexml is a bundled gem in ruby 3.
 - When we gem install rexml version 3.2.9 to resolve CVE 2024-35176, we end up having two versions of rexml.
 - rexml 3.2.5 which is shipped with ruby as its bundled gem and rexml 3.2.9 which we manually installed.
 - This causes 'Gem::Specification.reset:rexml' warning to go to stderr each time puppet runs.
 - Run 'gem cleanup rexml' so that it removes the 3.2.5 version.