### PR TITLE
(PA-6507)(PA-6736) Gem install rexml to 3.3.2 for CVE-2024-35176 and CVE-2024-…

### DIFF
--- a/configs/components/_base-rubygem.rb
+++ b/configs/components/_base-rubygem.rb
@@ -40,13 +40,22 @@ pkg.mirror("#{settings[:buildsources_url]}/#{name}-#{version}.gem")
 # If a gem needs more command line options to install set the :gem_install_options
 # in its component file rubygem-<compoment>, before the instance_eval of this file.
 gem_install_options = settings["#{pkg.get_name}_gem_install_options".to_sym]
-if gem_install_options.nil?
-  pkg.install do
-    "#{settings[:gem_install]} #{name}-#{version}.gem"
+pkg.install do
+  steps = []
+  if gem_install_options.nil?
+    steps << "#{settings[:gem_install]} #{name}-#{version}.gem"
+  else
+    steps << "#{settings[:gem_install]} #{name}-#{version}.gem #{gem_install_options}"
   end
-else
-  pkg.install do
-    "#{settings[:gem_install]} #{name}-#{version}.gem #{gem_install_options}"
+
+  # We gem installed rexml to 3.3.2 in ruby 3 for CVE-2024-35176 and CVE-2024-39908. Since rexml is a bundled gem in ruby 3, we end up having 
+  # two versions of rexml -- 1) the bundled version shipped with ruby 3 (3.2.5) and 2) the one we manually installed with 
+  # the above gem install command.
+  # So, we run gem cleanup so that it deletes the older version 3.2.5. 
+  # Note: We won't need to cleanup and install rexml once we upgrade to ruby >= 3.3.3
+  if name == 'rexml' && settings[:ruby_version].to_i == 3
+    steps << "#{settings[:gem_cleanup]} #{name}"
   end
+  steps
 end
 

--- a/configs/components/rubygem-rexml.rb
+++ b/configs/components/rubygem-rexml.rb
@@ -1,6 +1,14 @@
 component 'rubygem-rexml' do |pkg, settings, platform|
-  pkg.version '3.2.6'
-  pkg.md5sum 'a57288ae5afed07dd08c9f1302da7b25'
+  pkg.version '3.3.2'
+  pkg.md5sum '55d213401f5e6a7a83ff3d2cd64a23fe'
 
+  # If the platform is solaris with sparc architecture in agent-runtime-7.x project, we want to gem install rexml
+  # ignoring the dependencies, this is because the pl-ruby version used in these platforms is ancient so it gets
+  # confused when installing rexml. It tries to install rexml's dependency 'strscan' by building native extensions
+  # but fails. We can ignore insalling that since strscan is already shipped with ruby 2 as its default gem.
+  if platform.name =~ /solaris-(10|11)-sparc/ && settings[:ruby_version].to_i < 3
+    settings["#{pkg.get_name}_gem_install_options".to_sym] = "--ignore-dependencies"
+  end
+  
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -62,6 +62,10 @@ proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
 proj.component 'rubygem-ffi'
 
+# Note: We won't need to explicitly add 'rubygem-rexml' to agent-runtimes once ruby is upgraded to 3.3.3 or higher (CVE-2024-35176 and CVE-2024-39908).
+# This is because the bundled rexml gem version shipped with ruby itself will be free from these CVEs.
+proj.component 'rubygem-rexml'
+
 if platform.is_windows? || platform.is_solaris? || platform.is_aix?
   proj.component 'rubygem-minitar'
 end

--- a/configs/projects/_shared-pe-bolt-server_with_ruby.rb
+++ b/configs/projects/_shared-pe-bolt-server_with_ruby.rb
@@ -68,6 +68,7 @@ else
   proj.setting(:gem_install, "#{proj.host_gem} install --no-rdoc --no-ri --local --bindir=#{proj.bindir}")
 end
 
+proj.setting(:gem_cleanup, "#{proj.host_gem} cleanup")
 
 proj.setting(:datadir, File.join(proj.prefix, "share"))
 proj.setting(:mandir, File.join(proj.datadir, "man"))

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -43,6 +43,8 @@ project 'agent-runtime-main' do |proj|
   # platforms that use older rubies.
   proj.setting(:gem_install, "#{proj.host_gem} install --no-document --local")
 
+  proj.setting(:gem_cleanup, "#{proj.host_gem} cleanup")
+
   ########
   # Load shared agent components
   ########


### PR DESCRIPTION
…39908

 - The CVEs were fixed from rexml version 3.2.7 (CVE-2024-35176) and 3.3.2 (CVE-2024-39908).
 - Patching for the CVE wasn't getting applied cleanly and had a lot of conflicts. So updated the gem version to 3.3.2 in the rexml component file.
 - Added the change to _shared-agent-components since the CVEs impacts both agent-runtime-main (ruby 3.2.4 using rexml 3.2.6) and agent-runtime-7.x (ruby 2.7.8 using rexml 3.2.3)
 - For solaris-10-sparc and solaris-11-sparc, we ignore dependency when installing rexml since the ruby in these platforms tries to install strscan (rexml's dependency) but fails while building native extensions. We can ignore installing str scan since it is shipped with ruby 2.7.8 as its default gem.
 - rexml is a bundled gem in ruby 3.
 - When we gem install rexml version 3.3.2 to resolve CVEs, we end up having two versions of rexml -- rexml 3.2.5 which is shipped with ruby as its bundled gem and rexml 3.3.2 which we manually installed.
 - This causes 'Gem::Specification.reset:rexml' warning to go to stderr each time puppet runs.
 - Run 'gem cleanup rexml' so that it removes the 3.2.5 version for both agent-runtimes and pe-bolt-server-runtime-main, the impacted projects requiring the rexml component.