### PR TITLE
(PA-6383) Enable PIE for Ubuntu and Debian

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -76,6 +76,9 @@ elsif platform.is_macos?
   elsif platform.architecture == 'arm64' && platform.os_version.to_i >= 13
     pkg.environment 'CC', 'clang'
   end
+elsif settings[:supports_pie]
+  pkg.environment 'LDFLAGS', settings[:ldflags]
+  pkg.environment 'optflags', settings[:cflags]
 end
 
 ####################

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -119,7 +119,7 @@ component 'augeas' do |pkg, settings, platform|
     end
   end
 
-  if platform.name =~ /sles-15|el-8|debian-10/ || platform.is_fedora?
+  if settings[:supports_pie]
     pkg.environment 'CFLAGS', settings[:cflags]
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment "LDFLAGS", settings[:ldflags]

--- a/configs/components/ruby-2.7.8.rb
+++ b/configs/components/ruby-2.7.8.rb
@@ -100,7 +100,7 @@ component 'ruby-2.7.8' do |pkg, settings, platform|
 
   special_flags = " --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
 
-  if platform.name =~ /sles-15|el-8|debian-10/
+  if settings[:supports_pie]
     special_flags += " CFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}' CPPFLAGS='#{settings[:cppflags]}' "
   end
 

--- a/configs/components/ruby-3.2.5.rb
+++ b/configs/components/ruby-3.2.5.rb
@@ -93,7 +93,7 @@ component 'ruby-3.2.5' do |pkg, settings, platform|
 
   special_flags = " --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
 
-  if platform.name =~ /sles-15|el-8|debian-10/
+  if settings[:supports_pie]
     special_flags += " CFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}' CPPFLAGS='#{settings[:cppflags]}' "
   end
 

--- a/configs/components/runtime-bolt.rb
+++ b/configs/components/runtime-bolt.rb
@@ -13,7 +13,7 @@ component "runtime-bolt" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
-  elsif platform.is_macos? or platform.name =~ /sles-15|el-8|debian-10|ubuntu-20.04|ubuntu-22.04/ || platform.is_fedora?
+  elsif settings[:supports_pie]
 
     # Do nothing for distros that have a suitable compiler do not use pl-build-tools
 

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -140,23 +140,8 @@ end
 proj.setting(:platform_triple, platform_triple)
 proj.setting(:host, host)
 
-# Define default CFLAGS and LDFLAGS for most platforms, and then
-# tweak or adjust them as needed.
-proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-proj.setting(:cflags, "#{proj.cppflags}")
-proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
-
-# Platform specific overrides or settings, which may override the defaults
-
-# Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
-# stack canary and full RELRO.
-# We only do this on platforms that use their default OS toolchain since pl-gcc versions
-# are too old to support these flags.
-if platform.name =~ /sles-15|el-8|debian-10/ || platform.is_fedora?
-  proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
-  proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
-  proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
-end
+# Load default compiler settings
+instance_eval File.read('configs/projects/_shared-compiler-settings.rb')
 
 if ruby_version_x == "3"
   proj.setting(:openssl_version, '3.0')

--- a/configs/projects/_shared-compiler-settings.rb
+++ b/configs/projects/_shared-compiler-settings.rb
@@ -1,0 +1,24 @@
+# Define default CFLAGS and LDFLAGS for most platforms, and then
+# tweak or adjust them as needed.
+proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+proj.setting(:cflags, "#{proj.cppflags}")
+proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+
+# Platform specific overrides or settings, which may override the defaults
+
+# Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support,
+# stack canary and full RELRO.
+# We only do this on platforms that use their default OS toolchain since pl-gcc versions
+# are too old to support these flags.
+
+if((platform.is_sles? && platform.os_version.to_i >= 15) ||
+      (platform.is_el? && platform.os_version.to_i == 8 && platform.architecture !~ /ppc64/) ||
+      (platform.is_debian? && platform.os_version.to_i >= 10) ||
+      (platform.is_ubuntu? && platform.os_version.to_i >= 22) ||
+      platform.is_fedora?
+    )
+  proj.setting(:supports_pie, true)
+  proj.setting(:cppflags, "-I#{proj.includedir} -D_FORTIFY_SOURCE=2")
+  proj.setting(:cflags, '-fstack-protector-strong -fno-plt -O2')
+  proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir},-z,relro,-z,now")
+end


### PR DESCRIPTION
Enable PIE for Ubuntu 22, Debian 10 and up

agent-runtime-main: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3168/

agent-runtime-7.x: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3167/

pdk-runtime: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3170/

bolt-runtime: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3171/

pe-installer-runtime-2021.7.x: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3172/

pe-installer-runtime-main: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3173/
