### PR TITLE
(CAT-643) - Add puppet_forge to pdk-runtime

### DIFF
--- a/configs/components/rubygem-faraday-follow_redirects.rb
+++ b/configs/components/rubygem-faraday-follow_redirects.rb
@@ -1,0 +1,6 @@
+component 'rubygem-faraday-follow_redirects' do |pkg, settings, platform|
+  pkg.version '0.3.0'
+  pkg.md5sum '75fa678fa40b54a94e51efc1600a6461'
+
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-faraday-net_http.rb
+++ b/configs/components/rubygem-faraday-net_http.rb
@@ -1,6 +1,16 @@
 component 'rubygem-faraday-net_http' do |pkg, settings, platform|
-  pkg.version '1.0.2'
-  pkg.md5sum 'b8e560b8cd7c008a7fd1686143428337'
+  version = settings[:rubygem_faraday_net_http_version] || '1.0.2'
+
+  case version
+  when '1.0.2'
+    pkg.version '1.0.2'
+    pkg.md5sum 'b8e560b8cd7c008a7fd1686143428337'
+  when '3.3.0'
+    pkg.version '3.3.0'
+    pkg.md5sum '7e6378aaa271587dd4109795c0a05769'
+  else
+    raise "rubygem-faraday-net_http version #{version} is not supported"
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-faraday.rb
+++ b/configs/components/rubygem-faraday.rb
@@ -1,6 +1,16 @@
 component 'rubygem-faraday' do |pkg, settings, platform|
-  pkg.version '1.10.3'
-  pkg.md5sum 'c7b56130721c0b055c071bec593e2446'
+  version = settings[:rubygem_faraday_version] || '1.10.3'
+
+  case version
+  when '1.10.3'
+    pkg.version '1.10.3'
+    pkg.md5sum 'c7b56130721c0b055c071bec593e2446'
+  when '2.12.0'
+    pkg.version '2.12.0'
+    pkg.md5sum 'c0248b00a32c46b64cd2a172c96409ec' 
+  else
+    raise "rubygem-faraday version #{version} is not supported"
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-puppet_forge.rb
+++ b/configs/components/rubygem-puppet_forge.rb
@@ -1,6 +1,17 @@
 component 'rubygem-puppet_forge' do |pkg, settings, platform|
-  pkg.version '3.2.0'
-  pkg.md5sum '501d5f9f742007504d0d60ce6cf0c27f'
+  version = settings[:rubygem_puppet_forge_version] || '3.2.0'
+  pkg.version version
+
+  case version
+  when '3.2.0'
+    pkg.version '3.2.0'
+    pkg.md5sum '501d5f9f742007504d0d60ce6cf0c27f'
+  when '5.0.4'
+    pkg.version '5.0.4'
+    pkg.md5sum '04a2ca2f027ed41d9142ced587b71bd7'
+  else 
+    raise "rubygem-puppet_forge version #{version} is not supported"
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/_pdk-components.rb
+++ b/configs/projects/_pdk-components.rb
@@ -60,6 +60,10 @@ proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
 proj.component 'rubygem-gettext-setup'
 proj.component 'rubygem-minitar'
+proj.component 'rubygem-faraday'
+proj.component 'rubygem-faraday-follow_redirects'
+proj.component 'rubygem-semantic_puppet'
+proj.component 'rubygem-faraday-net_http'
 
 # Bundler
 proj.component 'rubygem-bundler'
@@ -99,5 +103,6 @@ proj.component 'rubygem-deep_merge'
 proj.component 'rubygem-json_pure'
 proj.component 'rubygem-diff-lcs'
 proj.component 'rubygem-pathspec'
+proj.component 'rubygem-puppet_forge'
 
 proj.component 'ansicon' if platform.is_windows?

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -5,6 +5,9 @@ project 'pdk-runtime' do |proj|
   proj.setting(:rubygem_fast_gettext_version, '1.1.2')
   proj.setting(:rubygem_gettext_version, '3.2.2')
   proj.setting(:rubygem_gettext_setup_version, '0.34')
+  proj.setting(:rubygem_puppet_forge_version, '5.0.4')
+  proj.setting(:rubygem_faraday_version, '2.12.0')
+  proj.setting(:rubygem_faraday_net_http_version, '3.3.0')
 
   platform = proj.get_platform
 


### PR DESCRIPTION
This PR adds 5.0.4 puppet forge gem as a component and a dependency to the PDK project

dependencies of puppet-forge gem: 
  faraday ~> 2.0 -> v2.12.0 added as component
  faraday-follow_redirects ~> 0.3.0 -> added as component
  minitar < 1.0.0 -> v0.9.0 already present in runtime
  semantic_puppet ~> 1.0 -> semantic puppet version 1.1.0 already present in runtime (default version)

https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3293/