### PR TITLE
(PA-6881) Configure a default gem_uninstall command

### DIFF
--- a/configs/components/_base-rubygem.rb
+++ b/configs/components/_base-rubygem.rb
@@ -41,9 +41,11 @@ pkg.mirror("#{settings[:buildsources_url]}/#{name}-#{version}.gem")
 # in its component file rubygem-<compoment>, before the instance_eval of this file.
 gem_install_options = settings["#{pkg.get_name}_gem_install_options".to_sym]
 remove_older_versions = settings["#{pkg.get_name}_remove_older_versions".to_sym]
+# Set a default gem_uninstall
+gem_uninstall = settings[:gem_uninstall] || "#{settings[:host_gem]} uninstall --all --ignore-dependencies"
 pkg.install do
   steps = []
-  steps << "#{settings[:gem_uninstall]} #{name}" if remove_older_versions
+  steps << "#{gem_uninstall} #{name}" if remove_older_versions
   steps << if gem_install_options.nil?
              "#{settings[:gem_install]} #{name}-#{version}.gem"
            else


### PR DESCRIPTION
With the addition logic in https://github.com/puppetlabs/puppet-runtime/pull/901 for deduplicating rexml gems an inadvertant requirement was imposed on projects to define a `gem_uninstall` command. This command should be ubiquitous (especially with impending ruby 3 only streams)  so instead of requiring all projects to configure it a default is added. This setting is still configurable at a project level, but is not required.