### PR TITLE
(CAT-2111) - Add puppet-modulebuilder deps first to pdk

### DIFF
--- a/configs/projects/_pdk-components.rb
+++ b/configs/projects/_pdk-components.rb
@@ -95,14 +95,13 @@ proj.component 'rubygem-public_suffix'
 proj.component 'rubygem-addressable'
 proj.component 'rubygem-json-schema'
 
-# PDK build
-proj.component 'rubygem-puppet-modulebuilder'
-
 # Other deps
 proj.component 'rubygem-deep_merge'
 proj.component 'rubygem-json_pure'
 proj.component 'rubygem-diff-lcs'
 proj.component 'rubygem-pathspec'
 proj.component 'rubygem-puppet_forge'
+# PDK build
+proj.component 'rubygem-puppet-modulebuilder'
 
 proj.component 'ansicon' if platform.is_windows?


### PR DESCRIPTION
Prior to this PR, pathspec (which is a runtime dependency of puppet-modubuilder) was added as a component after the puppet-modulebuilder gem, which I don't believe is correct.

This PR updates the puppet-modulebuilder gem to be pulled in after its dependencies.

https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3304/