### PR TITLE
(PA-6881) Adding rexml gem to agent-runtime-main for CVE-2024-41123 and CVE-2024-41946

### DIFF
--- a/configs/components/_base-rubygem.rb
+++ b/configs/components/_base-rubygem.rb
@@ -40,13 +40,13 @@ pkg.mirror("#{settings[:buildsources_url]}/#{name}-#{version}.gem")
 # If a gem needs more command line options to install set the :gem_install_options
 # in its component file rubygem-<compoment>, before the instance_eval of this file.
 gem_install_options = settings["#{pkg.get_name}_gem_install_options".to_sym]
-if gem_install_options.nil?
-  pkg.install do
-    "#{settings[:gem_install]} #{name}-#{version}.gem"
-  end
-else
-  pkg.install do
-    "#{settings[:gem_install]} #{name}-#{version}.gem #{gem_install_options}"
-  end
+remove_older_versions = settings["#{pkg.get_name}_remove_older_versions".to_sym]
+pkg.install do
+  steps = []
+  steps << "#{settings[:gem_uninstall]} #{name}" if remove_older_versions
+  steps << if gem_install_options.nil?
+             "#{settings[:gem_install]} #{name}-#{version}.gem"
+           else
+             "#{settings[:gem_install]} #{name}-#{version}.gem #{gem_install_options}"
+           end
 end
-

--- a/configs/components/rubygem-rexml.rb
+++ b/configs/components/rubygem-rexml.rb
@@ -2,6 +2,8 @@ component 'rubygem-rexml' do |pkg, settings, platform|
   pkg.version '3.3.4'
   pkg.md5sum 'b7411377f3c1a9cbe65e862f74067f91'
 
+  settings["#{pkg.get_name}_remove_older_versions".to_sym] = true
+
   # If the platform is solaris with sparc architecture in agent-runtime-7.x project, we want to gem install rexml
   # ignoring the dependencies, this is because the pl-ruby version used in these platforms is ancient so it gets
   # confused when installing rexml. It tries to install rexml's dependency 'strscan' by building native extensions

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -62,6 +62,12 @@ proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
 proj.component 'rubygem-ffi'
 
+# We add rexml explicitly in here because even though ruby 3 ships with rexml as its default gem, the version
+# of rexml it ships with contains CVE-2024-41946, CVE-2024-41123, CVE-2024-35176 and CVE-2024-39908.
+# So, we add it here to update to a higher version
+# free from the CVEs.
+proj.component 'rubygem-rexml'
+
 if platform.is_windows? || platform.is_solaris? || platform.is_aix?
   proj.component 'rubygem-minitar'
 end

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -131,6 +131,7 @@ elsif platform.is_windows?
 end
 
 proj.setting(:gem_install, "#{proj.host_gem} install --no-rdoc --no-ri --local ")
+proj.setting(:gem_uninstall, "#{proj.host_gem} uninstall --all --ignore-dependencies ")
 
 # For AIX, we use the triple to install a better rbconfig
 if platform.is_aix?

--- a/configs/projects/agent-runtime-7.x.rb
+++ b/configs/projects/agent-runtime-7.x.rb
@@ -61,11 +61,6 @@ project 'agent-runtime-7.x' do |proj|
   proj.component 'rubygem-thor'
   proj.component 'rubygem-scanf'
 
-  # We add rexml explicitly in here because even though ruby 2 ships with rexml as its default gem, the version
-  # of rexml it ships with contains CVE-2024-35176 and CVE-2024-39908. So, we add it here to update to a higher version
-  # free from the CVEs.
-  proj.component 'rubygem-rexml'
-
   if platform.is_linux?
     proj.component "virt-what"
     proj.component "dmidecode" unless platform.architecture =~ /ppc64/


### PR DESCRIPTION
## Testing Done for el7 and ubuntu
### Agent-runtime-main build
[vanagon-generic-builder (generic) Generic Builder Step 03 -- Vanagon Project Packaging #3181 Console [Jenkins]](
https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3181/console)

### Agent-runtime-main artifacts
[Index of /puppet-runtime/63d6a583a1e69661d6795bd48f92074d119ef7e1/artifacts/](
http://builds.delivery.puppetlabs.net/puppet-runtime/63d6a583a1e69661d6795bd48f92074d119ef7e1/artifacts/)

### Puppet-Agent Build
[vanagon-generic-builder (generic) Generic Builder Step 03 -- Vanagon Project Packaging #3182 Console [Jenkins]](
https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3182/console)

### Puppet-Artifacts
[Index of /puppet-agent/eb37c609e51f1b8c94d7634d71ac206867eedbd7/artifacts/deb/bionic/puppet8/](
http://builds.delivery.puppetlabs.net/puppet-agent/eb37c609e51f1b8c94d7634d71ac206867eedbd7/artifacts/deb/bionic/puppet8/)

[Index of /puppet-agent/eb37c609e51f1b8c94d7634d71ac206867eedbd7/artifacts/el/7/puppet8/x86_64/](
http://builds.delivery.puppetlabs.net/puppet-agent/eb37c609e51f1b8c94d7634d71ac206867eedbd7/artifacts/el/7/puppet8/x86_64/)