### PR TITLE
(PA-6889) Bump puppet-agent's bundled openssl 1.1.1v to 1.1.1w and addressed CVE-2024-5535

### DIFF
--- a/configs/components/openssl-1.1.1.rb
+++ b/configs/components/openssl-1.1.1.rb
@@ -1,6 +1,6 @@
 component 'openssl' do |pkg, settings, platform|
-  pkg.version '1.1.1v'
-  pkg.sha256sum 'd6697e2871e77238460402e9362d47d18382b15ef9f246aba6c7bd780d38a6b0'
+  pkg.version '1.1.1w'
+  pkg.sha256sum 'cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8'
   pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/openssl-#{pkg.get_version}.tar.gz"
 
@@ -89,6 +89,7 @@ component 'openssl' do |pkg, settings, platform|
 
   pkg.apply_patch 'resources/patches/openssl/CVE-2023-5678.patch'
   pkg.apply_patch 'resources/patches/openssl/CVE-2024-0727.patch'
+  pkg.apply_patch 'resources/patches/openssl/CVE-2024-5535.patch'
   pkg.apply_patch 'resources/patches/openssl/openssl-1.1.1-CVE-2024-2511.patch'
   pkg.apply_patch 'resources/patches/openssl/openssl-1.1.1-CVE-2024-4741.patch'
 


### PR DESCRIPTION
# Testing Done on ubuntu and el

## Agent Runtime 7.x Build
* [vanagon-generic-builder (generic) Generic Builder Step 03 -- Vanagon Project Packaging #3178 Console [Jenkins]](
https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3178/console)

## Agent Runtime 7.x artifacts
* [Index of /puppet-runtime/a20ef9232a3ed9b732e5e2c3d12df12015d68864/artifacts/](
http://builds.delivery.puppetlabs.net/puppet-runtime/a20ef9232a3ed9b732e5e2c3d12df12015d68864/artifacts/)

## Puppet Agent 7.x Build
* [vanagon-generic-builder (generic) Generic Builder Step 03 -- Vanagon Project Packaging #3179 Console [Jenkins]](
https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3179/console)

## Puppet Agent 7.x artifacts
* [Index of /puppet-agent/11a3d34e5d4e723bce59daca166a4d6aab1add3e/artifacts/deb/bionic/puppet7/](
http://builds.delivery.puppetlabs.net/puppet-agent/11a3d34e5d4e723bce59daca166a4d6aab1add3e/artifacts/deb/bionic/puppet7/)

* [Index of /puppet-agent/11a3d34e5d4e723bce59daca166a4d6aab1add3e/artifacts/el/7/puppet7/x86_64/](
http://builds.delivery.puppetlabs.net/puppet-agent/11a3d34e5d4e723bce59daca166a4d6aab1add3e/artifacts/el/7/puppet7/x86_64/)