### PR TITLE
(CAT-1903) Add support for RedHat 8 and 9 AARCH architecture to the PDK

### DIFF
--- a/configs/components/git.rb
+++ b/configs/components/git.rb
@@ -48,7 +48,7 @@ component "git" do |pkg, settings, platform|
     ]
   end
 
-  if platform.name == 'el-8-x86_64' || platform.name == 'el-9-x86_64'
+  if platform.name.match(/^el\-(?:8|9)\-(?:x86_64|aarch64)/)
     build_deps.reject! { |r| r == 'dh-autoreconf' }
   end
 


### PR DESCRIPTION
- Update the git component so that a line rejecting `dh-autoreconf` as a dependency when building for RedHat 8 and 9 will do the same when building against their AARCH architecture versions.