### PR TITLE
(PA-6507)(PA-6736) Gem install rexml to 3.3.2 for CVE-2024-35176 and …

### DIFF
--- a/configs/components/rubygem-rexml.rb
+++ b/configs/components/rubygem-rexml.rb
@@ -1,6 +1,14 @@
 component 'rubygem-rexml' do |pkg, settings, platform|
-  pkg.version '3.2.6'
-  pkg.md5sum 'a57288ae5afed07dd08c9f1302da7b25'
+  pkg.version '3.3.2'
+  pkg.md5sum '55d213401f5e6a7a83ff3d2cd64a23fe'
 
+  # If the platform is solaris with sparc architecture in agent-runtime-7.x project, we want to gem install rexml
+  # ignoring the dependencies, this is because the pl-ruby version used in these platforms is ancient so it gets
+  # confused when installing rexml. It tries to install rexml's dependency 'strscan' by building native extensions
+  # but fails. We can ignore insalling that since strscan is already shipped with ruby 2 as its default gem.
+  if platform.name =~ /solaris-(10|11)-sparc/ && settings[:ruby_version].to_i < 3
+    settings["#{pkg.get_name}_gem_install_options".to_sym] = "--ignore-dependencies"
+  end
+  
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/agent-runtime-7.x.rb
+++ b/configs/projects/agent-runtime-7.x.rb
@@ -61,6 +61,11 @@ project 'agent-runtime-7.x' do |proj|
   proj.component 'rubygem-thor'
   proj.component 'rubygem-scanf'
 
+  # We add rexml explicitly in here because even though ruby 2 ships with rexml as its default gem, the version
+  # of rexml it ships with contains CVE-2024-35176 and CVE-2024-39908. So, we add it here to update to a higher version
+  # free from the CVEs.
+  proj.component 'rubygem-rexml'
+
   if platform.is_linux?
     proj.component "virt-what"
     proj.component "dmidecode" unless platform.architecture =~ /ppc64/


### PR DESCRIPTION
…CVE-2024-39908 in 7.x

 - The CVEs were fixed from rexml version 3.2.7 (CVE-2024-35176) and 3.3.2 (CVE-2024-39908).
 - Patching for the CVE wasn't getting applied cleanly and had a lot of conflicts. So updated the gem version to 3.3.2 in the rexml component file.
 - This addresses the CVEs for 7.x.
 - For solaris-10-sparc and solaris-11-sparc, we ignore dependency when installing rexml since the ruby in these platforms tries to install strscan (rexml's dependency) but fails while building native extensions. We can ignore installing strscan since it is shipped with ruby 2.7.8 as its default gem.