### PR TITLE
Revert "Update rubygem-r10k to 4.1.0"

### DIFF
--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,6 +1,6 @@
 component 'rubygem-r10k' do |pkg, settings, platform|
-  pkg.version '4.1.0'
-  pkg.sha256sum '64e5b9e1a6cbb4006c96477d8c34ce589fe1c278117311f452d9f30b9cc86e4c'
+  pkg.version '3.16.2'
+  pkg.sha256sum '9775a726ba94a543bf49952b10dcd23690a54f5d2a361746b78b1292abe32eb9'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Reverts https://github.com/puppetlabs/puppet-runtime/pull/927
Seems to be breaking projects that use r10k