### PR TITLE
(PA-7105) Update Ruby 3.2.5 to 3.2.6

### DIFF
--- a/configs/components/ruby-3.2.6.rb
+++ b/configs/components/ruby-3.2.6.rb
@@ -1,7 +1,7 @@
 # The file name of the ruby component must match the ruby_version
-component 'ruby-3.2.5' do |pkg, settings, platform|
-  pkg.version '3.2.5'
-  pkg.sha256sum 'ef0610b498f60fb5cfd77b51adb3c10f4ca8ed9a17cb87c61e5bea314ac34a16'
+component 'ruby-3.2.6' do |pkg, settings, platform|
+  pkg.version '3.2.6'
+  pkg.sha256sum 'd9cb65ecdf3f18669639f2638b63379ed6fbb17d93ae4e726d4eb2bf68a48370'
 
   # rbconfig-update is used to munge rbconfigs after the fact.
   pkg.add_source("file://resources/files/ruby/rbconfig-update.rb")

--- a/configs/projects/_shared-agent-components.rb
+++ b/configs/projects/_shared-agent-components.rb
@@ -62,11 +62,6 @@ proj.component 'rubygem-gettext'
 proj.component 'rubygem-fast_gettext'
 proj.component 'rubygem-ffi'
 
-# We add rexml explicitly in here because even though ruby 3 ships with rexml as its default gem, the version
-# of rexml it ships with contains CVE-2024-41946, CVE-2024-41123, CVE-2024-35176 and CVE-2024-39908.
-# So, we add it here to update to a higher version
-# free from the CVEs.
-proj.component 'rubygem-rexml'
 
 if platform.is_windows? || platform.is_solaris? || platform.is_aix?
   proj.component 'rubygem-minitar'

--- a/configs/projects/agent-runtime-7.x.rb
+++ b/configs/projects/agent-runtime-7.x.rb
@@ -61,6 +61,12 @@ project 'agent-runtime-7.x' do |proj|
   proj.component 'rubygem-thor'
   proj.component 'rubygem-scanf'
 
+  # We add rexml explicitly in here because even though ruby 3 ships with rexml as its default gem, the version
+  # of rexml it ships with contains CVE-2024-41946, CVE-2024-41123, CVE-2024-35176 and CVE-2024-39908.
+  # So, we add it here to update to a higher version
+  # free from the CVEs.
+  proj.component 'rubygem-rexml'
+
   if platform.is_linux?
     proj.component "virt-what"
     proj.component "dmidecode" unless platform.architecture =~ /ppc64/

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -1,7 +1,7 @@
 project 'agent-runtime-main' do |proj|
 
   # Set preferred component versions if they differ from defaults:
-  proj.setting :ruby_version, '3.2.5'
+  proj.setting :ruby_version, '3.2.6'
   proj.setting :rubygem_deep_merge_version, '1.2.2'
   proj.setting :rubygem_highline_version, '3.0.1'
   proj.setting :rubygem_hocon_version, '1.4.0'

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -1,7 +1,7 @@
 project 'bolt-runtime' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'bolt')
-  proj.setting(:ruby_version, '3.2.5')
+  proj.setting(:ruby_version, '3.2.6')
   proj.setting(:openssl_version, '3.0')
   # Legacy algos must be enabled in OpenSSL >= 3.0 for Bolt's WinRM transport to work.
   proj.setting(:use_legacy_openssl_algos, true)

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -51,7 +51,7 @@ project 'pdk-runtime' do |proj|
   proj.setting(:includedir, File.join(proj.prefix, 'include'))
   proj.setting(:bindir, File.join(proj.prefix, 'bin'))
 
-  proj.setting(:ruby_version, '3.2.5')
+  proj.setting(:ruby_version, '3.2.6')
   proj.setting(:ruby_major_version, 3)
   proj.setting(:ruby_api, '3.2.0')
 

--- a/configs/projects/pe-bolt-server-runtime-2023.8.x.rb
+++ b/configs/projects/pe-bolt-server-runtime-2023.8.x.rb
@@ -6,7 +6,7 @@ project 'pe-bolt-server-runtime-2023.8.x' do |proj|
   # Once we are no longer using ruby 2.5 we can update.
   proj.setting(:no_doc, true)
 
-  proj.setting(:ruby_version, '3.2.5')
+  proj.setting(:ruby_version, '3.2.6')
   proj.setting(:openssl_version, '3.0')
 
   # We enable legacy algorithms for winrm transport. Currently the winrm transport

--- a/configs/projects/pe-bolt-server-runtime-main.rb
+++ b/configs/projects/pe-bolt-server-runtime-main.rb
@@ -6,7 +6,7 @@ project 'pe-bolt-server-runtime-main' do |proj|
   # Once we are no longer using ruby 2.5 we can update.
   proj.setting(:no_doc, true)
 
-  proj.setting(:ruby_version, '3.2.5')
+  proj.setting(:ruby_version, '3.2.6')
   proj.setting(:openssl_version, '3.0')
 
   # We enable legacy algorithms for winrm transport. Currently the winrm transport

--- a/configs/projects/pe-installer-runtime-2023.8.x.rb
+++ b/configs/projects/pe-installer-runtime-2023.8.x.rb
@@ -1,5 +1,5 @@
 project 'pe-installer-runtime-2023.8.x' do |proj|
-  proj.setting(:ruby_version, '3.2.5')
+  proj.setting(:ruby_version, '3.2.6')
   proj.setting(:openssl_version, '3.0')
   # NLTM uses MD4 unconditionally in its protocol, so legacy algos must be
   # enabled in OpenSSL >= 3.0 for Bolt's WinRM transport to work.

--- a/configs/projects/pe-installer-runtime-main.rb
+++ b/configs/projects/pe-installer-runtime-main.rb
@@ -1,5 +1,5 @@
 project 'pe-installer-runtime-main' do |proj|
-  proj.setting(:ruby_version, '3.2.5')
+  proj.setting(:ruby_version, '3.2.6')
   proj.setting(:openssl_version, '3.0')
   # NLTM uses MD4 unconditionally in its protocol, so legacy algos must be
   # enabled in OpenSSL >= 3.0 for Bolt's WinRM transport to work.


### PR DESCRIPTION
pe-installer-runtime-main: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3361/
pe-installer-runtime-2023.8.x: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3362/

pe-bolt-server-runtime-2023.8.x: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3354/
pe-bolt-server-runtime-main: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3360/

agent-runtime-7.x: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/
agent-runtime-main: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/lastFailedBuild/

pdk-runtime:https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3363/ 
			https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3365/
			Windows failing with libpsl issue

bolt-runtime: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3368/

Windows patch issue noted and fixed on local