### PR TITLE
(maint) Keep component name consistent with version

### DIFF
--- a/configs/components/ruby-3.2.5.rb
+++ b/configs/components/ruby-3.2.5.rb
@@ -1,5 +1,5 @@
 # The file name of the ruby component must match the ruby_version
-component 'ruby-3.2.4' do |pkg, settings, platform|
+component 'ruby-3.2.5' do |pkg, settings, platform|
   pkg.version '3.2.5'
   pkg.sha256sum 'ef0610b498f60fb5cfd77b51adb3c10f4ca8ed9a17cb87c61e5bea314ac34a16'
 


### PR DESCRIPTION
This commit updates the component name to match the file name and pkg.version.