### PR TITLE
(PA-7099) Libpsl component addition to agent-runtime-main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source ENV['GEM_SOURCE'] || "https://rubygems.org"
+source "https://rubygems.org"
 
 def location_for(place)
   if place =~ /^((?:git[:@]|https:)[^#]*)#(.*)/

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -17,6 +17,9 @@ component 'curl' do |pkg, settings, platform|
 
   pkg.build_requires "openssl-#{settings[:openssl_version]}"
   pkg.build_requires "puppet-ca-bundle"
+  unless platform.is_windows?
+    pkg.build_requires "libpsl"
+  end
 
   ldflags = settings[:ldflags]
   if platform.is_cross_compiled_linux?
@@ -35,6 +38,7 @@ component 'curl' do |pkg, settings, platform|
     # exclude -Wl,-brtl
     ldflags = "-L#{settings[:libdir]}"
   else
+    pkg.environment "PKG_CONFIG_PATH", "/opt/puppetlabs/puppet/lib/pkgconfig"
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
   end
 
@@ -53,7 +57,10 @@ component 'curl' do |pkg, settings, platform|
   end
 
   configure_options = []
-  configure_options << "--with-ssl=#{settings[:prefix]} --without-libpsl"
+  configure_options << "--with-ssl=#{settings[:prefix]}"
+  if platform.is_windows?
+    configure_options << "--without-libpsl"
+  end
 
   # OpenSSL version 3.0 & up no longer ships by default the insecure algorithms
   # that curl's ntlm module depends on (md4 & des).

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -17,7 +17,7 @@ component 'curl' do |pkg, settings, platform|
 
   pkg.build_requires "openssl-#{settings[:openssl_version]}"
   pkg.build_requires "puppet-ca-bundle"
-  unless platform.is_windows?
+  unless platform.is_windows? || platform.name =~ /solaris-11/
     pkg.build_requires "libpsl"
   end
 
@@ -40,6 +40,14 @@ component 'curl' do |pkg, settings, platform|
   else
     pkg.environment "PKG_CONFIG_PATH", "/opt/puppetlabs/puppet/lib/pkgconfig"
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
+  end
+
+  if(version.start_with?('8'))
+    if(platform.name =~ /solaris-11/)
+      pkg.environment "LD_LIBRARY_PATH", "/opt/csw/lib: "
+    else
+      pkg.environment "LD_LIBRARY_PATH", "/opt/csw/lib"
+    end
   end
 
   # Following lines should we removed once we drop curl 7

--- a/configs/components/libpsl.rb
+++ b/configs/components/libpsl.rb
@@ -1,0 +1,28 @@
+component 'libpsl' do |pkg, settings, platform|
+  pkg.version '0.21.5'
+  pkg.url "https://github.com/rockdaboot/libpsl/releases/download/#{pkg.get_version}/libpsl-#{pkg.get_version}.tar.gz"
+  pkg.mirror "https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/libpsl-0.21.5.tar.gz"
+  pkg.sha256sum "1dcc9ceae8b128f3c0b3f654decd0e1e891afc6ff81098f227ef260449dae208"
+
+  if platform.is_aix?
+    pkg.environment "MAKE", 'gmake'
+    pkg.environment "PATH", "$(PATH):/opt/freeware/bin"
+  elsif platform.is_solaris?
+    pkg.environment "MAKE", 'gmake'
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
+    pkg.environment "CFLAGS", "-I/opt/csw/include"
+    pkg.environment "LDFLAGS", "-L/opt/csw/lib"
+  end
+
+  pkg.configure do
+    ["./configure --prefix=#{settings[:prefix]}"]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end

--- a/configs/platforms/el-8-aarch64.rb
+++ b/configs/platforms/el-8-aarch64.rb
@@ -4,6 +4,7 @@ platform 'el-8-aarch64' do |plat|
   packages = %w(
     perl-Getopt-Long 
     patch 
+    python3.11
     swig 
     libselinux-devel 
     readline-devel 

--- a/configs/platforms/el-8-ppc64le.rb
+++ b/configs/platforms/el-8-ppc64le.rb
@@ -1,3 +1,5 @@
 platform 'el-8-ppc64le' do |plat|
   plat.inherit_from_default
+  packages = ["python3.11"]
+  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
 end

--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -6,6 +6,7 @@ platform "el-8-x86_64" do |plat|
     libsepol-devel
     libselinux-devel
     pkgconfig 
+    python3.11
     readline-devel
     rpmdevtools
     swig

--- a/configs/platforms/redhatfips-8-x86_64.rb
+++ b/configs/platforms/redhatfips-8-x86_64.rb
@@ -1,3 +1,5 @@
 platform "redhatfips-8-x86_64" do |plat|
   plat.inherit_from_default
+  packages = ["python3.11"]
+  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
 end

--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -41,7 +41,7 @@ action=nocheck
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
   pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev autoconf gcc4core CSWxz-5.2.8,REV=2022.11.16 || exit 1;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i libffi_dev autoconf gcc4core CSWxz-5.2.8,REV=2022.11.16 python33 || exit 1;
   ntpdate pool.ntp.org]
   plat.output_dir File.join("solaris", "11", "PC1")
 end

--- a/configs/platforms/solaris-11-native-sparc.rb
+++ b/configs/platforms/solaris-11-native-sparc.rb
@@ -55,6 +55,6 @@ action=nocheck
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
   pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-  /opt/csw/bin/pkgutil -config=/var/tmp/vanagon-pkgutil.conf -U && /opt/csw/bin/pkgutil -config=/var/tmp/vanagon-pkgutil.conf -y -i bison CSWxz-5.2.8,REV=2022.11.16 || exit 1
+  /opt/csw/bin/pkgutil -config=/var/tmp/vanagon-pkgutil.conf -U && /opt/csw/bin/pkgutil -config=/var/tmp/vanagon-pkgutil.conf -y -i bison CSWxz-5.2.8,REV=2022.11.16 libunistring_dev || exit 1
   ]
 end

--- a/configs/platforms/solaris-11-native-sparc.rb
+++ b/configs/platforms/solaris-11-native-sparc.rb
@@ -56,6 +56,6 @@ basedir=default" > /var/tmp/vanagon-noask;
 echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing
 wgetopts=--no-check-certificate" > /var/tmp/vanagon-pkgutil.conf;
 pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-/opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -U && /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i bison CSWxz-5.6.3,REV=2024.10.10 libunistring_dev python33 || exit 1
+/opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -U && /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i bison CSWxz-5.6.3,REV=2024.10.10 libunistring_dev python33 libpsl_dev || exit 1
 ]
 end

--- a/configs/platforms/solaris-11-native-sparc.rb
+++ b/configs/platforms/solaris-11-native-sparc.rb
@@ -53,8 +53,9 @@ conflict=nocheck
 action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
-  echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
-  pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
-  /opt/csw/bin/pkgutil -config=/var/tmp/vanagon-pkgutil.conf -U && /opt/csw/bin/pkgutil -config=/var/tmp/vanagon-pkgutil.conf -y -i bison CSWxz-5.2.8,REV=2022.11.16 libunistring_dev || exit 1
-  ]
+echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing
+wgetopts=--no-check-certificate" > /var/tmp/vanagon-pkgutil.conf;
+pkgadd -n -a /var/tmp/vanagon-noask -d http://get.opencsw.org/now all
+/opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -U && /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i bison CSWxz-5.6.3,REV=2024.10.10 libunistring_dev python33 || exit 1
+]
 end

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -47,6 +47,9 @@ project 'agent-runtime-main' do |proj|
   # Load shared agent components
   ########
 
+  unless platform.is_windows?
+    proj.component 'libpsl'
+  end
   instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-components.rb'))
 
   ########


### PR DESCRIPTION
 - Curl 8.10.1 requires the libpsl component.
 - Skip windows platforms for now (https://perforce.atlassian.net/browse/PA-7116).
 - Add python3.11 package to applicable platforms as libpsl requires it for building.
 - Add libunistring_dev package to solaris-11-native-sparc as libpsl requires unistr in solaris-11