### PR TITLE
Update rubygem-puppet to 8.10.0

### DIFF
--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -13,8 +13,8 @@ component 'rubygem-puppet' do |pkg, settings, platform|
   #
   # Always use the generic version below
   case version
-  when '8.8.1'
-    pkg.md5sum '2f039fa86f8bd02e1258bca40dcc9b6b'
+  when '8.10.0'
+    pkg.md5sum '3d186db20ec581f6d6aef0b26b0e1275'
   when '7.32.1'
     pkg.md5sum 'e4e91fae76bb76d4e899b9cf7aafe365'
   when '6.28.0'

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -9,7 +9,7 @@ project 'bolt-runtime' do |proj|
   proj.setting(:augeas_version, '1.14.1')
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_deep_merge_version, '1.2.2')
-  proj.setting(:rubygem_puppet_version, '8.8.1')
+  proj.setting(:rubygem_puppet_version, '8.10.0')
 
   platform = proj.get_platform
 

--- a/configs/projects/pe-bolt-server-runtime-2023.8.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2023.8.x.rb
@@ -1,6 +1,6 @@
 project 'pe-bolt-server-runtime-2023.8.x' do |proj|
   proj.setting(:pe_version, '2023.8')
-  proj.setting(:rubygem_puppet_version, '8.8.1')
+  proj.setting(:rubygem_puppet_version, '8.10.0')
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.7 we need to use a --no-document flag
   # for gem installs instead of --no-ri --no-rdoc. This setting allows us to use this while we support both ruby 2.5 and 2.7
   # Once we are no longer using ruby 2.5 we can update.

--- a/configs/projects/pe-bolt-server-runtime-main.rb
+++ b/configs/projects/pe-bolt-server-runtime-main.rb
@@ -1,6 +1,6 @@
 project 'pe-bolt-server-runtime-main' do |proj|
   proj.setting(:pe_version, 'main')
-  proj.setting(:rubygem_puppet_version, '8.8.1')
+  proj.setting(:rubygem_puppet_version, '8.10.0')
   # We build bolt server with the ruby installed in the puppet-agent dep. For ruby 2.7 we need to use a --no-document flag
   # for gem installs instead of --no-ri --no-rdoc. This setting allows us to use this while we support both ruby 2.5 and 2.7
   # Once we are no longer using ruby 2.5 we can update.

--- a/configs/projects/pe-installer-runtime-2023.8.x.rb
+++ b/configs/projects/pe-installer-runtime-2023.8.x.rb
@@ -8,6 +8,6 @@ project 'pe-installer-runtime-2023.8.x' do |proj|
 
   # rubygem-net-ssh included in shared-agent-components
   proj.setting(:rubygem_net_ssh_version, '7.2.3')
-  proj.setting(:rubygem_puppet_version, '8.8.1')
+  proj.setting(:rubygem_puppet_version, '8.10.0')
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-installer-runtime.rb'))
 end

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -8,6 +8,6 @@ project 'pe-installer-runtime-main' do |proj|
 
   # rubygem-net-ssh included in shared-agent-components
   proj.setting(:rubygem_net_ssh_version, '7.2.3')
-  proj.setting(:rubygem_puppet_version, '8.8.1')
+  proj.setting(:rubygem_puppet_version, '8.10.0')
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-pe-installer-runtime.rb'))
 end


### PR DESCRIPTION
Updated rubygem-puppet's Puppet 8 version from 8.8.1 to 8.10.0. I have also updated all relevant runtimes