### PR TITLE
(CAT-2128) Remove json_pure dependency from the PDK runtime

### DIFF
--- a/configs/components/rubygem-json_pure.rb
+++ b/configs/components/rubygem-json_pure.rb
@@ -1,6 +1,0 @@
-component "rubygem-json_pure" do |pkg, settings, platform|
-  pkg.version "2.6.3"
-  pkg.sha256sum 'c39185aa41c04a1933b8d66d1294224743262ee6881adc7b5a488ab2ae19c74e'
-
-  instance_eval File.read('configs/components/_base-rubygem.rb')
-end

--- a/configs/projects/_pdk-components.rb
+++ b/configs/projects/_pdk-components.rb
@@ -97,7 +97,6 @@ proj.component 'rubygem-json-schema'
 
 # Other deps
 proj.component 'rubygem-deep_merge'
-proj.component 'rubygem-json_pure'
 proj.component 'rubygem-diff-lcs'
 proj.component 'rubygem-pathspec'
 proj.component 'rubygem-puppet_forge'


### PR DESCRIPTION
This was originally added to ensure JSON would be available in all environments but should no longer necessary as JSON has been added as a default ruby gem.