### PR TITLE
(PA-6872) Upgrade Curl to address CVE-2024-6874 and CVE-2024-6197

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -6,8 +6,8 @@ component 'curl' do |pkg, settings, platform|
   case version
   when '7.88.1'
     pkg.sha256sum 'cdb38b72e36bc5d33d5b8810f8018ece1baa29a8f215b4495e495ded82bbf3c7'
-  when '8.7.1'
-    pkg.sha256sum 'f91249c87f68ea00cf27c44fdfa5a78423e41e71b7d408e5901a9896d905c495'
+  when '8.9.1'
+    pkg.sha256sum '291124a007ee5111997825940b3876b3048f7d31e73e9caa681b80fe48b2dcd5'
   else
     raise "curl version #{version} has not been configured; Cannot continue."
   end

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -14,7 +14,7 @@ project 'agent-runtime-main' do |proj|
     proj.setting :augeas_version, '1.14.1'
   end
 
-  proj.setting :curl_version, '8.7.1'
+  proj.setting :curl_version, '8.9.1'
 
   ########
   # Load shared agent settings


### PR DESCRIPTION
## Agent Runtime Main Build
[vanagon-generic-builder (generic) Generic Builder Step 03 -- Vanagon Project Packaging #3175 [Jenkins]](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3175/
)

## Agent Runtime Main Artifacts
[Index of /puppet-runtime/bb946dd72aae72481e2bd71f6a1f4bb527f08770/artifacts/
](http://builds.delivery.puppetlabs.net/puppet-runtime/bb946dd72aae72481e2bd71f6a1f4bb527f08770/artifacts/)


## Puppet-Agent Build for el7 & ubuntu
[vanagon-generic-builder (generic) Generic Builder Step 03 -- Vanagon Project Packaging #3176 Console [Jenkins]](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3176/console)

## Puppet-Agent Artifacts for el7 & ubuntu
[Index of /puppet-agent/f9836323568d51146c11173a156ec0dcf472f687/artifacts/el/7/puppet8/x86_64/
](http://builds.delivery.puppetlabs.net/puppet-agent/f9836323568d51146c11173a156ec0dcf472f687/artifacts/el/7/puppet8/x86_64/)

[Index of /puppet-agent/f9836323568d51146c11173a156ec0dcf472f687/artifacts/deb/bionic/puppet8/
](http://builds.delivery.puppetlabs.net/puppet-agent/f9836323568d51146c11173a156ec0dcf472f687/artifacts/deb/bionic/puppet8/)