### PR TITLE
Updated rubygem-r10k from 3.16.2 to 4.1.0

### DIFF
--- a/configs/components/rubygem-faraday-net_http_persistent.rb
+++ b/configs/components/rubygem-faraday-net_http_persistent.rb
@@ -9,7 +9,7 @@ component 'rubygem-faraday-net_http_persistent' do |pkg, settings, platform|
     pkg.version '2.3.0'
     pkg.md5sum 'b8003472ed288c44021dcfed574353b2' 
   else
-    raise "rubygem-faraday version #{version} is not supported"
+    raise "rubygem-faraday-net_http_persistent version #{version} is not supported"
   end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/configs/components/rubygem-faraday-net_http_persistent.rb
+++ b/configs/components/rubygem-faraday-net_http_persistent.rb
@@ -1,6 +1,16 @@
 component 'rubygem-faraday-net_http_persistent' do |pkg, settings, platform|
-  pkg.version '1.2.0'
-  pkg.md5sum 'e13bafd2297cbf703e0385e142c9ce62'
+  version = settings[:rubygem_faraday_net_http_persistent_version] || '1.2.0'
+
+  case version
+  when '1.2.0'
+    pkg.version '1.2.0'
+    pkg.md5sum 'e13bafd2297cbf703e0385e142c9ce62'
+  when '2.3.0'
+    pkg.version '2.3.0'
+    pkg.md5sum 'b8003472ed288c44021dcfed574353b2' 
+  else
+    raise "rubygem-faraday version #{version} is not supported"
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-orchestrator_client.rb
+++ b/configs/components/rubygem-orchestrator_client.rb
@@ -1,6 +1,6 @@
 component 'rubygem-orchestrator_client' do |pkg, settings, platform|
-  pkg.version '0.7.0'
-  pkg.md5sum '03fb7c2fb2d8d407b638e31761bc0d92'
+  pkg.version '0.7.1'
+  pkg.md5sum '177686e31c134ae9fdee25ba8c0404a0'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,6 +1,16 @@
 component 'rubygem-r10k' do |pkg, settings, platform|
-  pkg.version '4.1.0'
-  pkg.sha256sum '64e5b9e1a6cbb4006c96477d8c34ce589fe1c278117311f452d9f30b9cc86e4c'
+  version = settings[:rubygem_r10k_version] || '3.16.2'
+
+  case version
+  when '3.16.2'
+    pkg.version '3.16.2'
+    pkg.sha256sum '9775a726ba94a543bf49952b10dcd23690a54f5d2a361746b78b1292abe32eb9'
+  when '4.1.0'
+    pkg.version '4.1.0'
+    pkg.sha256sum '64e5b9e1a6cbb4006c96477d8c34ce589fe1c278117311f452d9f30b9cc86e4c'
+  else
+    raise "rubygem-r10k version #{version} is not supported"
+  end
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -10,6 +10,10 @@ project 'bolt-runtime' do |proj|
   # TODO: Can runtime projects use these updated versions?
   proj.setting(:rubygem_deep_merge_version, '1.2.2')
   proj.setting(:rubygem_puppet_version, '8.8.1')
+  proj.setting(:rubygem_puppet_forge_version, '5.0.4')
+  proj.setting(:rubygem_faraday_version, '2.12.0')
+  proj.setting(:rubygem_faraday_net_http_version, '3.3.0')
+  proj.setting(:rubygem_faraday_net_http_persistent_version, '2.3.0')
 
   platform = proj.get_platform
 
@@ -158,7 +162,7 @@ project 'bolt-runtime' do |proj|
   proj.component 'rubygem-faraday-patron'
   proj.component 'rubygem-faraday-rack'
   proj.component 'rubygem-faraday-retry'
-  proj.component 'rubygem-faraday_middleware'
+  proj.component 'rubygem-faraday-follow_redirects'
   proj.component 'rubygem-ruby2_keywords'
 
   # Core dependencies

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -14,6 +14,7 @@ project 'bolt-runtime' do |proj|
   proj.setting(:rubygem_faraday_version, '2.12.0')
   proj.setting(:rubygem_faraday_net_http_version, '3.3.0')
   proj.setting(:rubygem_faraday_net_http_persistent_version, '2.3.0')
+  proj.setting(:rubygem_r10k_version, '4.1.0')
 
   platform = proj.get_platform
 


### PR DESCRIPTION
Updating to r10k 4 also required the following changes:

- Removed faraday_middleware in bolt-runtime and added faraday-net_http_persistent 2.3.0 as faraday_middleware does not support faraday 2. Further, It is not necessary to use faraday_middleware when using net_http_persistent on Ruby 2.0+ (see - https://github.com/lostisland/faraday_middleware/issues/279#issuecomment-1021023287)
- Updated orchestrator client version from 0.7.0 to 0.7.1 as 0.7.0 had a conflicting faraday version with puppet forge
- Specified puppet forge and faraday/faraday dependency versions in bolt-runtime

Testing:
- Was able to run a passing build for el-9-x86_64 in puppet-runtime and bolt-vanagon
- Bolt acceptance tests passing