### PR TITLE
(PA-6878) Patch agent-runtime-7.x and main Curl for CVE-2024-7264

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -48,6 +48,7 @@ component 'curl' do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/curl/CVE-2023-46218.patch'
     pkg.apply_patch 'resources/patches/curl/CVE-2024-2004.patch'
     pkg.apply_patch 'resources/patches/curl/CVE-2024-2398.patch'
+    pkg.apply_patch 'resources/patches/curl/CVE-2024-7264.patch'
   end
 
   configure_options = []

--- a/resources/patches/curl/CVE-2024-7264.patch
+++ b/resources/patches/curl/CVE-2024-7264.patch
@@ -1,0 +1,93 @@
+diff --git a/lib/vtls/x509asn1.c b/lib/vtls/x509asn1.c
+index 39e4fb33b..7e2e3d724 100644
+--- a/lib/vtls/x509asn1.c
++++ b/lib/vtls/x509asn1.c
+@@ -566,28 +566,40 @@ static const char *GTime2str(const char *beg, const char *end)
+   tzp = fracp;
+   fracl = 0;
+   if(fracp < end && (*fracp == '.' || *fracp == ',')) {
+-    fracp++;
+-    do
++    /* Have fractional seconds, e.g. "[.,]\d+". How many? */
++    fracp++; /* should be a digit char or BAD ARGUMENT */
++    tzp = fracp;
++    while(tzp < end && ISDIGIT(*tzp))
+       tzp++;
+-    while(tzp < end && *tzp >= '0' && *tzp <= '9');
+-    /* Strip leading zeroes in fractional seconds. */
+-    for(fracl = tzp - fracp - 1; fracl && fracp[fracl - 1] == '0'; fracl--)
+-      ;
++    if(tzp == fracp) /* never looped, no digit after [.,] */
++      return CURLE_BAD_FUNCTION_ARGUMENT;
++    fracl = tzp - fracp; /* number of fractional sec digits */
++    DEBUGASSERT(fracl > 0);
++    /* Strip trailing zeroes in fractional seconds.
++     * May reduce fracl to 0 if only '0's are present. */
++    while(fracl && fracp[fracl - 1] == '0')
++      fracl--;
+   }
+ 
+   /* Process timezone. */
+-  if(tzp >= end)
+-    ;           /* Nothing to do. */
++  if(tzp >= end) {
++    sep = " ";
++    tzp = "GMT";
++    tzl = 3;
++  }
++  else if((*tzp == '+') || (*tzp == '-')) {
++    sep = " UTC";
++    tzl = end - tzp;
++  }         /* Nothing to do. */
+   else if(*tzp == 'Z') {
+     tzp = " GMT";
+     end = tzp + 4;
+   }
+   else {
+     sep = " ";
+-    tzp++;
++    tzl = end - tzp;
+   }
+ 
+-  tzl = end - tzp;
+   return curl_maprintf("%.4s-%.2s-%.2s %.2s:%.2s:%c%c%s%.*s%s%.*s",
+                        beg, beg + 4, beg + 6,
+                        beg + 8, beg + 10, sec1, sec2,
+@@ -595,6 +607,15 @@ static const char *GTime2str(const char *beg, const char *end)
+                        sep, (int)tzl, tzp);
+ }
+ 
++#ifdef UNITTESTS
++/* used by unit1656.c */
++CURLcode Curl_x509_GTime2str(struct dynbuf *store,
++                             const char *beg, const char *end)
++{
++  return GTime2str(store, beg, end);
++}
++#endif
++
+ /*
+  *  Convert an ASN.1 UTC time to a printable string.
+  * Return the dynamically allocated string, or NULL if an error occurs.
+diff --git a/lib/vtls/x509asn1.h b/lib/vtls/x509asn1.h
+index 5496de40e..93925718c 100644
+--- a/lib/vtls/x509asn1.h
++++ b/lib/vtls/x509asn1.h
+@@ -76,6 +76,17 @@ CURLcode Curl_extract_certinfo(struct Curl_easy *data, int certnum,
+                                const char *beg, const char *end);
+ CURLcode Curl_verifyhost(struct Curl_cfilter *cf, struct Curl_easy *data,
+                          const char *beg, const char *end);
++
++#ifdef UNITTESTS
++#if defined(USE_GNUTLS) || defined(USE_SCHANNEL) || defined(USE_SECTRANSP) || \
++  defined(USE_MBEDTLS)
++
++/* used by unit1656.c */
++CURLcode Curl_x509_GTime2str(struct dynbuf *store,
++                             const char *beg, const char *end);
++#endif
++#endif
++
+ #endif /* USE_GSKIT or USE_NSS or USE_GNUTLS or USE_WOLFSSL or USE_SCHANNEL
+         * or USE_SECTRANSP */
+ #endif /* HEADER_CURL_X509ASN1_H */


### PR DESCRIPTION
Patch to fix curl CVE-2024-7264

7.x curl version - 7.88.1
For 7.x patch was inspired from : [http://archive.ubuntu.com/ubuntu/pool/main/c/curl/](http://archive.ubuntu.com/ubuntu/pool/main/c/curl/curl_7.68.0-1ubuntu2.23.debian.tar.xz)

For main - we have the curl 8.9.1 version for which the fix is already present as per  https://curl.se/docs/CVE-2024-7264.html

vanagon-generic-main : https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3215/

vanagon-generic-7.x : https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3214/