### PR TITLE
(PA-7089) Apply upstream rdoc fix for start_with?

### DIFF
--- a/resources/patches/ruby_27/0001-Filter-marshaled-objects-ruby30.patch
+++ b/resources/patches/ruby_27/0001-Filter-marshaled-objects-ruby30.patch
@@ -80,7 +80,7 @@ index 5ba671ca1b..5b663d73fb 100644
 +    case obj
 +    when true, false, nil, Array, Class, Encoding, Hash, Integer, String, Symbol, RDoc::Text
 +    else
-+      unless obj.class.name.start_with("RDoc::")
++      unless obj.class.name.start_with?("RDoc::")
 +        raise TypeError, "not permitted class: #{obj.class.name}"
 +      end
 +    end


### PR DESCRIPTION
Installing r10k was failing on ruby 2.7 due to our faulty rdoc patch

    /opt/puppetlabs/puppet/bin/gem install r10k
        ERROR:  While executing gem ... (NoMethodError)
        undefined method `start_with' for "RDoc::Markup::Document":String

Apply the upstream fix from ruby/rdoc@e21dfccb4a