### PR TITLE
(PE-38998) Downgrade rubyntlm for now

### DIFF
--- a/configs/components/rubygem-rubyntlm.rb
+++ b/configs/components/rubygem-rubyntlm.rb
@@ -1,5 +1,7 @@
 component 'rubygem-rubyntlm' do |pkg, settings, platform|
-  pkg.version '0.6.5'
-  pkg.md5sum 'a395ed20dbac837d6e61ca0c1e1fe131'
+  # Do not update past this version without solving the jruby/ruby2.7 issue described in the commit
+  # message this comment is associated with.
+  pkg.version '0.6.3'
+  pkg.md5sum 'e1f7477acf8a7d3effb2a3fb931aa84c'
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
The rubyntlm gem brought in a dep on a new default gem for ruby3 (base64). This is causing issues with bolt being packaged with ruby 2.7 and jruby on 2023.x PE. The changelog does not mention any critical patches so we can take our time getting this right instead of rushing this in to the release. This commit downgrades rubyntlm to the last version before carrying the base64 dep

https://github.com/WinRb/rubyntlm/blob/master/CHANGELOG.md