### PR TITLE
(PA-6959) Update OpenSSL to 3.0.15 for puppet-agent main

### DIFF
--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -1,7 +1,7 @@
 component 'openssl' do |pkg, settings, platform|
-  pkg.version '3.0.14'
-  pkg.sha256sum 'eeca035d4dd4e84fc25846d952da6297484afa0650a6f84c682e39df3a4123ca'
-  pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
+  pkg.version '3.0.15'
+  pkg.sha256sum '23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533'
+  pkg.url "https://github.com/openssl/openssl/releases/download/openssl-#{pkg.get_version}/openssl-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/openssl-#{pkg.get_version}.tar.gz"
 
   #############################
@@ -120,9 +120,6 @@ component 'openssl' do |pkg, settings, platform|
     # 'no-rmd160', this is causing failures with pxp, remove once pxp-agent does not need it
     'no-whirlpool'
   ]
-
-  # Remove this in 3.0.15 or later
-  pkg.apply_patch 'resources/patches/openssl/CVE-2024-5535.patch'
 
   if settings[:use_legacy_openssl_algos]
     pkg.apply_patch 'resources/patches/openssl/openssl-3-activate-legacy-algos.patch'


### PR DESCRIPTION
## Testing Done

* Agent Runtime Build
[vanagon-generic-builder (generic) Generic Builder Step 03 -- Vanagon Project Packaging #3233 Console [Jenkins]
](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3233/console)

* Agent Runtime Artifacts
[Index of /puppet-runtime/3b33d1a6b0d2c1535a25ef77c9ac3fcbd8e60946/artifacts/](
http://builds.delivery.puppetlabs.net/puppet-runtime/3b33d1a6b0d2c1535a25ef77c9ac3fcbd8e60946/artifacts/)

* Puppet Agent Build
[vanagon-generic-builder (generic) Generic Builder Step 03 -- Vanagon Project Packaging #3234 Console [Jenkins]
](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3234/console)

* Puppet Agent Artifacts
[Index of /puppet-agent/6e2a512d5e908fab861994231ac89417d49a10eb/artifacts/el/7/puppet8/x86_64/](
http://builds.delivery.puppetlabs.net/puppet-agent/6e2a512d5e908fab861994231ac89417d49a10eb/artifacts/el/7/puppet8/x86_64/)
[Index of /puppet-agent/6e2a512d5e908fab861994231ac89417d49a10eb/artifacts/deb/bionic/puppet8/
](http://builds.delivery.puppetlabs.net/puppet-agent/6e2a512d5e908fab861994231ac89417d49a10eb/artifacts/deb/bionic/puppet8/)