### PR TITLE
Bump minitar 1.0.1 for puppet 8

### DIFF
--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -1,6 +1,15 @@
 component 'rubygem-minitar' do |pkg, settings, platform|
-  pkg.version '0.9'
-  pkg.md5sum '4ab2c278183c9a83f3ad97066c381d84'
+  version = settings[:rubygem_minitar_version] || '0.9'
+  pkg.version version
+
+  case version
+  when '1.0.1'
+    pkg.sha256sum 'ba258663f25a3e89ca55bfa2680ce35866d5d2d2998c14d2d2342650f5499705'
+  when '0.9'
+    pkg.md5sum '4ab2c278183c9a83f3ad97066c381d84'
+  else
+    raise "rubygem-minitar version #{version} has not been configured; Cannot continue."
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -5,6 +5,7 @@ project 'agent-runtime-main' do |proj|
   proj.setting :rubygem_deep_merge_version, '1.2.2'
   proj.setting :rubygem_highline_version, '3.0.1'
   proj.setting :rubygem_hocon_version, '1.4.0'
+  proj.setting :rubygem_minitar_version, '1.0.1'
   proj.setting :rubygem_net_ssh_version, '7.2.3'
 
   # Solaris and AIX depend on libedit which breaks augeas compliation starting with 1.13.0

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -7,7 +7,12 @@ project 'bolt-runtime' do |proj|
   proj.setting(:augeas_version, '1.14.1')
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_deep_merge_version, '1.2.2')
+  # bolt-runtime must be made compatible with minitar 1.x before
+  # bumping to a version of puppet 8 that requires minitar 1.x
   proj.setting(:rubygem_puppet_version, '7.32.1')
+  # if you update puppet version to a version that requires minitar 1.x,
+  # then update minitar too
+  # proj.settings(:rubygem_minitar_version, '1.0.1')
 
   platform = proj.get_platform
 

--- a/configs/projects/pe-bolt-server-runtime-main.rb
+++ b/configs/projects/pe-bolt-server-runtime-main.rb
@@ -1,6 +1,12 @@
 project 'pe-bolt-server-runtime-main' do |proj|
   proj.setting(:pe_version, 'main')
+  # pe-bolt-server must be made compatible with minitar 1.x before
+  # bumping to a version of puppet 8 that requires minitar 1.x
   proj.setting(:rubygem_puppet_version, '8.8.1')
+  # if you update puppet version to a version that requires minitar 1.x,
+  # then update minitar too
+  # proj.settings(:rubygem_minitar_version, '1.0.1')
+
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.7 we need to use a --no-document flag
   # for gem installs instead of --no-ri --no-rdoc. This setting allows us to use this while we support both ruby 2.5 and 2.7
   # Once we are no longer using ruby 2.5 we can update.

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -8,6 +8,12 @@ project 'pe-installer-runtime-main' do |proj|
 
   # rubygem-net-ssh included in shared-agent-components
   proj.setting(:rubygem_net_ssh_version, '7.2.3')
+  # verify pe-installer-runtime components are compatible with minitar 1.x before
+  # bumping to a version of puppet 8 that requires minitar 1.x
   proj.setting(:rubygem_puppet_version, '8.8.1')
+  # if you update puppet version to a version that requires minitar 1.x,
+  # then update minitar too
+  # proj.settings(:rubygem_minitar_version, '1.0.1')
+
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-installer-runtime.rb'))
 end


### PR DESCRIPTION
Minitar 1.x is not backwards compatible with 0.9, so only make this change in agent-runtime-main for now.

Projects that depend on minitar and puppet will need to be made compatible with minitar 1.x before bumping their puppet dependency in puppet-runtime. And when they do bump puppet, they should bump minitar too. I added a reminder for the latter part. This applies to:

    bolt-runtime
    pe-bolt-server-runtime-main
    pe-installer-runtime-main

pdk-runtime depends on minitar, but not puppet. When a new version of puppet is released that depends on minitar 1.x, then modules created using an older version of the pdk, will pull in the latest puppet, but have an incompatible minitar version.