### PR TITLE
(PE-38998) Update shared ruby runtime for PE release

### DIFF
--- a/configs/components/rubygem-addressable.rb
+++ b/configs/components/rubygem-addressable.rb
@@ -1,6 +1,6 @@
 component "rubygem-addressable" do |pkg, settings, platform|
-  pkg.version "2.8.6"
-  pkg.sha256sum "798f6af3556641a7619bad1dce04cdb6eb44b0216a991b0396ea7339276f2b47"
+  pkg.version "2.8.7"
+  pkg.sha256sum "462986537cf3735ab5f3c0f557f14155d778f4b43ea4f485a9deb9c8f7c58232"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-partitions" do |pkg, settings, platform|
-  pkg.version "1.913.0"
-  pkg.md5sum "6231fd992c84e56941488776aa0be8b5"
+  pkg.version "1.960.0"
+  pkg.md5sum "c8b0c649c7a00c79e0af4272debbd8f9"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-core" do |pkg, settings, platform|
-  pkg.version "3.191.6"
-  pkg.md5sum "cdce9ffd297496550ec650fe7c0f0c0e"
+  pkg.version "3.201.3"
+  pkg.md5sum "4513d88fdfb723a7395290c3d54f9019"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sdk-ec2" do |pkg, settings, platform|
-  pkg.version "1.448.0"
-  pkg.md5sum "79f7f0f2fd051cedda210399d45590c6"
+  pkg.version "1.467.0"
+  pkg.md5sum "4b8f90993610214036a661e2ed9506ac"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-aws-sigv4.rb
+++ b/configs/components/rubygem-aws-sigv4.rb
@@ -1,6 +1,6 @@
 component "rubygem-aws-sigv4" do |pkg, settings, platform|
-  pkg.version "1.8.0"
-  pkg.md5sum "586f3e0e914c67bae0b8793e64347c03"
+  pkg.version "1.9.1"
+  pkg.md5sum "3b9757f618ad2c151c73462cb5061a6f"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-builder.rb
+++ b/configs/components/rubygem-builder.rb
@@ -1,6 +1,6 @@
 component 'rubygem-builder' do |pkg, settings, platform|
-  pkg.version '3.2.4'
-  pkg.md5sum '3f97760c1802f23c7ddd5e789eba21fa'
+  pkg.version '3.3.0'
+  pkg.md5sum '3048be022111b96f47bb17c34c67dbc7'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-cri.rb
+++ b/configs/components/rubygem-cri.rb
@@ -1,6 +1,6 @@
 component "rubygem-cri" do |pkg, settings, platform|
-  pkg.version "2.15.11"
-  pkg.sha256sum "254320ef42198cf2670b36dbdd67aa8f8c177e7f058ce176f995a4ada47d1aae"
+  pkg.version "2.15.12"
+  pkg.sha256sum "8abfe924ef53e772a8e4ee907e791d3bfcfca78bc62a5859e3b9899ba29956e5"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-erubi.rb
+++ b/configs/components/rubygem-erubi.rb
@@ -1,6 +1,6 @@
 component 'rubygem-erubi' do |pkg, settings, platform|
-  pkg.version '1.12.0'
-  pkg.md5sum '92fa9ac9f48cce608153108e327d020d'
+  pkg.version '1.13.0'
+  pkg.md5sum 'ebcea152a605001af22d9899a57087f7'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-facter.rb
+++ b/configs/components/rubygem-facter.rb
@@ -1,6 +1,6 @@
 component 'rubygem-facter' do |pkg, settings, platform|
-  pkg.version '4.7.0'
-  pkg.md5sum 'b77bcd4ed8ebf713717a89014b835830'
+  pkg.version '4.8.0'
+  pkg.md5sum 'fdcdbd04cb3aaee32c39e79a5ea05478'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-faraday-net_http.rb
+++ b/configs/components/rubygem-faraday-net_http.rb
@@ -1,6 +1,6 @@
 component 'rubygem-faraday-net_http' do |pkg, settings, platform|
-  pkg.version '1.0.1'
-  pkg.md5sum '73db9270982cb4a0d5c0cc9de07d8a51'
+  pkg.version '1.0.2'
+  pkg.md5sum 'b8e560b8cd7c008a7fd1686143428337'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -1,10 +1,10 @@
 component "rubygem-fast_gettext" do |pkg, settings, platform|
-  version = settings[:rubygem_fast_gettext_version] || '2.3.0'
+  version = settings[:rubygem_fast_gettext_version] || '2.4.0'
   pkg.version version
 
   case version
-  when '2.3.0'
-    pkg.sha256sum '0253e26423ccab68061c42387827e3b99243a1b15ad614df1c800ba870d64f84'
+  when '2.4.0'
+    pkg.sha256sum 'fd26c4c406aa10be34f0fd2847ce3ffdc1e9d9798de87538594757bbb9175fbf'
   when '1.1.2'
     pkg.sha256sum 'e868f02c24af746a137f3aaf898ca3660e6611aa7f1f96ce60e9a425130f2732'
   else

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -11,8 +11,8 @@ component "rubygem-ffi" do |pkg, settings, platform|
     pkg.version '1.13.1'
     pkg.sha256sum '4e15f52ee45af7c5674d656041855448adbb5022618be252cd602d81b8e2978a'
   else
-    pkg.version '1.16.3'
-    pkg.sha256sum '6d3242ff10c87271b0675c58d68d3f10148fabc2ad6da52a18123f06078871fb'
+    pkg.version '1.17.0'
+    pkg.sha256sum '51630e43425078311c056ca75f961bb3bda1641ab36e44ad4c455e0b0e4a231c'
   end
 
   rb_major_minor_version = settings[:ruby_version].to_f
@@ -37,8 +37,8 @@ component "rubygem-ffi" do |pkg, settings, platform|
       case pkg.get_version
       when '1.9.25'
         pkg.sha256sum '5473ac958b78f271f53e9a88197c35cd3e990fbe625d21e525c56d62ae3750da'
-      when '1.16.3'
-        pkg.sha256sum '6ec709011e3955e97033fa77907a8ab89a9150137d4c45c82c77399b909c9259'
+      when '1.17.0'
+        pkg.sha256sum '63c9b1c847036550c655237526c151ee535dbbeb638e70d9dd3ccbc6104c713b'
       end
 
       pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x64-mingw32.gem"
@@ -48,8 +48,8 @@ component "rubygem-ffi" do |pkg, settings, platform|
       case pkg.get_version
       when '1.9.25'
         pkg.sha256sum '43d357732a6a0e3e41dc7e28a9c9c5112ac66f4a6ed9e1de40afba9ffcb836c1'
-      when '1.16.3'
-        pkg.sha256sum '6344ea0da65decec0d4454dfcf080e3ab39213e76f0bed6aed5b0eeb1073c501'
+      when '1.17.0'
+        pkg.sha256sum 'e6f55971b8d4909d95c19647adb1f9e8abfa5461d62deaaa1f69b8dccaf6c932'
       end
 
       pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x86-mingw32.gem"

--- a/configs/components/rubygem-json-schema.rb
+++ b/configs/components/rubygem-json-schema.rb
@@ -1,6 +1,6 @@
 component "rubygem-json-schema" do |pkg, settings, platform|
-  pkg.version "4.3.0"
-  pkg.sha256sum "ac35bfabf99eea2b8b45fbccbb714b399fbe7824c621fc985048a9c2e45d58d2"
+  pkg.version "4.3.1"
+  pkg.sha256sum "d5e68dc32b94408d0b06ad04f9382ccbb6fe5a44910e066f8547f56c471a7825"
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-logging.rb
+++ b/configs/components/rubygem-logging.rb
@@ -1,6 +1,6 @@
 component 'rubygem-logging' do |pkg, settings, platform|
-  pkg.version '2.3.1'
-  pkg.md5sum '864dbb25dcaa5fe55c39df3e599149a1'
+  pkg.version '2.4.0'
+  pkg.md5sum '8953eab63c979ecdac781cbf0da1872a'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-multipart-post.rb
+++ b/configs/components/rubygem-multipart-post.rb
@@ -1,6 +1,6 @@
 component 'rubygem-multipart-post' do |pkg, settings, platform|
-  pkg.version '2.4.0'
-  pkg.md5sum '626fd8b3f8cd080c1eccfa0e25d7bfed'
+  pkg.version '2.4.1'
+  pkg.md5sum '190a88b4cae633a46b64c30764e5d624'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-public_suffix.rb
+++ b/configs/components/rubygem-public_suffix.rb
@@ -1,6 +1,6 @@
 component 'rubygem-public_suffix' do |pkg, _settings, _platform|
-  pkg.version '5.0.5'
-  pkg.md5sum '1e6879068c1bc976a0ba890a4b11b24d'
+  pkg.version '5.1.1'
+  pkg.md5sum '0895274ce1ffdadffcd979ced832b851'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -13,10 +13,10 @@ component 'rubygem-puppet' do |pkg, settings, platform|
   #
   # Always use the generic version below
   case version
-  when '8.6.0'
-    pkg.md5sum '5ac831a42a5fbaef9c6e320c64bbcbd5'
-  when '7.30.0'
-    pkg.md5sum '1b36ae786efdf3c91edf60f60af54af7'
+  when '8.8.1'
+    pkg.md5sum '2f039fa86f8bd02e1258bca40dcc9b6b'
+  when '7.32.1'
+    pkg.md5sum 'e4e91fae76bb76d4e899b9cf7aafe365'
   when '6.28.0'
     pkg.md5sum '31520d986869f9362c88c7d6a4a5c103'
   else

--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,6 +1,6 @@
 component 'rubygem-r10k' do |pkg, settings, platform|
-  pkg.version '3.16.0'
-  pkg.sha256sum 'b149769db941e93494e2748229fc247c34a8509261209f640a57e16e40560ba5'
+  pkg.version '3.16.2'
+  pkg.sha256sum '9775a726ba94a543bf49952b10dcd23690a54f5d2a361746b78b1292abe32eb9'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-rexml.rb
+++ b/configs/components/rubygem-rexml.rb
@@ -1,6 +1,6 @@
 component 'rubygem-rexml' do |pkg, settings, platform|
-  pkg.version '3.3.2'
-  pkg.md5sum '55d213401f5e6a7a83ff3d2cd64a23fe'
+  pkg.version '3.3.4'
+  pkg.md5sum 'b7411377f3c1a9cbe65e862f74067f91'
 
   # If the platform is solaris with sparc architecture in agent-runtime-7.x project, we want to gem install rexml
   # ignoring the dependencies, this is because the pl-ruby version used in these platforms is ancient so it gets

--- a/configs/components/rubygem-rubyntlm.rb
+++ b/configs/components/rubygem-rubyntlm.rb
@@ -1,5 +1,5 @@
 component 'rubygem-rubyntlm' do |pkg, settings, platform|
-  pkg.version '0.6.3'
-  pkg.md5sum 'e1f7477acf8a7d3effb2a3fb931aa84c'
+  pkg.version '0.6.5'
+  pkg.md5sum 'a395ed20dbac837d6e61ca0c1e1fe131'
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -7,7 +7,7 @@ project 'bolt-runtime' do |proj|
   proj.setting(:augeas_version, '1.14.1')
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_deep_merge_version, '1.2.2')
-  proj.setting(:rubygem_puppet_version, '7.30.0')
+  proj.setting(:rubygem_puppet_version, '7.32.1')
 
   platform = proj.get_platform
 

--- a/configs/projects/pe-bolt-server-runtime-2021.7.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2021.7.x.rb
@@ -1,6 +1,6 @@
 project 'pe-bolt-server-runtime-2021.7.x' do |proj|
   proj.setting(:pe_version, '2021.7')
-  proj.setting(:rubygem_puppet_version, '7.30.0')
+  proj.setting(:rubygem_puppet_version, '7.32.1')
   proj.setting(:rubygem_puppet_strings_version, '3.0.1')
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.7 we need to use a --no-document flag

--- a/configs/projects/pe-bolt-server-runtime-main.rb
+++ b/configs/projects/pe-bolt-server-runtime-main.rb
@@ -1,6 +1,6 @@
 project 'pe-bolt-server-runtime-main' do |proj|
   proj.setting(:pe_version, 'main')
-  proj.setting(:rubygem_puppet_version, '8.6.0')
+  proj.setting(:rubygem_puppet_version, '8.8.1')
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.7 we need to use a --no-document flag
   # for gem installs instead of --no-ri --no-rdoc. This setting allows us to use this while we support both ruby 2.5 and 2.7
   # Once we are no longer using ruby 2.5 we can update.

--- a/configs/projects/pe-installer-runtime-2021.7.x.rb
+++ b/configs/projects/pe-installer-runtime-2021.7.x.rb
@@ -11,6 +11,6 @@ project 'pe-installer-runtime-2021.7.x' do |proj|
   
   # rubygem-net-ssh included in shared-agent-components
   proj.setting(:rubygem_net_ssh_version, '6.1.0')
-  proj.setting(:rubygem_puppet_version, '7.30.0')
+  proj.setting(:rubygem_puppet_version, '7.32.1')
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-installer-runtime.rb'))
 end

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -8,6 +8,6 @@ project 'pe-installer-runtime-main' do |proj|
 
   # rubygem-net-ssh included in shared-agent-components
   proj.setting(:rubygem_net_ssh_version, '7.2.3')
-  proj.setting(:rubygem_puppet_version, '8.6.0')
+  proj.setting(:rubygem_puppet_version, '8.8.1')
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-installer-runtime.rb'))
 end


### PR DESCRIPTION
This commit updates the shared gems for ruby runtimes (bolt, installer, bolt-server, orch, etc) ahead of the impending PE releases.