### PR TITLE
(PE-38998) Include getoptlong for bolt-server main

### DIFF
--- a/configs/components/rubygem-getoptlong.rb
+++ b/configs/components/rubygem-getoptlong.rb
@@ -1,0 +1,6 @@
+component 'rubygem-getoptlong' do |pkg, settings, platform|
+  pkg.version '0.2.0'
+  pkg.md5sum '91760bf343765c5d3f08cb5393d90487'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/pe-bolt-server-runtime-main.rb
+++ b/configs/projects/pe-bolt-server-runtime-main.rb
@@ -19,6 +19,10 @@ project 'pe-bolt-server-runtime-main' do |proj|
   end
 
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-bolt-server_with_ruby.rb'))
+  # These are ruby 3/puppet 8 specific gems. Some of them are "default/standard" gems. There
+  # is a very annoying issue where default gems can be loaded by MRI but not jruby. 
+  # We explicitly pacakge up some default gems where we have explicit dependencies for jruby
   proj.component 'rubygem-prime'
   proj.component 'rubygem-rexml'
+  proj.component 'rubygem-getoptlong'
 end


### PR DESCRIPTION
Puppet 8 now has an explict dep on getoptlong https://github.com/puppetlabs/puppet/pull/9398/commits/5bce3bb270785faac0cd5a9a3bdfe4c1ae38b341 This is a "default" gem for ruby 3. When orchestrator's jruby tries to load bolt it cant find the default gems. This commit explictly packages the getoptlong gem outside of the default gems.